### PR TITLE
Add re.escape to variables formatted into re.compile

### DIFF
--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -166,7 +166,9 @@ class HighEntropyStringsPlugin(BasePlugin):
         cases, we modify the regex accordingly.
         """
         old_regex = self.regex
-        self.regex = re.compile(r'^([%s]+)$' % self.charset)
+        self.regex = re.compile(
+            r'^([%s]+)$' % re.escape(self.charset)
+        )
 
         try:
             yield
@@ -246,8 +248,8 @@ class IniFileParser(object):
         lines_modified = False
 
         first_line_regex = re.compile(r'^\s*{}[ :=]+{}'.format(
-            key,
-            values_list[current_value_list_index],
+            re.escape(key),
+            re.escape(values_list[current_value_list_index]),
         ))
         comment_regex = re.compile(r'\s*[;#]')
         for index, line in enumerate(self.lines):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ flake8
 mock
 pre-commit
 pytest
+pyyaml
+unidiff


### PR DESCRIPTION
+ Add `pyyaml` and `unidiff` back to requirements-dev.txt, b/c while developing you can just install from there.