### PR TITLE
Clearer usage commands

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import argparse
 from collections import namedtuple
 
+from detect_secrets import VERSION
+
 
 class ParserBuilder(object):
 
@@ -34,7 +36,8 @@ class ParserBuilder(object):
     def _add_version_argument(self):
         self.parser.add_argument(
             '--version',
-            action='store_true',
+            action='version',
+            version=VERSION,
             help='Display version information.',
         )
         return self

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -25,7 +25,7 @@ def main(argv=None):
     if args.verbose:  # pragma: no cover
         log.set_debug_level(args.verbose)
 
-    if args.scan:
+    if args.action == 'scan':
         print(
             json.dumps(
                 _perform_scan(args),
@@ -34,14 +34,14 @@ def main(argv=None):
             ),
         )
 
-    elif args.audit:
-        audit.audit_baseline(args.audit[0])
+    elif args.action == 'audit':
+        audit.audit_baseline(args.filename[0])
 
     return 0
 
 
 def _perform_scan(args):
-    old_baseline = _get_existing_baseline(args)
+    old_baseline = _get_existing_baseline(args.import_filename)
 
     # Plugins are *always* rescanned with fresh settings, because
     # we want to get the latest updates.
@@ -56,7 +56,7 @@ def _perform_scan(args):
     new_baseline = baseline.initialize(
         plugins,
         args.exclude,
-        args.scan,
+        args.path,
     ).format_for_baseline_output()
 
     if old_baseline:
@@ -68,10 +68,10 @@ def _perform_scan(args):
     return new_baseline
 
 
-def _get_existing_baseline(args):
+def _get_existing_baseline(import_filename):
     # Favors --import argument over stdin.
-    if getattr(args, 'import'):
-        with open(getattr(args, 'import')[0]) as f:
+    if import_filename:
+        with open(import_filename[0]) as f:
             return json.loads(f.read())
 
     if not sys.stdin.isatty():

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import json
 import sys
 
-from detect_secrets import VERSION
 from detect_secrets.core import audit
 from detect_secrets.core import baseline
 from detect_secrets.core.log import log
@@ -25,10 +24,6 @@ def main(argv=None):
     args = parse_args(argv)
     if args.verbose:  # pragma: no cover
         log.set_debug_level(args.verbose)
-
-    if args.version:    # pragma: no cover
-        print(VERSION)
-        return
 
     if args.scan:
         print(

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -9,8 +9,9 @@ class TestPluginOptions(object):
 
     @staticmethod
     def parse_args(argument_string=''):
-        # PluginOptions are added by default
-        return ParserBuilder().parse_args(argument_string.split())
+        # PluginOptions are added in pre-commit hook
+        return ParserBuilder().add_pre_commit_arguments()\
+            .parse_args(argument_string.split())
 
     def test_added_by_default(self):
         # This is what happens with unrecognized arguments

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -43,13 +43,9 @@ class TestMain(object):
     Most of the functional test cases should be within their own module tests.
     """
 
-    def test_smoke(self):
-        with mock_stdin():
-            assert main([]) == 0
-
     def test_scan_basic(self, mock_baseline_initialize):
         with mock_stdin():
-            assert main(['--scan']) == 0
+            assert main(['scan']) == 0
 
         mock_baseline_initialize.assert_called_once_with(
             Any(tuple),
@@ -59,7 +55,7 @@ class TestMain(object):
 
     def test_scan_with_rootdir(self, mock_baseline_initialize):
         with mock_stdin():
-            assert main('--scan test_data'.split()) == 0
+            assert main('scan test_data'.split()) == 0
 
         mock_baseline_initialize.assert_called_once_with(
             Any(tuple),
@@ -69,7 +65,7 @@ class TestMain(object):
 
     def test_scan_with_excludes_flag(self, mock_baseline_initialize):
         with mock_stdin():
-            assert main('--scan --exclude some_pattern_here'.split()) == 0
+            assert main('scan --exclude some_pattern_here'.split()) == 0
 
         mock_baseline_initialize.assert_called_once_with(
             Any(tuple),
@@ -79,7 +75,7 @@ class TestMain(object):
 
     def test_reads_from_stdin(self, mock_merge_baseline):
         with mock_stdin(json.dumps({'key': 'value'})):
-            assert main(['--scan']) == 0
+            assert main(['scan']) == 0
 
         mock_merge_baseline.assert_called_once_with(
             {'key': 'value'},
@@ -91,7 +87,7 @@ class TestMain(object):
             json.dumps({'key': 'value'}),
             'detect_secrets.main.open',
         ) as m:
-            assert main('--scan --import old_baseline_file'.split()) == 0
+            assert main('scan --import old_baseline_file'.split()) == 0
             assert m.call_args[0][0] == 'old_baseline_file'
 
         mock_merge_baseline.assert_called_once_with(
@@ -133,14 +129,14 @@ class TestMain(object):
             ),
         ],
     )
-    def test_audit_first_line(self, filename, expected_output):
+    def test_audit_short_file(self, filename, expected_output):
         BashColor.disable_color()
 
         with mock_stdin(), mock_printer(
             # To extract the baseline output
             main_module,
         ) as printer_shim:
-            main(['--scan', filename])
+            main(['scan', filename])
             baseline = printer_shim.message
 
         with mock_stdin(), mock.patch(
@@ -160,7 +156,7 @@ class TestMain(object):
         ), mock_printer(
             audit_module,
         ) as printer_shim:
-            main('--audit will_be_mocked'.split())
+            main('audit will_be_mocked'.split())
 
             assert printer_shim.message == textwrap.dedent("""
                 Secrets Left: 1/1


### PR DESCRIPTION
Previously, scanning and auditing were command line flags. This meant that *technically*, they could be used in the following manner:

```
$ detect-secrets --audit .secrets.baseline --scan test_data
```

which doesn't really make any sense.

This change clarifies the API a little, so we avoid this situation.