### PR TITLE
Improved BasicAuth detector

### DIFF
--- a/detect_secrets/plugins/basic_auth.py
+++ b/detect_secrets/plugins/basic_auth.py
@@ -6,8 +6,12 @@ from .base import BasePlugin
 from detect_secrets.core.potential_secret import PotentialSecret
 
 
+SPECIAL_URL_CHARACTERS = ':/?#[]@'
 BASIC_AUTH_REGEX = re.compile(
-    r'://[^:]+:([^@]+)@',
+    r'://[^{}\s]+:([^{}\s]+)@'.format(
+        re.escape(SPECIAL_URL_CHARACTERS),
+        re.escape(SPECIAL_URL_CHARACTERS),
+    ),
 )
 
 

--- a/tests/plugins/basic_auth_test.py
+++ b/tests/plugins/basic_auth_test.py
@@ -11,6 +11,7 @@ class TestBasicAuthDetector(object):
         'payload, should_flag',
         [
             ('https://username:password@yelp.com', True,),
+            ('http://localhost:5000/<%= @variable %>', False,),
         ],
     )
     def test_analyze_string(self, payload, should_flag):


### PR DESCRIPTION
### Summary

\[ https://github.com/Yelp/detect-secrets/commit/89ff5941e5149dcb41245450672dcb3e7a520eb7 ]
Even though browsers have different ways of parsing a URL, there is a set of generic characters that can't be used in certain parts of the URL. Using this information, we can improve our regex to reduce false positives.

On an internal sample set, I managed to reduce false positives by ~8%.

As a side note, I did evaluate the use of https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json#L19, but there were strange length limits which I did not understand. They may have been used to heuristically reduce more false positives, but from the data that I've been testing it on, it doesn't seem to be necessary.

\[ https://github.com/Yelp/detect-secrets/commit/d7a0a08f49db0e44bb833bee73c67a772c9a95c6 ]
Bug fix: there's a strange case that occurs when comparing baselines. If a secret is removed, then it wouldn't be able to find itself, and perform the proper highlighting. However, since you **want** to see what lines are removed and added, let's show it for the `audit --diff` functionality.