### PR TITLE
More intelligent upgrade of baselines

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -107,12 +107,12 @@ class ScanOptions(object):
             help='Pass in regex to specify ignored paths during initialization scan.',
         )
 
-        # Pairing `--import` with `--scan` because it's only used for initialization.
+        # Pairing `--update` with `--scan` because it's only used for initialization.
         self.parser.add_argument(
-            '--import',
+            '--update',
             nargs=1,
             metavar='OLD_BASELINE_FILE',
-            help='Import settings from previous existing baseline.',
+            help='Update existing baseline by import settings from it.',
             dest='import_filename',
         )
 

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -112,7 +112,7 @@ class ScanOptions(object):
             '--update',
             nargs=1,
             metavar='OLD_BASELINE_FILE',
-            help='Update existing baseline by import settings from it.',
+            help='Update existing baseline by importing settings from it.',
             dest='import_filename',
         )
 


### PR DESCRIPTION
## Testing

```
$ detect-secrets scan --update .secrets.baseline
```

Easier to use, and more accurate than

```
$ detect-secrets scan < .secrets.baseline > .secrets.baseline.new
$ mv .secrets.baseline.new .secrets.baseline
```

Fixes https://github.com/Yelp/detect-secrets/issues/55