### PR TITLE
audit bug fix: handles short files better

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -212,10 +212,25 @@ def _get_secret_with_context(
         filename,
     ]).decode('utf-8').splitlines()
 
+    trailing_lines_of_context = lines_of_context
+    if len(output) < end_line - start_line + 1:
+        # This handles the case of a short file.
+        num_lines_in_file = int(subprocess.check_output([
+            'wc',
+            '-l',
+            filename,
+        ]).decode('utf-8').split()[0])
+
+        trailing_lines_of_context = lines_of_context - \
+            (end_line - num_lines_in_file)
+
     # -1, because that's where the secret actually is (without it,
-    # it would just be the start of the context block)
-    output[-lines_of_context - 1] = _highlight_secret(
-        output[-lines_of_context - 1],
+    # it would just be the start of the context block).
+    # NOTE: index_of_secret_in_output should *always* be negative.
+    index_of_secret_in_output = -trailing_lines_of_context - 1
+
+    output[index_of_secret_in_output] = _highlight_secret(
+        output[index_of_secret_in_output],
         secret,
         filename,
         plugin_settings,

--- a/test_data/short_files/first_line.py
+++ b/test_data/short_files/first_line.py
@@ -1,0 +1,3 @@
+secret = '0123456789a'
+print('second line')
+var = 'third line'

--- a/test_data/short_files/last_line.ini
+++ b/test_data/short_files/last_line.ini
@@ -1,0 +1,5 @@
+[some section]
+secrets_for_no_one_to_find =
+    hunter2
+    password123
+    0123456789a

--- a/test_data/short_files/middle_line.yml
+++ b/test_data/short_files/middle_line.yml
@@ -1,0 +1,6 @@
+deploy:
+    user: aaronloo
+    password:
+        secure: thequickbrownfoxjumpsoverthelazydog
+    on:
+        repo: Yelp/detect-secrets

--- a/testing/mocks.py
+++ b/testing/mocks.py
@@ -127,6 +127,26 @@ def mock_file_object(string):
 
 
 @contextmanager
+def mock_printer(obj):
+    """
+    :type obj: module
+    """
+    class PrinterShim(object):
+        def __init__(self):
+            self.clear()
+
+        def add(self, message):
+            self.message += str(message) + '\n'
+
+        def clear(self):
+            self.message = ''
+
+    shim = PrinterShim()
+    with mock.patch.object(obj, 'print', shim.add):
+        yield shim
+
+
+@contextmanager
 def mock_log(namespace):
     class MockLogWrapper(object):
         """This is used to check what is being logged."""

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -11,6 +11,7 @@ import pytest
 from detect_secrets.core import audit
 from detect_secrets.core.color import BashColor
 from testing.factories import potential_secret_factory
+from testing.mocks import mock_printer as mock_printer_base
 
 
 class TestAuditBaseline(object):
@@ -441,15 +442,7 @@ class TestGetUserDecision(object):
 
 @pytest.fixture
 def mock_printer():
-    class PrinterShim(object):
-        def __init__(self):
-            self.message = ''
-
-        def add(self, message):
-            self.message += str(message) + '\n'
-
-    shim = PrinterShim()
-    with mock.patch.object(audit, 'print', shim.add):
+    with mock_printer_base(audit) as shim:
         yield shim
 
 


### PR DESCRIPTION
Our default `lines_of_context` when printing the interactive auditor is 5. However, when there isn't five lines to print, we can find ourselves in a strange case: the auditor doesn't know how to handle it so it either:

a) throws an IndexError exception (if `abs(-lines_of_context -1 ) > len(output)`), OR
b) displays a `ERROR: Secret not found on specified line number!`

So let's handle this better.