### PR TITLE
:tada: [pre-commit-hook] Automatically update the baseline

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -66,7 +66,6 @@ class SecretsCollection(object):
             'exclude_regex',
             'plugins_used',
             'results',
-            'version',
         )):
             raise IOError
 
@@ -95,7 +94,11 @@ class SecretsCollection(object):
                 secret.secret_hash = item['hashed_secret']
                 result.data[filename][secret] = secret
 
-        result.version = data['version']
+        result.version = (
+            data['version']
+            if 'version' in data
+            else '0.0.0'
+        )
 
         return result
 

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -32,7 +32,7 @@ class ParserBuilder(object):
             dest='action',
         )
 
-        for action_parser in [ScanOptions, AuditOptions]:
+        for action_parser in (ScanOptions, AuditOptions):
             action_parser(subparser).add_arguments()
 
         return self
@@ -62,7 +62,11 @@ class ParserBuilder(object):
         return self
 
     def _add_filenames_argument(self):
-        self.parser.add_argument('filenames', nargs='*', help='Filenames to check')
+        self.parser.add_argument(
+            'filenames',
+            nargs='*',
+            help='Filenames to check',
+        )
         return self
 
     def _add_set_baseline_argument(self):

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -11,7 +11,7 @@ from detect_secrets.core.baseline import format_baseline_for_output
 from detect_secrets.core.baseline import get_secrets_not_in_baseline
 from detect_secrets.core.baseline import merge_baseline
 from detect_secrets.core.baseline import merge_results
-from detect_secrets.core.baseline import update_baseline_with_removed_secrets
+from detect_secrets.core.baseline import trim_baseline_of_removed_secrets
 from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.high_entropy_strings import Base64HighEntropyString
 from detect_secrets.plugins.high_entropy_strings import HexHighEntropyString
@@ -31,19 +31,19 @@ class TestInitializeBaseline(object):
 
     def get_results(
         self,
-        rootdir='./test_data/files',
+        path='./test_data/files',
         exclude_regex=None,
         scan_all_files=False,
     ):
         return baseline.initialize(
             self.plugins,
-            rootdir=rootdir,
+            path=path,
             exclude_regex=exclude_regex,
             scan_all_files=scan_all_files,
         ).json()
 
     @pytest.mark.parametrize(
-        'rootdir',
+        'path',
         [
             './test_data/files',
 
@@ -51,8 +51,8 @@ class TestInitializeBaseline(object):
             'test_data/../test_data/files/tmp/..',
         ],
     )
-    def test_basic_usage(self, rootdir):
-        results = self.get_results(rootdir=rootdir)
+    def test_basic_usage(self, path):
+        results = self.get_results(path=path)
 
         assert len(results.keys()) == 2
         assert len(results['test_data/files/file_with_secrets.py']) == 1
@@ -82,7 +82,7 @@ class TestInitializeBaseline(object):
                 ),
             ),
         ):
-            results = self.get_results(rootdir='will_be_mocked')
+            results = self.get_results(path='will_be_mocked')
 
         assert not results
 
@@ -99,7 +99,7 @@ class TestInitializeBaseline(object):
         assert len(results['will_be_mocked']) == 1
 
     def test_scan_all_files(self):
-        results = self.get_results(rootdir='test_data/files', scan_all_files=True)
+        results = self.get_results(path='test_data/files', scan_all_files=True)
         assert len(results.keys()) == 2
 
 
@@ -229,7 +229,7 @@ class TestUpdateBaselineWithRemovedSecrets(object):
             },
         ])
 
-        is_successful = update_baseline_with_removed_secrets(
+        is_successful = trim_baseline_of_removed_secrets(
             new_findings,
             baseline,
             ['filename'],
@@ -247,7 +247,7 @@ class TestUpdateBaselineWithRemovedSecrets(object):
             },
         ])
 
-        is_successful = update_baseline_with_removed_secrets(
+        is_successful = trim_baseline_of_removed_secrets(
             new_findings,
             baseline,
             [
@@ -272,7 +272,7 @@ class TestUpdateBaselineWithRemovedSecrets(object):
             },
         ])
 
-        is_successful = update_baseline_with_removed_secrets(
+        is_successful = trim_baseline_of_removed_secrets(
             new_findings,
             baseline,
             ['filename'],
@@ -303,7 +303,7 @@ class TestUpdateBaselineWithRemovedSecrets(object):
         new_findings = secrets_collection_factory([results_dict])
         baseline = secrets_collection_factory([baseline_dict])
 
-        assert not update_baseline_with_removed_secrets(
+        assert not trim_baseline_of_removed_secrets(
             new_findings,
             baseline,
             ['filename'],

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -97,40 +97,55 @@ class TestPreCommitHook(object):
         'baseline_version, current_version',
         [
             ('', '0.8.8',),
+            ('0.8.8', '0.8.9',),
             ('0.8.8', '0.9.0',),
             ('0.8.8', '1.0.0',),
         ],
     )
-    def test_fails_if_baseline_version_is_outdated(
+    def test_that_baseline_gets_updated(
         self,
         mock_log,
         baseline_version,
         current_version,
     ):
         with _mock_versions(baseline_version, current_version):
-            assert_commit_blocked(
-                '--baseline will_be_mocked',
-            )
+            baseline_string = _create_baseline()
+            modified_baseline = json.loads(baseline_string)
 
-        assert mock_log.error_messages == (
-            'The supplied baseline may be incompatible with the current\n'
-            'version of detect-secrets. Please recreate your baseline to\n'
-            'avoid potential mis-configurations.\n'
-            '\n'
-            '$ detect-secrets scan --update will_be_mocked\n'
-            '\n'
-            'Current Version: {}\n'
-            'Baseline Version: {}\n'
-        ).format(
-            current_version,
-            baseline_version if baseline_version else '0.0.0',
-        )
+            with mock.patch(
+                'detect_secrets.pre_commit_hook._get_baseline_string_from_file',
+                return_value=json.dumps(modified_baseline),
+            ), mock.patch(
+                'detect_secrets.pre_commit_hook._write_to_baseline_file',
+            ) as m:
+                assert_commit_blocked(
+                    '--baseline will_be_mocked test_data/files/file_with_secrets.py',
+                )
 
-    def test_succeeds_if_patch_version_is_different(self):
-        with _mock_versions('0.8.8', '0.8.9'):
-            assert_commit_succeeds(
-                'test_data/files/file_with_no_secrets.py',
-            )
+                baseline_written = m.call_args[0][1]
+
+            original_baseline = json.loads(baseline_string)
+            assert original_baseline['exclude_regex'] == baseline_written['exclude_regex']
+            assert original_baseline['results'] == baseline_written['results']
+
+            # See that we updated the plugins and version
+            assert current_version == baseline_written['version']
+            assert baseline_written['plugins_used'] == [
+                {
+                    'base64_limit': 4.5,
+                    'name': 'Base64HighEntropyString',
+                },
+                {
+                    'name': 'BasicAuthDetector',
+                },
+                {
+                    'hex_limit': 3,
+                    'name': 'HexHighEntropyString',
+                },
+                {
+                    'name': 'PrivateKeyDetector',
+                },
+            ]
 
     def test_writes_new_baseline_if_modified(self):
         baseline_string = _create_baseline()


### PR DESCRIPTION
When no secrets are present, that is.

(pre_commit_hook.py)
    Do not raise exception when baseline out-of-date
    Replace baseline `version`/`plugins` with the current ones.
    Replaced `raise_exception_if_baseline_version_is_outdated` with if statement
    Renamed `raise_exception_if_baseline_file_is_not_up_to_date` to `raise_exception_if_baseline_file_is_unstaged`
    Improve comment

(core/secrets_collection.py)
    Make `version` not required for baseline's any more

(tests/pre_commit_hook_test.py):
    Replaced `test_fails_if_baseline_version_is_outdated` with `test_that_baseline_gets_updated`

Clean up:
    (core/usage.py)
        Static list into a tuple
    (core/baseline.py)
        `initialize()` docstring accurate
        Renamed `update_baseline_with_removed_secrets` to `trim_baseline_of_removed_secrets`
        Renamed `git_files` to `files_to_scan`
        Fix typo (propogate -> propagate)