### PR TITLE
Nicer audit display

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -132,13 +132,15 @@ def _print_context(filename, secret, count, total, plugin_settings):   # pragma:
 
     :raises: SecretNotFoundOnSpecifiedLineError
     """
-    print('{} {} {} {}\n{} {}'.format(
-        BashColor.color('Secret', Color.BOLD),
+    print('{} {} {} {}\n{} {}\n{} {}'.format(
+        BashColor.color('Secret:     ', Color.BOLD),
         BashColor.color(str(count), Color.PURPLE),
         BashColor.color('of', Color.BOLD),
         BashColor.color(str(total), Color.PURPLE),
-        BashColor.color('Filename:', Color.BOLD),
+        BashColor.color('Filename:   ', Color.BOLD),
         BashColor.color(filename, Color.PURPLE),
+        BashColor.color('Secret Type:', Color.BOLD),
+        BashColor.color(secret['type'], Color.PURPLE),
     ))
     print('-' * 10)
 

--- a/test_data/short_files/first_line.py
+++ b/test_data/short_files/first_line.py
@@ -1,4 +1,4 @@
-seecret = 'BEEF0123456789a'
+secret = 'BEEF0123456789a'
 skipped_sequential_false_positive = '0123456789a'
 print('second line')
 var = 'third line'

--- a/test_data/short_files/last_line.ini
+++ b/test_data/short_files/last_line.ini
@@ -1,5 +1,5 @@
 [some section]
-secreets_for_no_one_to_find =
+secrets_for_no_one_to_find =
     hunter2
-    passsword123
+    password123
     BEEF0123456789a

--- a/test_data/short_files/middle_line.yml
+++ b/test_data/short_files/middle_line.yml
@@ -1,6 +1,6 @@
 deploy:
     user: aaronloo
-    passhword:
+    password:
         secure: thequickbrownfoxjumpsoverthelazydog
     on:
-        repo: Yelp/detect-sechrets
+        repo: Yelp/detect-secrets

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -362,8 +362,9 @@ class TestPrintContext(object):
             assert sed_call.call_args[0][0] == 'sed -n 10,20p filenameA'.split()
 
         assert mock_printer.message == textwrap.dedent("""
-            Secret 1 of 2
-            Filename: filenameA
+            Secret:      1 of 2
+            Filename:    filenameA
+            Secret Type: Private Key
             ----------
             10:a
             11:b
@@ -394,8 +395,9 @@ class TestPrintContext(object):
             assert sed_call.call_args[0][0] == 'sed -n 1,6p filenameA'.split()
 
         assert mock_printer.message == textwrap.dedent("""
-            Secret 1 of 2
-            Filename: filenameA
+            Secret:      1 of 2
+            Filename:    filenameA
+            Secret Type: Private Key
             ----------
             1:-----BEGIN PRIVATE KEY-----
             2:e
@@ -421,8 +423,9 @@ class TestPrintContext(object):
             )
 
         assert mock_printer.message == textwrap.dedent("""
-            Secret 1 of 2
-            Filename: filenameA
+            Secret:      1 of 2
+            Filename:    filenameA
+            Secret Type: Private Key
             ----------
             ERROR: Secret not found on line 15!
             Try recreating your baseline to fix this issue.
@@ -450,8 +453,9 @@ class TestPrintContext(object):
             )
 
         assert mock_printer.message == textwrap.dedent("""
-            Secret 1 of 2
-            Filename: filenameB
+            Secret:      1 of 2
+            Filename:    filenameB
+            Secret Type: Hex High Entropy String
             ----------
             10:a
             11:b

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -192,7 +192,7 @@ class TestMain(object):
             (
                 'test_data/short_files/first_line.py',
                 textwrap.dedent("""
-                    1:seecret = 'BEEF0123456789a'
+                    1:secret = 'BEEF0123456789a'
                     2:skipped_sequential_false_positive = '0123456789a'
                     3:print('second line')
                     4:var = 'third line'
@@ -203,19 +203,19 @@ class TestMain(object):
                 textwrap.dedent("""
                     1:deploy:
                     2:    user: aaronloo
-                    3:    passhword:
+                    3:    password:
                     4:        secure: thequickbrownfoxjumpsoverthelazydog
                     5:    on:
-                    6:        repo: Yelp/detect-sechrets
+                    6:        repo: Yelp/detect-secrets
                 """)[1:-1],
             ),
             (
                 'test_data/short_files/last_line.ini',
                 textwrap.dedent("""
                     1:[some section]
-                    2:secreets_for_no_one_to_find =
+                    2:secrets_for_no_one_to_find =
                     3:    hunter2
-                    4:    passsword123
+                    4:    password123
                     5:    BEEF0123456789a
                 """)[1:-1],
             ),
@@ -231,10 +231,11 @@ class TestMain(object):
             main(['scan', filename])
             baseline = printer_shim.message
 
+        baseline_dict = json.loads(baseline)
         with mock_stdin(), mock.patch(
             # To pipe in printer_shim
             'detect_secrets.core.audit._get_baseline_from_file',
-            return_value=json.loads(baseline),
+            return_value=baseline_dict,
         ), mock.patch(
             # We don't want to clear the pytest testing screen
             'detect_secrets.core.audit._clear_screen',
@@ -251,14 +252,16 @@ class TestMain(object):
             main('audit will_be_mocked'.split())
 
             assert printer_shim.message == textwrap.dedent("""
-                Secret 1 of 1
-                Filename: {}
+                Secret:      1 of 1
+                Filename:    {}
+                Secret Type: {}
                 ----------
                 {}
                 ----------
                 Saving progress...
             """)[1:].format(
                 filename,
+                baseline_dict['results'][filename][0]['type'],
                 expected_output,
             )
 


### PR DESCRIPTION
It occurred to me while doing an audit, and encountering false positives: why were *these* specific portions of text highlighted? Wouldn't it be good if we could display which plugin thought this was a secret, so that we can more easily go back and modify the plugin if needed?

Then I realized: we already have that information, it's just a matter of displaying it.