### PR TITLE
Update merge results to only propagate is_secret of new secrets

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -177,7 +177,7 @@ def _get_user_decision(prompt_secret_decision=True, can_step_back=False):
             print('Invalid input.')
 
         if 'y' in allowable_user_input:
-            user_input_string = 'Is this a valid secret? (y)es, (n)o, '
+            user_input_string = 'Is this a valid secret? i.e. not a false-positive (y)es, (n)o, '
         else:
             user_input_string = 'What would you like to do? '
         if 'b' in allowable_user_input:

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -188,17 +188,21 @@ def merge_results(old_results, new_results):
         if filename not in new_results:
             continue
 
-        for new_secret in new_results[filename]:
-            for old_secret in old_secrets:
-                if old_secret['hashed_secret'] != new_secret['hashed_secret']:
-                    # We don't join the two secret sets, because if the later
-                    # result set did not discover an old secret, it's probably
-                    # moved.
-                    continue
+        old_secrets_mapping = dict()
+        for old_secret in old_secrets:
+            old_secrets_mapping[old_secret['hashed_secret']] = old_secret
 
-                # Only propogate 'is_secret' if it's not already there
-                if 'is_secret' in old_secret and 'is_secret' not in new_secret:
-                    new_secret['is_secret'] = old_secret['is_secret']
+        for new_secret in new_results[filename]:
+            if new_secret['hashed_secret'] not in old_secrets_mapping:
+                # We don't join the two secret sets, because if the newer
+                # result set did not discover an old secret, it probably
+                # moved.
+                continue
+
+            old_secret = old_secrets_mapping[new_secret['hashed_secret']]
+            # Only propogate 'is_secret' if it's not already there
+            if 'is_secret' in old_secret and 'is_secret' not in new_secret:
+                new_secret['is_secret'] = old_secret['is_secret']
 
     return new_results
 

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -223,7 +223,7 @@ def format_baseline_for_output(baseline):
         indent=2,
         sort_keys=True,
         separators=(',', ': '),
-    )
+    ) + '\n'
 
 
 def _get_git_tracked_files(rootdir='.'):

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -500,7 +500,7 @@ class TestGetUserDecision(object):
         [
             (
                 True,
-                'Is this a valid secret? (y)es, (n)o, (s)kip, (q)uit: ',
+                'Is this a valid secret? i.e. not a false-positive (y)es, (n)o, (s)kip, (q)uit: ',
             ),
             (
                 False,

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -422,7 +422,7 @@ class TestMergeResults(object):
             ],
         }
 
-        assert merge_results(old_result, {}) == old_result
+        assert merge_results(old_result, {}) == {}
 
     def test_old_results_have_subset_of_new_results(self):
         secretA = self.get_secret()
@@ -446,7 +446,6 @@ class TestMergeResults(object):
         ) == {
             'filenameA': [
                 modified_secretA,
-                secretB,
             ],
         }
 
@@ -480,10 +479,8 @@ class TestMergeResults(object):
             },
         ) == {
             'filename': [
-                secretA,
                 modified_secretB,
                 modified_secretC,
-                secretD,
             ],
         }
 


### PR DESCRIPTION

When I do `detect-secrets -vvv scan --update .secrets.baseline` it'll run with new plugins, so I changed some of the assumptions in `merge_results`