### PR TITLE
add whitelist directive regexes to match against inline comment syntaxes in more languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ either the client-side pre-commit hook, or the server-side secret scanner.
 3. **Secrets Baseline**, to whitelist pre-existing secrets in the repository,
    so that they won't be continuously caught through scan iterations.
 
-### Client-side Pre-commit Hook
+### Client-side `pre-commit` Hook
 
 See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions
 to install the pre-commit framework. The example usage above has a sample
@@ -119,26 +119,21 @@ as your pre-commit hook, and server-side secret scanner!
 
 #### Inline Whitelisting
 
-Another way of whitelisting secrets is through the inline comment
-`# pragma: whitelist secret`.
+To tell `detect-secrets` to ignore a particular line of code, simply append an
+inline `pragma: whitelist secret` comment. For example:
 
-For example:
-
+```python
+API_KEY = "blah-blah-but-actually-not-secret"  # pragma: whitelist secret
+print('hello world')
 ```
-API_KEY = "blah-blah-but-actually-not-secret" # pragma: whitelist secret
 
-def main():
-    print('hello world')
-
-if __name__ == '__main__'
-    main()
-```
+Inline commenting syntax for a multitude of languages is supported.
 
 This may be a convenient way for you to whitelist secrets, without having to
 regenerate the entire baseline again. Furthermore, this makes the whitelisted
 secrets easily searchable, auditable, and maintainable.
 
-## Current Supported Plugins
+## Currently Supported Plugins
 
 The current heuristic searches we implement out of the box include:
 
@@ -158,7 +153,7 @@ See [detect_secrets/
 plugins](https://github.com/Yelp/detect-secrets/tree/master/detect_secrets/plugins)
 for more details.
 
-## A Few Caveats
+## Caveats
 
 This is not meant to be a sure-fire solution to prevent secrets from entering
 the codebase. Only proper developer education can truly do that. This pre-commit

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from abc import abstractproperty
 
 from detect_secrets.core.potential_secret import PotentialSecret
-from detect_secrets.plugins.core.constants import WHITELIST_REGEX
+from detect_secrets.plugins.core.constants import WHITELIST_REGEXES
 
 
 class BasePlugin(object):
@@ -27,7 +27,7 @@ class BasePlugin(object):
         """
         potential_secrets = {}
         for line_num, line in enumerate(file.readlines(), start=1):
-            if WHITELIST_REGEX.search(line):
+            if any(regex.search(line) for regex in WHITELIST_REGEXES):
                 continue
             secrets = self.analyze_string(line, line_num, filename)
             potential_secrets.update(secrets)

--- a/detect_secrets/plugins/core/constants.py
+++ b/detect_secrets/plugins/core/constants.py
@@ -1,4 +1,17 @@
 import re
 
-# TODO: Update for not just python comments?
-WHITELIST_REGEX = re.compile(r'# ?pragma: ?whitelist[ -]secret')
+WHITELIST_REGEXES = [
+    re.compile(r)
+    for r in [
+        r'[ \t]+{} ?pragma: ?whitelist[ -]secret{}[ \t]*$'.format(start, end)
+        for start, end in (
+            ('#', ''),              # e.g. python
+            ('//', ''),             # e.g. golang
+            (r'/\*', r' ?\*/'),     # e.g. c
+            ('\'', ''),             # e.g. visual basic .net
+            ('--', ''),             # e.g. sql
+            # many other inline comment syntaxes are not included,
+            # because we want to be performant for the common case
+        )
+    ]
+]

--- a/detect_secrets/plugins/core/yaml_file_parser.py
+++ b/detect_secrets/plugins/core/yaml_file_parser.py
@@ -1,6 +1,6 @@
 import yaml
 
-from detect_secrets.plugins.core.constants import WHITELIST_REGEX
+from detect_secrets.plugins.core.constants import WHITELIST_REGEXES
 
 
 class YamlFileParser(object):
@@ -127,7 +127,7 @@ class YamlFileParser(object):
         ignored_lines = set()
 
         for line_number, line in enumerate(self.content.split('\n'), 1):
-            if WHITELIST_REGEX.search(line):
+            if any(regex.search(line) for regex in WHITELIST_REGEXES):
                 ignored_lines.add(line_number)
 
         return ignored_lines

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -12,7 +12,6 @@ import yaml
 
 from .base import BasePlugin
 from detect_secrets.core.potential_secret import PotentialSecret
-from detect_secrets.plugins.core.constants import WHITELIST_REGEXES
 from detect_secrets.plugins.core.ini_file_parser import IniFileParser
 from detect_secrets.plugins.core.yaml_file_parser import YamlFileParser
 
@@ -95,9 +94,6 @@ class HighEntropyStringsPlugin(BasePlugin):
         match self.regex, with a limit defined as self.entropy_limit.
         """
         output = {}
-
-        if any(regex.search(string) for regex in WHITELIST_REGEXES):
-            return output
 
         for result in self.secret_generator(string):
             if self.is_sequential_string(result):

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -12,7 +12,7 @@ import yaml
 
 from .base import BasePlugin
 from detect_secrets.core.potential_secret import PotentialSecret
-from detect_secrets.plugins.core.constants import WHITELIST_REGEX
+from detect_secrets.plugins.core.constants import WHITELIST_REGEXES
 from detect_secrets.plugins.core.ini_file_parser import IniFileParser
 from detect_secrets.plugins.core.yaml_file_parser import YamlFileParser
 
@@ -96,7 +96,7 @@ class HighEntropyStringsPlugin(BasePlugin):
         """
         output = {}
 
-        if WHITELIST_REGEX.search(string):
+        if any(regex.search(string) for regex in WHITELIST_REGEXES):
             return output
 
         for result in self.secret_generator(string):

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -175,7 +175,7 @@ def pretty_print_diagnostics(secrets):
 def _print_warning_header():
     message = (
         'Potential secrets about to be committed to git repo! Please rectify '
-        'or explicitly ignore with `pragma: whitelist secret` comment.'
+        'or explicitly ignore with an inline `pragma: whitelist secret` comment.'
     )
 
     log.error(textwrap.fill(message))
@@ -191,7 +191,7 @@ def _print_secrets_found(secrets):
 def _print_mitigation_suggestions():
     suggestions = [
         'For information about putting your secrets in a safer place, please ask in #security',
-        'Mark false positives with `# pragma: whitelist secret`',
+        'Mark false positives with an inline `pragma: whitelist secret` comment',
         'Commit with `--no-verify` if this is a one-time false positive',
     ]
 

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -94,8 +94,11 @@ class HighEntropyStringsTest(object):
         'content_to_format',
         [
             # Test inline annotation for whitelisting
-            "'{secret}' # pragma: whitelist secret",
-
+            "'{secret}'  # pragma: whitelist secret",
+            "'{secret}'  // pragma: whitelist secret",
+            "'{secret}'  /* pragma: whitelist secret */",
+            "'{secret}'  ' pragma: whitelist secret",
+            "'{secret}'  -- pragma: whitelist secret",
             # Not a string
             "{secret}",
         ],


### PR DESCRIPTION
Also:

- improved the base regex to account for leading whitespace before the inline comment start character, and trailing whitespace until EOL.
- some docs tweaks

The only suitable and pre-existing place I could find was in `tests/plugins/high_entropy_strings_test.py`. Ideally, tests should be moved to (and should only exist exclusively in) `tests/plugins/base_test.py`. The redundant logic to detect whether or not to ignore a file should also be removed from `YamlFileParser` and the `HighEntropyStringsPlugin`. The latter should be refactored so that the logic in `analyze_string` is run by `BasePlugin`'s `analyze`.