### PR TITLE
Only load json from stdin if it exists

### DIFF
--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -82,7 +82,9 @@ def _get_existing_baseline(import_filename):
     if import_filename:
         return _read_from_file(import_filename[0])
     if not sys.stdin.isatty():
-        return json.loads(sys.stdin.read())
+        stdin = sys.stdin.read().strip()
+        if stdin:
+            return json.loads(stdin)
 
 
 def _read_from_file(filename):


### PR DESCRIPTION
I was trying to warp `detect-secrets` in an automated code review tool I'm working on that shells out to various static analysis tools. However, when it runs `detect-secrets`, `detect-secrets` appears to expect JSON on stdin when run in non-interactive mode. This PR adds a small workaround to only load the JSON if stdin input actually exists.

An alternative approach might be a try/except block around the JSON load.