### PR TITLE
Add a (b)ack option to 'Is this a valid secret?' Closes Issue #63

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.egg-info
 *.py[co]
 *.sw[op]
-.secrets.baseline
 
 /.coverage
 /.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.py[co]
 *.sw[op]
+.secrets.baseline
 
 /.coverage
 /.pytest_cache

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -11,10 +11,10 @@ from collections import defaultdict
 from ..plugins.core import initialize
 from ..plugins.high_entropy_strings import HighEntropyStringsPlugin
 from .baseline import merge_results
+from .bidirectional_iterator import BidirectionalIterator
 from .color import BashColor
 from .color import Color
 from .potential_secret import PotentialSecret
-from .bidirectional_iterator import BidirectionalIterator
 
 
 class SecretNotFoundOnSpecifiedLineError(Exception):
@@ -56,7 +56,7 @@ def audit_baseline(baseline_filename):
         if decision == 'q':
             print('Quitting...')
             break
-        
+
         if decision == 'b':
             secret_iterator.step_back_on_next_iteration()
 

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -174,7 +174,7 @@ def _print_context(filename, secret, count, total, plugin_settings):   # pragma:
         raise error_obj
 
 
-def _get_user_decision(prompt_secret_decision=True):
+def _get_user_decision(prompt_secret_decision=True, can_go_back=False):
     """
     :type prompt_secret_decision: bool
     :param prompt_secret_decision: if False, won't ask to label secret.
@@ -182,6 +182,8 @@ def _get_user_decision(prompt_secret_decision=True):
     allowable_user_input = ['s', 'q']
     if prompt_secret_decision:
         allowable_user_input.extend(['y', 'n'])
+    if can_go_back:
+        allowable_user_input.append('b')
 
     user_input = None
     while user_input not in allowable_user_input:
@@ -192,6 +194,8 @@ def _get_user_decision(prompt_secret_decision=True):
             user_input_string = 'Is this a valid secret? (y)es, (n)o, '
         else:
             user_input_string = 'What would you like to do? '
+        if 'b' in allowable_user_input:
+            user_input_string += '(b)ack, '
         user_input_string += '(s)kip, (q)uit: '
 
         user_input = input(user_input_string)

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -206,6 +206,8 @@ def _handle_user_decision(decision, secret):
         secret['is_secret'] = True
     elif decision == 'n':
         secret['is_secret'] = False
+    elif decision == 's' and 'is_secret' in secret:
+        del secret['is_secret']
 
 
 def _save_baseline_to_file(filename, data):  # pragma: no cover

--- a/detect_secrets/core/bidirectional_iterator.py
+++ b/detect_secrets/core/bidirectional_iterator.py
@@ -1,25 +1,25 @@
 class BidirectionalIterator(object):
     def __init__(self, collection):
         self.collection = collection
-        self.index = -1 #starts on -1, as index is increased _before_ getting result
-        self.step_back_once = False 
+        self.index = -1  # starts on -1, as index is increased _before_ getting result
+        self.step_back_once = False
 
     def __next__(self):
+        if self.step_back_once:
+            self.index -= 1
+            self.step_back_once = False
+        else:
+            self.index += 1
+        if self.index < 0:
+            raise StopIteration
         try:
-            if self.step_back_once:
-                self.index -= 1
-                self.step_back_once = False 
-                if self.index < 0:
-                    raise StopIteration
-            else:
-                self.index += 1
             result = self.collection[self.index]
         except IndexError:
             raise StopIteration
         return result
 
     def next(self):
-        self.__next__()
+        return self.__next__()
 
     def step_back_on_next_iteration(self):
         self.step_back_once = True

--- a/detect_secrets/core/bidirectional_iterator.py
+++ b/detect_secrets/core/bidirectional_iterator.py
@@ -18,6 +18,9 @@ class BidirectionalIterator(object):
             raise StopIteration
         return result
 
+    def next(self):
+        self.__next__()
+
     def step_back_on_next_iteration(self):
         self.step_back_once = True
 

--- a/detect_secrets/core/bidirectional_iterator.py
+++ b/detect_secrets/core/bidirectional_iterator.py
@@ -1,0 +1,28 @@
+class BidirectionalIterator(object):
+    def __init__(self, collection):
+        self.collection = collection
+        self.index = -1 #starts on -1, as index is increased _before_ getting result
+        self.step_back_once = False 
+
+    def __next__(self):
+        try:
+            if self.step_back_once:
+                self.index -= 1
+                self.step_back_once = False 
+                if self.index < 0:
+                    raise StopIteration
+            else:
+                self.index += 1
+            result = self.collection[self.index]
+        except IndexError:
+            raise StopIteration
+        return result
+
+    def step_back_on_next_iteration(self):
+        self.step_back_once = True
+
+    def can_step_back(self):
+        return self.index > 0
+
+    def __iter__(self):
+        return self

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -92,6 +92,73 @@ class TestAuditBaseline(object):
             'Saving progress...\n'
         )
 
+    def test_go_back_and_change_yes_to_no(self, mock_printer):
+        modified_baseline = deepcopy(self.baseline)
+
+        values_to_inject = [None, False, True]
+        for secrets in modified_baseline['results'].values():
+            for secret in secrets:
+                value = values_to_inject.pop(0)
+                if value is not None:
+                    secret['is_secret'] = value
+
+        self.run_logic(['s', 'y', 'b', 'n', 'y'], modified_baseline)
+
+        assert mock_printer.message == (
+            'Saving progress...\n'
+        )
+
+    def test_go_back_and_change_no_to_yes(self, mock_printer):
+        modified_baseline = deepcopy(self.baseline)
+
+        values_to_inject = [None, True, True]
+        for secrets in modified_baseline['results'].values():
+            for secret in secrets:
+                value = values_to_inject.pop(0)
+                if value is not None:
+                    secret['is_secret'] = value
+
+        self.run_logic(['s', 'n', 'b', 'y', 'y'], modified_baseline)
+
+        assert mock_printer.message == (
+            'Saving progress...\n'
+        )
+
+    def test_go_back_and_change_yes_to_skip(self, mock_printer):
+        modified_baseline = deepcopy(self.baseline)
+
+        values_to_inject = [None, None, True]
+        for secrets in modified_baseline['results'].values():
+            for secret in secrets:
+                value = values_to_inject.pop(0)
+                if value is not None:
+                    secret['is_secret'] = value
+
+        self.run_logic(['s', 'y', 'b', 's', 'y'], modified_baseline)
+
+        assert mock_printer.message == (
+            'Saving progress...\n'
+        )
+
+    def test_go_back_several_steps(self, mock_printer):
+        modified_baseline = deepcopy(self.baseline)
+
+        values_to_inject = [False, False, False]
+        for secrets in modified_baseline['results'].values():
+            for secret in secrets:
+                value = values_to_inject.pop(0)
+                if value is not None:
+                    secret['is_secret'] = value
+
+        self.run_logic(
+            ['s', 'y', 'b', 's', 'b', 'b', 'n', 'n', 'n'],
+            modified_baseline,
+        )
+
+        assert mock_printer.message == (
+            'Saving progress...\n'
+        )
+
     def test_leapfrog_decision(self, mock_printer):
         modified_baseline = deepcopy(self.leapfrog_baseline)
         modified_baseline['results']['filenameA'][1]['is_secret'] = True

--- a/tests/core/bidirectional_iterator_test.py
+++ b/tests/core/bidirectional_iterator_test.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+
+import pytest
+
+from detect_secrets.core import bidirectional_iterator
+
+
+class TestBidirectionalIterator(object):
+
+    def test_no_input(self):
+        iterator = bidirectional_iterator.BidirectionalIterator([])
+        with pytest.raises(StopIteration):
+            iterator.__next__()
+
+    def test_cannot_step_back_too_far(self):
+        iterator = bidirectional_iterator.BidirectionalIterator([0])
+        iterator.step_back_on_next_iteration()
+        with pytest.raises(StopIteration):
+            iterator.__next__()
+
+    def test_cannot_step_back_too_far_after_stepping_in(self):
+        iterator = bidirectional_iterator.BidirectionalIterator([0, 1, 2])
+        for _ in range(3):
+            iterator.__next__()
+        for _ in range(2):
+            iterator.step_back_on_next_iteration()
+            iterator.__next__()
+        iterator.step_back_on_next_iteration()
+        with pytest.raises(StopIteration):
+            iterator.__next__()
+
+    def test_works_correctly_in_loop(self):
+        iterator = bidirectional_iterator.BidirectionalIterator([0, 1, 2, 3, 4, 5])
+        commands = [0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0]
+        command_count = 0
+        results = []
+        for index in iterator:
+            if commands[command_count]:
+                iterator.step_back_on_next_iteration()
+            results.append(index)
+            command_count += 1
+        assert results == [0, 1, 0, 1, 2, 1, 0, 1, 2, 3, 4, 3, 2, 3, 4, 5]
+
+    def test_normal_iterator_if_not_told_to_step_back(self):
+        input_list = [0, 1, 2, 3, 4, 5]
+        iterator = bidirectional_iterator.BidirectionalIterator(input_list)
+        results = []
+        for index in iterator:
+            results.append(index)
+        assert results == input_list
+
+    def test_knows_when_stepping_back_possible(self):
+        iterator = bidirectional_iterator.BidirectionalIterator([0, 1, 2, 3])
+        commands = [0, 1, 0, 0, 1, 1, 0, 0, 0, 0]
+        command_count = 0
+        results = []
+        for _ in iterator:
+            if commands[command_count]:
+                iterator.step_back_on_next_iteration()
+            results.append(iterator.can_step_back())
+            command_count += 1
+        assert results == [False, True, False, True, True, True, False, True, True, True]


### PR DESCRIPTION
Add going backwards option to 'Is this a valid secret?', closing Issue #63 

This would be my first contribution to open source ever - thank you for the "good first issue" flag!

I have not yet figured out how to run the tests properly, else I would try to be test-driven.

The two directions I could see this go in are currently (preferences welcome):
  1) (the "obvious" one) Make `_secret_generator` in `core/audit.py` a list instead of a generator and handle indices in `audit_baseline`
  2) Cast `_secret_generator` to a "bidirectional iterator" object (still goes through `list`). That adds some overhead, but keeps the `for ... in _secret_generator` of `audit_baseline` and might make `audit.py` more readable.