### PR TITLE
check the whitelist regex in the base plugin class  (for #93)

### DIFF
--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -1,6 +1,8 @@
 from abc import ABCMeta
 from abc import abstractmethod
 
+from detect_secrets.plugins.core.constants import WHITELIST_REGEX
+
 
 class BasePlugin(object):
     """This is an abstract class to define Plugins API"""
@@ -23,6 +25,8 @@ class BasePlugin(object):
         """
         potential_secrets = {}
         for line_num, line in enumerate(file.readlines(), start=1):
+            if WHITELIST_REGEX.search(line):
+                continue
             secrets = self.analyze_string(line, line_num, filename)
             potential_secrets.update(secrets)
 

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 
 from .base import BasePlugin
 from detect_secrets.core.potential_secret import PotentialSecret
-from detect_secrets.plugins.core.constants import WHITELIST_REGEX
 
 
 BLACKLIST = (
@@ -53,9 +52,6 @@ class KeywordDetector(BasePlugin):
 
     def analyze_string(self, string, line_num, filename):
         output = {}
-
-        if WHITELIST_REGEX.search(string):
-            return output
 
         for identifier in self.secret_generator(string):
             secret = PotentialSecret(

--- a/test_data/config.ini
+++ b/test_data/config.ini
@@ -22,3 +22,5 @@ keyB = 456789123
     567891234
 
 keyC =
+
+password = 12345678901234  # pragma: whitelist secret


### PR DESCRIPTION
This adds a check for the `WHITELIST_REGEX` (i.e. `# pragma: whitelist secret`) in the base plugin class, in `analyze()`, see #93.

This doesn't affect `HighEntropyStringsPlugin` because that class overrides `analyze()`, but that class already does this regex check (in `analyze_string()`). Seems reasonable to me that if a class is overriding `analyze()` it should handle this whitelist check itself too.


#### Test coverage

This actually increases test coverage slightly... I did have to add a whitelisted line to the test .ini file, otherwise the whitelist check in HighEntropyStringsPlugin loses its test coverage.