### PR TITLE
Ordered hashes, to make better diffs

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 
 from ..plugins.core import initialize
 from ..plugins.high_entropy_strings import HighEntropyStringsPlugin
+from .baseline import format_baseline_for_output
 from .baseline import merge_results
 from .bidirectional_iterator import BidirectionalIterator
 from .color import BashColor
@@ -201,12 +202,7 @@ def _handle_user_decision(decision, secret):
 
 def _save_baseline_to_file(filename, data):  # pragma: no cover
     with open(filename, 'w') as f:
-        f.write(json.dumps(
-            data,
-            indent=2,
-            sort_keys=True,
-            separators=(',', ': '),
-        ))
+        f.write(format_baseline_for_output(data))
 
 
 def _get_secret_with_context(

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -235,6 +235,12 @@ def format_baseline_for_output(baseline):
     :type baseline: dict
     :rtype: str
     """
+    for filename, secret_list in baseline['results'].items():
+        baseline['results'][filename] = sorted(
+            secret_list,
+            key=lambda x: (x['line_number'], x['hashed_secret'],),
+        )
+
     return json.dumps(
         baseline,
         indent=2,

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import json
 import os
 import re
 import subprocess
@@ -227,6 +228,19 @@ def merge_results(old_results, new_results):
                 break
 
     return new_results
+
+
+def format_baseline_for_output(baseline):
+    """
+    :type baseline: dict
+    :rtype: str
+    """
+    return json.dumps(
+        baseline,
+        indent=2,
+        sort_keys=True,
+        separators=(',', ': '),
+    )
 
 
 def _get_git_tracked_files(rootdir='.'):

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -38,11 +38,8 @@ def main(argv=None):
             _scan_string(line, plugins)
 
         else:
-            output = json.dumps(
+            output = baseline.format_baseline_for_output(
                 _perform_scan(args, plugins),
-                indent=2,
-                sort_keys=True,
-                separators=(',', ': '),
             )
 
             if args.import_filename:

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 
 from detect_secrets import VERSION
+from detect_secrets.core.baseline import format_baseline_for_output
 from detect_secrets.core.baseline import get_secrets_not_in_baseline
 from detect_secrets.core.baseline import update_baseline_with_removed_secrets
 from detect_secrets.core.log import get_logger
@@ -72,14 +73,7 @@ def main(argv=None):
 def _write_to_baseline_file(filename, payload):  # pragma: no cover
     """Breaking this function up for mockability."""
     with open(filename, 'w') as f:
-        f.write(
-            json.dumps(
-                payload,
-                indent=2,
-                sort_keys=True,
-                separators=(',', ': '),
-            ),
-        )
+        f.write(format_baseline_for_output(payload))
 
 
 def get_baseline(baseline_filename):

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+import json
 import random
 
 import mock
 import pytest
 
 from detect_secrets.core import baseline
+from detect_secrets.core.baseline import format_baseline_for_output
 from detect_secrets.core.baseline import get_secrets_not_in_baseline
 from detect_secrets.core.baseline import merge_baseline
 from detect_secrets.core.baseline import merge_results
@@ -512,3 +514,33 @@ class TestMergeResults(object):
             'line_number': random_number,
             'type': 'Test Type',
         }
+
+
+class TestFormatBaselineForOutput(object):
+
+    def test_sorts_by_line_number_then_hash(self):
+        output_string = format_baseline_for_output({
+            'results': {
+                'filename': [
+                    {
+                        'hashed_secret': 'a',
+                        'line_number': 3,
+                    },
+                    {
+                        'hashed_secret': 'z',
+                        'line_number': 2,
+                    },
+                    {
+                        'hashed_secret': 'f',
+                        'line_number': 3,
+                    },
+                ],
+            },
+        })
+
+        ordered_hashes = list(map(
+            lambda x: x['hashed_secret'],
+            json.loads(output_string)['results']['filename'],
+        ))
+
+        assert ordered_hashes == ['z', 'a', 'f']

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -35,10 +35,9 @@ def mock_merge_baseline():
     with mock.patch(
         'detect_secrets.main.baseline.merge_baseline',
     ) as m:
-        # This return value doesn't matter, because we're not testing
-        # for it. It just needs to be a dictionary, so it can be properly
-        # JSON dumped.
-        m.return_value = {}
+        # This return value needs to have the `results` key, so that it can
+        # formatted appropriately for output.
+        m.return_value = {'results': {}}
         yield m
 
 


### PR DESCRIPTION
### Current Issue

```
@@ -994,17 +994,17 @@
         "type": "Hex High Entropy String"
       },
       {
-        "hashed_secret": "b927c80e00a783f0169fa2a4a115ee9ed7011d9b",
+        "hashed_secret": "e9fb1204aaac5061bf3c08c820f1cfaeb9c83aae",
         "line_number": 10,
         "type": "Hex High Entropy String"
       },
       {
-        "hashed_secret": "e9fb1204aaac5061bf3c08c820f1cfaeb9c83aae",
+        "hashed_secret": "88261181847473b4d9933c8e6ec7068a839213ed",
         "line_number": 10,
         "type": "Hex High Entropy String"
       },
       {
-        "hashed_secret": "88261181847473b4d9933c8e6ec7068a839213ed",
+        "hashed_secret": "b927c80e00a783f0169fa2a4a115ee9ed7011d9b",
         "line_number": 10,
         "type": "Hex High Entropy String"
       },
```

As you can see, the above `hashed_secret`s kinda played musical chairs, making diffs harder to read, and larger than they really need to be.

### Solution

Order the secrets first by line number, then by hashed_secret. This way, it should have a deterministic order.