### PR TITLE
Fixes for audit

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -324,11 +324,14 @@ def _highlight_secret(secret_line, secret_lineno, secret, filename, plugin_setti
     else:
         raise SecretNotFoundOnSpecifiedLineError(secret_lineno)
 
-    index_of_secret = secret_line.index(raw_secret)
+    index_of_secret = secret_line.lower().index(raw_secret.lower())
+    end_of_secret = index_of_secret + len(raw_secret)
     return '{}{}{}'.format(
         secret_line[:index_of_secret],
         BashColor.color(
-            raw_secret,
+            # copy the secret out of the line because .lower() from secret
+            # generator may be different from the original value:
+            secret_line[index_of_secret:end_of_secret],
             Color.RED,
         ),
         secret_line[index_of_secret + len(raw_secret):],

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -248,8 +248,12 @@ def _get_secret_with_context(
     if len(output) < end_line - start_line + 1:
         # This handles the case of a short file.
         num_lines_in_file = int(subprocess.check_output([
-            'wc',
-            '-l',
+            # https://stackoverflow.com/a/38870057
+            # - 'wc -l' cannot be used here because if the last char
+            # of the file isn't \n, then the last line isn't counted
+            'grep',
+            '-c',
+            '',
             filename,
         ]).decode('utf-8').split()[0])
 

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -55,7 +55,7 @@ class KeywordDetector(BasePlugin):
         if WHITELIST_REGEX.search(string):
             return output
 
-        for identifier in self.secret_generator(string.lower()):
+        for identifier in self.secret_generator(string):
             secret = PotentialSecret(
                 self.secret_type,
                 filename,

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -68,5 +68,5 @@ class KeywordDetector(BasePlugin):
 
     def secret_generator(self, string):
         for line in BLACKLIST:
-            if line in string:
+            if line.lower() in string.lower():
                 yield line

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -32,7 +32,9 @@ from detect_secrets.plugins.core.constants import WHITELIST_REGEX
 
 
 BLACKLIST = (
-    'PASS =',
+    # NOTE all values here should be lowercase,
+    # otherwise _secret_generator can fail to match them
+    'pass =',
     'password',
     'passwd',
     'pwd',
@@ -66,7 +68,10 @@ class KeywordDetector(BasePlugin):
 
         return output
 
-    def secret_generator(self, string):
+    def _secret_generator(self, lowercase_string):
         for line in BLACKLIST:
-            if line.lower() in string.lower():
+            if line in lowercase_string:
                 yield line
+
+    def secret_generator(self, string):
+        return self._secret_generator(string.lower())

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -18,6 +18,9 @@ class TestKeywordDetector(object):
             (
                 'token = "noentropy"'
             ),
+            (
+                'PASSWORD = "verysimple"'
+            ),
         ],
     )
     def test_analyze(self, file_content):
@@ -28,3 +31,5 @@ class TestKeywordDetector(object):
         assert len(output) == 1
         for potential_secret in output:
             assert 'mock_filename' == potential_secret.filename
+        generated = list(logic.secret_generator(file_content))
+        assert len(generated) == len(output)


### PR DESCRIPTION
This PR fixes two issues I've noticed in the `audit` mode:

1. `keyword` plugin failing with `SecretNotFoundOnSpecifiedLineError` if the secret is different in terms of lowercase vs uppercase. (before this change the `keyword` plugin is case-insensitive at https://github.com/Yelp/detect-secrets/blob/d912ced2e7a7607f06794e3d916b10e52536bd5c/detect_secrets/plugins/keyword.py#L58 but case-sensitive at https://github.com/Yelp/detect-secrets/blob/d912ced2e7a7607f06794e3d916b10e52536bd5c/detect_secrets/plugins/keyword.py#L70 — and the latter is used by the `audit` mode at https://github.com/Yelp/detect-secrets/blob/cc6bddbd9d2bd84a3fe32fb82db7c750460f812b/detect_secrets/core/audit.py#L313)
2. ` _get_secret_with_context` failing for small files if they don't have `\n` at the end of the file.