### PR TITLE
adding --all-files flag

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -7,7 +7,7 @@ import subprocess
 from detect_secrets.core.secrets_collection import SecretsCollection
 
 
-def initialize(plugins, exclude_regex=None, rootdir='.'):
+def initialize(plugins, exclude_regex=None, rootdir='.', scan_all_files=False):
     """Scans the entire codebase for high entropy strings, and returns a
     SecretsCollection object.
 
@@ -24,6 +24,8 @@ def initialize(plugins, exclude_regex=None, rootdir='.'):
     if os.path.isfile(rootdir):
         # This option allows for much easier adhoc usage.
         git_files = [rootdir]
+    elif scan_all_files:
+        git_files = _get_files_recursively(rootdir)
     else:
         git_files = _get_git_tracked_files(rootdir)
 
@@ -256,3 +258,15 @@ def _get_git_tracked_files(rootdir='.'):
         return set(git_files.decode('utf-8').split())
     except subprocess.CalledProcessError:
         return None
+
+
+def _get_files_recursively(rootdir):
+    """Sometimes, we want to use this tool with non-git repositories.
+    This function allows us to do so.
+    """
+    output = []
+    for root, dirs, files in os.walk(rootdir):
+        for filename in files:
+            output.append(os.path.join(root, filename))
+
+    return output

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -116,6 +116,12 @@ class ScanOptions(object):
             dest='import_filename',
         )
 
+        self.parser.add_argument(
+            '--all-files',
+            action='store_true',
+            help='Scan all files recursively (as compared to only scanning git tracked files).',
+        )
+
         return self
 
 

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -57,6 +57,7 @@ def _perform_scan(args):
         plugins,
         args.exclude,
         args.path,
+        args.all_files,
     ).format_for_baseline_output()
 
     if old_baseline:

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -27,11 +27,17 @@ class TestInitializeBaseline(object):
             HexHighEntropyString(3),
         )
 
-    def get_results(self, rootdir='./test_data/files', exclude_regex=None):
+    def get_results(
+        self,
+        rootdir='./test_data/files',
+        exclude_regex=None,
+        scan_all_files=False,
+    ):
         return baseline.initialize(
             self.plugins,
             rootdir=rootdir,
             exclude_regex=exclude_regex,
+            scan_all_files=scan_all_files,
         ).json()
 
     @pytest.mark.parametrize(
@@ -89,6 +95,10 @@ class TestInitializeBaseline(object):
             results = self.get_results('will_be_mocked')
 
         assert len(results['will_be_mocked']) == 1
+
+    def test_scan_all_files(self):
+        results = self.get_results(rootdir='test_data/files', scan_all_files=True)
+        assert len(results.keys()) == 2
 
 
 class TestGetSecretsNotInBaseline(object):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -51,6 +51,7 @@ class TestMain(object):
             Any(tuple),
             None,
             '.',
+            False,
         )
 
     def test_scan_with_rootdir(self, mock_baseline_initialize):
@@ -61,6 +62,7 @@ class TestMain(object):
             Any(tuple),
             None,
             'test_data',
+            False,
         )
 
     def test_scan_with_excludes_flag(self, mock_baseline_initialize):
@@ -71,6 +73,18 @@ class TestMain(object):
             Any(tuple),
             'some_pattern_here',
             '.',
+            False,
+        )
+
+    def test_scan_with_all_files_flag(self, mock_baseline_initialize):
+        with mock_stdin():
+            assert main('scan --all-files'.split()) == 0
+
+        mock_baseline_initialize.assert_called_once_with(
+            Any(tuple),
+            None,
+            '.',
+            True,
         )
 
     def test_reads_from_stdin(self, mock_merge_baseline):


### PR DESCRIPTION
## Testing

```
detect-secrets scan --all-files
```

This allows the extended usage of this tool, so we can scan non-git tracked files as well on an adhoc manner.