### PR TITLE
More performant BasicAuth plugin

### DIFF
--- a/detect_secrets/plugins/basic_auth.py
+++ b/detect_secrets/plugins/basic_auth.py
@@ -7,7 +7,7 @@ from detect_secrets.core.potential_secret import PotentialSecret
 
 
 BASIC_AUTH_REGEX = re.compile(
-    r'.*?://[^:]+:([^@]+)@',
+    r'://[^:]+:([^@]+)@',
 )
 
 


### PR DESCRIPTION
### Summary

This should make the BasicAuth plugin much more performant, and fixes https://github.com/Yelp/detect-secrets/issues/79 and https://github.com/Yelp/detect-secrets/issues/77.

### Testing

```
$ time python detect_secrets/main.py scan --no-hex-string-scan --no-base64-string-scan --no-keyword-scan --no-private-key-scan <large-file>
```

It actually finishes this time! Furthermore, I modified the large file by inserting a secret that I'd expect it to find, and it finds it as well.

### Rationale

We're already doing `BASIC_AUTH_REGEX.findall(line)` which will run the regex on all non-overlapping matches of the pattern in the string. This means that we can ignore the prefix catch-all expression (`.*?`) because we don't care about that, and we can let the python library handle it for us.