### PR TITLE
Adding cli functionality to check strings in an adhoc manner

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -83,7 +83,9 @@ class ScanOptions(object):
         )
 
     def add_arguments(self):
-        self._add_initialize_baseline_argument()
+        self._add_initialize_baseline_argument()\
+            ._add_adhoc_scanning_argument()
+
         PluginOptions(self.parser).add_arguments()
 
         return self
@@ -114,6 +116,19 @@ class ScanOptions(object):
             metavar='OLD_BASELINE_FILE',
             help='Import settings from previous existing baseline.',
             dest='import_filename',
+        )
+
+        return self
+
+    def _add_adhoc_scanning_argument(self):
+        self.parser.add_argument(
+            '--string',
+            nargs='?',
+            const=True,
+            help=(
+                'Scans an individual string, and displays configured '
+                'plugins\' verdict.'
+            ),
         )
 
         return self

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -50,6 +50,29 @@ class BasePlugin(object):
         """
         pass
 
+    def adhoc_scan(self, string):
+        """To support faster discovery, we want the ability to conveniently
+        check what different plugins say regarding a single line/secret. This
+        supports that.
+
+        This is very similar to self.analyze_string, but allows the flexibility
+        for subclasses to add any other notable info (rather than just a
+        PotentialSecret type). e.g. HighEntropyStrings adds their Shannon
+        entropy in which they made their decision.
+
+        :type string: str
+        :param string: the string to analyze
+        :rtype: str
+        :returns: descriptive string that fits the format
+            <classname>: <returned-value>
+        """
+        # TODO: Handle multiple secrets on single line.
+        results = self.analyze_string(string, 0, 'does_not_matter')
+        if not results:
+            return 'False'
+        else:
+            return 'True'
+
     @property
     def __dict__(self):
         return {

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -101,6 +101,21 @@ class HighEntropyStringsPlugin(BasePlugin):
             if entropy_value > self.entropy_limit:
                 yield result
 
+    def adhoc_scan(self, string):
+        # Since it's an individual string, it's just bad UX to require quotes
+        # around the expected secret.
+        with self.non_quoted_string_regex():
+            results = self.analyze_string(string, 0, 'does_not_matter')
+
+            # NOTE: Trailing space allows for nicer formatting
+            output = 'False' if not results else 'True '
+            if self.regex.search(string):
+                output += ' ({})'.format(
+                    round(self.calculate_shannon_entropy(string), 3),
+                )
+
+            return output
+
     @contextmanager
     def non_quoted_string_regex(self, strict=True):
         """For certain file formats, strings need not necessarily follow the

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -73,6 +73,34 @@ class TestMain(object):
             '.',
         )
 
+    def test_scan_string_basic(self, mock_baseline_initialize):
+        with mock_stdin(
+            '0123456789a',
+        ), mock_printer(
+            main_module,
+        ) as printer_shim:
+            assert main('scan --string'.split()) == 0
+            assert printer_shim.message == textwrap.dedent("""
+                Base64HighEntropyString: False (3.459)
+                HexHighEntropyString   : True  (3.459)
+                PrivateKeyDetector     : False
+            """)[1:]
+
+        mock_baseline_initialize.assert_not_called()
+
+    def test_scan_string_cli_overrides_stdin(self):
+        with mock_stdin(
+            '0123456789a',
+        ), mock_printer(
+            main_module,
+        ) as printer_shim:
+            assert main('scan --string 012345'.split()) == 0
+            assert printer_shim.message == textwrap.dedent("""
+                Base64HighEntropyString: False (2.585)
+                HexHighEntropyString   : False (2.121)
+                PrivateKeyDetector     : False
+            """)[1:]
+
     def test_reads_from_stdin(self, mock_merge_baseline):
         with mock_stdin(json.dumps({'key': 'value'})):
             assert main(['scan']) == 0


### PR DESCRIPTION
This long desired functionality should help usage when playing around with the tool.

## Testing

```
$ detect-secrets scan --string 0123456789a
Base64HighEntropyString: False (3.459)
HexHighEntropyString   : True  (3.459)
PrivateKeyDetector     : False
$
$ echo "some secret, but base64 encoded here" | base64 | detect-secrets scan --string
Base64HighEntropyString: True (4.676)
HexHighEntropyString   : False
PrivateKeyDetector     : False
```