### PR TITLE
Removing unidiff from standard dependencies

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -7,9 +7,6 @@ import re
 from time import gmtime
 from time import strftime
 
-from unidiff import PatchSet
-from unidiff.errors import UnidiffParseError
-
 from detect_secrets import VERSION
 from detect_secrets.core.log import log
 from detect_secrets.core.potential_secret import PotentialSecret
@@ -128,6 +125,11 @@ class SecretsCollection(object):
         :type repo_name: str
         :param repo_name: used for logging only -- the name of the repo
         """
+        # Local imports, so that we don't need to require unidiff for versions of
+        # detect-secrets that don't use it.
+        from unidiff import PatchSet
+        from unidiff.errors import UnidiffParseError
+
         try:
             patch_set = PatchSet.from_string(diff)
         except UnidiffParseError:  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     keywords=['secret-management', 'pre-commit', 'security', 'entropy-checks'],
     install_requires=[
         'pyyaml',
-        'unidiff',
     ],
     extras_require={
         ':python_version=="2.7"': [


### PR DESCRIPTION
It looks like `unidiff` is only used for the ability to scan diffs with SecretsCollection (ported from `detect-secrets-server`). However, during normal use of detect-secrets, there is no need for that.

Due to this, let's reduce unused dependencies.

I still kept it around in `requirements-dev.txt`, seeing that it should be needed for tests, so as to not break detect-secrets-server.