### PR TITLE
Nicer JSON output + exclude regex bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /.coverage
 /.pytest_cache
 /.tox
-/venv
+/venv**
 /tmp
 
 .*ignore

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -216,6 +216,7 @@ def _save_baseline_to_file(filename, data):  # pragma: no cover
             data,
             indent=2,
             sort_keys=True,
+            separators=(',', ': '),
         ))
 
 

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -42,6 +42,7 @@ def main(argv=None):
                 _perform_scan(args, plugins),
                 indent=2,
                 sort_keys=True,
+                separators=(',', ': '),
             )
 
             if args.import_filename:

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -86,8 +86,12 @@ def _perform_scan(args, plugins):
 
     # If we have knowledge of an existing baseline file, we should use
     # that knowledge and *not* scan that file.
-    if args.import_filename and args.exclude:
-        args.exclude += r'|^{}$'.format(args.import_filename[0])
+    if args.import_filename:
+        payload = '^{}$'.format(args.import_filename[0])
+        if args.exclude and payload not in args.exclude:
+            args.exclude += r'|{}'.format(payload)
+        elif not args.exclude:
+            args.exclude = payload
 
     new_baseline = baseline.initialize(
         plugins,

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -77,6 +77,7 @@ def _write_to_baseline_file(filename, payload):  # pragma: no cover
                 payload,
                 indent=2,
                 sort_keys=True,
+                separators=(',', ': '),
             ),
         )
 


### PR DESCRIPTION
\[ https://github.com/Yelp/detect-secrets/commit/658ad0d14b00bb7d595cd1653a67febc4536693c ]
It always annoyed me that the JSON output from `scan` had trailing whitespace. However, looks like this is an [old, known issue, that only happens in < Python 3.4](https://bugs.python.org/issue16333), and the [fix](https://docs.python.org/2/library/json.html#json.dump) is merely to add that line to it.

\[ https://github.com/Yelp/detect-secrets/commit/0a6f767f7961c356e937c886575ec69cb7e8e3ae ]
Fix to minor bug I discovered:
```
$ cat .secrets.baseline
{
  "exclude_regex": "^.secrets.baseline$",
  ...
}
$ detect-secrets scan --update .secrets.baseline
$ cat .secrets.baseline
{
  "exclude_regex": "^.secrets.baseline$|^.secrets.baseline",
  ...
}
```