### PR TITLE
[private key plugin] Change analyze_string output dict

### DIFF
--- a/detect_secrets/plugins/private_key.py
+++ b/detect_secrets/plugins/private_key.py
@@ -40,11 +40,12 @@ class PrivateKeyDetector(BasePlugin):
         output = {}
 
         if any(line in string for line in BLACKLIST):
-            output[filename] = PotentialSecret(
+            secret = PotentialSecret(
                 self.secret_type,
                 filename,
                 line_num,
                 string,
             )
+            output[secret] = secret
 
         return output

--- a/detect_secrets/plugins/private_key.py
+++ b/detect_secrets/plugins/private_key.py
@@ -25,11 +25,14 @@ class PrivateKeyDetector(BasePlugin):
     def analyze(self, file, filename):
         """We override this, because we're only looking at the first line.
 
-        Though this doesn't strictly follow the schema of the parent function,
-        all that really matters is that each secret within this file scanned
-        has a unique key. Since we're only expecting at most one secret from
-        this file, by definition any key is a unique key, so we good.
+        :param file:     The File object itself.
+        :param filename: string; filename of File object, used for creating
+                         PotentialSecret objects
+        :returns         dictionary representation of set (for random access by hash)
+                         { detect_secrets.core.potential_secret.__hash__:
+                               detect_secrets.core.potential_secret         }
         """
+
         return self.analyze_string(
             file.readline(),
             1,

--- a/tests/plugins/private_key_test.py
+++ b/tests/plugins/private_key_test.py
@@ -16,4 +16,7 @@ class TestPrivateKeyDetector(object):
         )
 
         f = create_file_object_from_string(file_content)
-        assert 'mock_filename' in logic.analyze(f, 'mock_filename')
+        output = logic.analyze(f, 'mock_filename')
+        assert len(output) == 1
+        for potential_secret in output:
+            assert 'mock_filename' == potential_secret.filename


### PR DESCRIPTION
To have PotentialSecret as the key, not filename.

Please see https://github.com/Yelp/detect-secrets/issues/14 for a more in-depth issue description.