### PR TITLE
audit: minor UX enhancements

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -131,27 +131,13 @@ def _print_context(filename, secret, count, total, plugin_settings):   # pragma:
 
     :raises: SecretNotFoundOnSpecifiedLineError
     """
-    secrets_left = '{}/{}'.format(
-        count,
-        total,
-    )
-    print('{} {}\n{} {}'.format(
-        BashColor.color(
-            'Secrets Left:',
-            Color.BOLD,
-        ),
-        BashColor.color(
-            secrets_left,
-            Color.PURPLE,
-        ),
-        BashColor.color(
-            'Filename:    ',
-            Color.BOLD,
-        ),
-        BashColor.color(
-            filename,
-            Color.PURPLE,
-        ),
+    print('{} {} {} {}\n{} {}'.format(
+        BashColor.color('Secret', Color.BOLD),
+        BashColor.color(str(count), Color.PURPLE),
+        BashColor.color('of', Color.BOLD),
+        BashColor.color(str(total), Color.PURPLE),
+        BashColor.color('Filename:', Color.BOLD),
+        BashColor.color(filename, Color.PURPLE),
     ))
     print('-' * 10)
 

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -4,7 +4,6 @@ import json
 import os
 import subprocess
 import sys
-import textwrap
 from builtins import input
 from collections import defaultdict
 
@@ -18,7 +17,11 @@ from .potential_secret import PotentialSecret
 
 
 class SecretNotFoundOnSpecifiedLineError(Exception):
-    pass
+    def __init__(self, line):
+        super(SecretNotFoundOnSpecifiedLineError, self).__init__(
+            "ERROR: Secret not found on line {}!\n".format(line) +
+            "Try recreating your baseline to fix this issue.",
+        )
 
 
 def audit_baseline(baseline_filename):
@@ -329,12 +332,7 @@ def _highlight_secret(secret_line, secret, filename, plugin_settings):
         if secret_obj.secret_hash == secret['hashed_secret']:
             break
     else:
-        raise SecretNotFoundOnSpecifiedLineError(
-            textwrap.dedent("""
-                ERROR: Secret not found on specified line number!
-                Try recreating your baseline to fix this issue.
-            """)[1:-1],
-        )
+        raise SecretNotFoundOnSpecifiedLineError(secret_line)
 
     index_of_secret = secret_line.index(raw_secret)
     return '{}{}{}'.format(

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -277,6 +277,7 @@ def _get_secret_with_context(
 
     output[index_of_secret_in_output] = _highlight_secret(
         output[index_of_secret_in_output],
+        secret_lineno,
         secret,
         filename,
         plugin_settings,
@@ -297,10 +298,13 @@ def _get_secret_with_context(
     )
 
 
-def _highlight_secret(secret_line, secret, filename, plugin_settings):
+def _highlight_secret(secret_line, secret_lineno, secret, filename, plugin_settings):
     """
     :type secret_line: str
-    :param secret_line: the line on whcih the secret is found
+    :param secret_line: the line on which the secret is found
+
+    :type secret_lineno: int
+    :param secret_lineno: secret_line's line number in the source file
 
     :type secret: dict
     :param secret: see caller's docstring
@@ -332,7 +336,7 @@ def _highlight_secret(secret_line, secret, filename, plugin_settings):
         if secret_obj.secret_hash == secret['hashed_secret']:
             break
     else:
-        raise SecretNotFoundOnSpecifiedLineError(secret_line)
+        raise SecretNotFoundOnSpecifiedLineError(secret_lineno)
 
     index_of_secret = secret_line.index(raw_secret)
     return '{}{}{}'.format(

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -362,8 +362,8 @@ class TestPrintContext(object):
             assert sed_call.call_args[0][0] == 'sed -n 10,20p filenameA'.split()
 
         assert mock_printer.message == textwrap.dedent("""
-            Secrets Left: 1/2
-            Filename:     filenameA
+            Secret 1 of 2
+            Filename: filenameA
             ----------
             10:a
             11:b
@@ -394,8 +394,8 @@ class TestPrintContext(object):
             assert sed_call.call_args[0][0] == 'sed -n 1,6p filenameA'.split()
 
         assert mock_printer.message == textwrap.dedent("""
-            Secrets Left: 1/2
-            Filename:     filenameA
+            Secret 1 of 2
+            Filename: filenameA
             ----------
             1:-----BEGIN PRIVATE KEY-----
             2:e
@@ -421,8 +421,8 @@ class TestPrintContext(object):
             )
 
         assert mock_printer.message == textwrap.dedent("""
-            Secrets Left: 1/2
-            Filename:     filenameA
+            Secret 1 of 2
+            Filename: filenameA
             ----------
             ERROR: Secret not found on line 15!
             Try recreating your baseline to fix this issue.
@@ -450,8 +450,8 @@ class TestPrintContext(object):
             )
 
         assert mock_printer.message == textwrap.dedent("""
-            Secrets Left: 1/2
-            Filename:     filenameB
+            Secret 1 of 2
+            Filename: filenameB
             ----------
             10:a
             11:b

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -424,7 +424,7 @@ class TestPrintContext(object):
             Secrets Left: 1/2
             Filename:     filenameA
             ----------
-            ERROR: Secret not found on specified line number!
+            ERROR: Secret not found on line 15!
             Try recreating your baseline to fix this issue.
             ----------
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -254,8 +254,8 @@ class TestMain(object):
             main('audit will_be_mocked'.split())
 
             assert printer_shim.message == textwrap.dedent("""
-                Secrets Left: 1/1
-                Filename:     {}
+                Secret 1 of 1
+                Filename: {}
                 ----------
                 {}
                 ----------


### PR DESCRIPTION
`SecretNotFoundOnSpecifiedLineError` now includes the line number of the secret.

Also, "Secrets Left: current / total" has been changed to the more sensical "Secret current of total".