### PR TITLE
[baseline output] Add sort_keys=True to json.dumps

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -325,7 +325,11 @@ class SecretsCollection(object):
         return output
 
     def __str__(self):  # pragma: no cover
-        return json.dumps(self.json(), indent=2)
+        return json.dumps(
+            self.json(),
+            indent=2,
+            sort_keys=True
+        )
 
     def __getitem__(self, key):  # pragma: no cover
         return self.data[key]

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -38,6 +38,7 @@ def main(argv=None):
                     args.scan
                 ).format_for_baseline_output(),
                 indent=2,
+                sort_keys=True
             )
         )
 

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -58,6 +58,7 @@ def main(argv=None):
                 json.dumps(
                     baseline_collection.format_for_baseline_output(),
                     indent=2,
+                    sort_keys=True
                 )
             )
 

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -166,4 +166,8 @@ class TestPreCommitHook(object):
             },
         }
 
-        return json.dumps(baseline, indent=2)
+        return json.dumps(
+            baseline,
+            indent=2,
+            sort_keys=True
+        )


### PR DESCRIPTION
This prevents unnecessary baseline modifications where the pre-commit hook can change the baseline only to re-order keys around (on certain python versions.)

Note that this will make it read differently then before, but in my opinion it's even more readable as the `exclude_regex` is no longer at the bottom after the results.

With `sort_keys` it is e.g.

```python
{
  "exclude_regex": null,
  "generated_at": "2018-06-14T20:55:58Z",
  "plugins_used": [
    {
      "limit": 4.5,
      "name": "Base64HighEntropyString"
    },
    {
      "limit": 3,
      "name": "HexHighEntropyString"
    },
    {
      "name": "PrivateKeyDetector"
    }
  ],
  "results": {
    "test_data/baseline.file": [
      {
        "hashed_secret": "fdd121830f7c0a035298a08a79c7a34835184b8a",
        "line_number": 9,
        "type": "High Entropy String"
      },
      {
....
  },
  "exclude_regex": null
}
```

Whereas without `sort_keys` it is e.g.

```
  "plugins_used": [
    {
      "limit": 4.5,
      "name": "Base64HighEntropyString"
    },
    {
      "limit": 3,
      "name": "HexHighEntropyString"
    },
    {
      "name": "PrivateKeyDetector"
    }
  ],
  "generated_at": "2018-06-14T20:55:23Z",
  "results": {
    "tests/pre_commit_hook_test.py": [
      {
        "line_number": 154,
....
  },
  "exclude_regex": null
}
```
