### PR TITLE
renaming detect-secrets --initialize to detect-secrets --scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ need to scan the entire repository every time.
 ### Setting Up a Baseline
 
 ```
-$ detect-secrets --initialize --exclude='^(\.git|venv)' > .secrets.baseline
+$ detect-secrets --scan --exclude='^(\.git|venv)' > .secrets.baseline
 ```
 
 ### Pre-commit Hook
@@ -53,13 +53,13 @@ either the client-side pre-commit hook, or the server-side secret scanner.
 
 1. **Client-side Pre-Commit Hook**, that alerts developers when they attempt
    to enter a secret in the code base.
-   
+
 2. **Server-side Secret Scanning**, to periodically scan tracked repositories,
    and make sure developers didn't accidentally skip the pre-commit check.
-   
+
 3. **Secrets Baseline**, to whitelist pre-existing secrets in the repository,
    so that they won't be continuously caught through scan iterations.
-   
+
 ### Client-side Pre-commit Hook
 
 See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions
@@ -179,10 +179,10 @@ The current heuristic searches we implement out of the box include:
 
 * **Base64HighEntropyString**: checks for all strings matching the Base64
   character set, and alerts if their Shannon entropy is above a certain limit.
-  
+
 * **HexHighEntropyString**: checks for all strings matching the Hex character
   set, and alerts if their Shannon entropy is above a certain limit.
-  
+
 * **PrivateKeyDetector**: checks to see if any private keys are committed.
 
 See [detect_secrets/
@@ -216,4 +216,3 @@ This preset amount can be adjusted in several ways:
 
 Lowering these limits will identify more potential secrets, but also create
 more false positives. Adjust these limits to suit your needs.
-

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -61,7 +61,7 @@ class ParserBuilder(object):
 
     def add_initialize_baseline_argument(self):
         self.parser.add_argument(
-            '--initialize',
+            '--scan',
             nargs='?',
             const='.',
             help=(
@@ -71,7 +71,7 @@ class ParserBuilder(object):
             metavar='DIR_TO_SCAN',
         )
 
-        # Pairing `--exclude` with `--initialize` because it's only used for the initialization.
+        # Pairing `--exclude` with `--scan` because it's only used for the initialization.
         # The pre-commit hook framework already has an `exclude` option that can be used instead.
         self.parser.add_argument(
             '--exclude',

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -31,11 +31,11 @@ def main(argv=None):
         PrivateKeyDetector(),
     )
 
-    if args.initialize:
+    if args.scan:
         if args.exclude:
             args.exclude = args.exclude[0]
 
-        print(initialize(default_plugins, args.exclude, args.initialize).output_baseline(args.exclude))
+        print(initialize(default_plugins, args.exclude, args.scan).output_baseline(args.exclude))
 
     return 0
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -23,7 +23,7 @@ class MainTest(unittest.TestCase):
 
     @mock.patch('detect_secrets.main.initialize')
     def test_initialize_flag_no_excludes_no_rootdir(self, mock_initialize):
-        assert main(['--initialize']) == 0
+        assert main(['--scan']) == 0
 
         mock_initialize.assert_called_once_with(
             Any(tuple),
@@ -34,7 +34,7 @@ class MainTest(unittest.TestCase):
     @mock.patch('detect_secrets.main.initialize')
     def test_initialize_flag_with_rootdir(self, mock_initialize):
         assert main([
-            '--initialize',
+            '--scan',
             'test_data'
         ]) == 0
 
@@ -47,7 +47,7 @@ class MainTest(unittest.TestCase):
     @mock.patch('detect_secrets.main.initialize')
     def test_initialize_flag_with_exclude(self, mock_initialize):
         assert main([
-            '--initialize',
+            '--scan',
             '--exclude',
             'some_pattern_here'
         ]) == 0


### PR DESCRIPTION
It just makes more UI sense.

### Tests

`make test` passes.