### PR TITLE
Allow adhoc non-git file scanning

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -21,7 +21,12 @@ def initialize(plugins, exclude_regex=None, rootdir='.'):
     """
     output = SecretsCollection(plugins, exclude_regex)
 
-    git_files = _get_git_tracked_files(rootdir)
+    if os.path.isfile(rootdir):
+        # This option allows for much easier adhoc usage.
+        git_files = [rootdir]
+    else:
+        git_files = _get_git_tracked_files(rootdir)
+
     if not git_files:
         return output
 

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -14,7 +14,7 @@ class BasePlugin(object):
                                detect_secrets.core.potential_secret         }
         """
         potential_secrets = {}
-        for line_num, line in enumerate(file, start=1):
+        for line_num, line in enumerate(file.readlines(), start=1):
             secrets = self.analyze_string(line, line_num, filename)
             potential_secrets.update(secrets)
 

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -111,6 +111,12 @@ class HighEntropyStringsPlugin(BasePlugin):
         lines = list(map(lambda x: x.strip(), file.readlines()))
         line_offset = 0
 
+        if not parser.sections():
+            # To prevent cases where it's not an ini file, but the parser
+            # helpfully attempts to parse everything to a DEFAULT section,
+            # when not explicitly provided.
+            raise configparser.Error
+
         with self._non_quoted_string_regex():
             for section_name, _ in parser.items():
                 for key, value in parser.items(section_name):
@@ -189,9 +195,10 @@ class HighEntropyStringsPlugin(BasePlugin):
         old_regex = self.regex
         self.regex = re.compile(r'^([%s]+)$' % self.charset)
 
-        yield
-
-        self.regex = old_regex
+        try:
+            yield
+        finally:
+            self.regex = old_regex
 
     @staticmethod
     def _get_line_offset_for_ini_files(key, value, lines):

--- a/tests/util/mock_util.py
+++ b/tests/util/mock_util.py
@@ -107,8 +107,18 @@ def Any(cls):
 
 @contextmanager
 def mock_open(data, namespace):
+    """We heavily rely on file.seek(0), and until we can change this, we need
+    to do a bit more overhead mocking, since the library doesn't support it.
+
+    https://github.com/testing-cabal/mock/issues/426
+    """
     m = mock.mock_open(read_data=data)
     with mock.patch(namespace, m):
+        # This is the patch that we do, because it seems that that the
+        # side_effect resets the data (exactly what we want with our use
+        # case of seek).
+        m().seek = m.side_effect
+
         yield m
 
 


### PR DESCRIPTION
Most of the changes in this CR is to support better testing. The real change is just adding a small conditional in `detect_secrets/core/baseline.py` to support this feature.

The idea is as follows: if I want to run this scan on an arbitrary file, that I *know* has secrets, and it doesn't catch anything, that's a very strange issue. And the reason behind that is because the file isn't tracked by git.

Perhaps in the future, we can add some sort of "files scanned" metric. However, for now, this should suffice.