### PR TITLE
small improvements to existing FileParsers

### DIFF
--- a/detect_secrets/plugins/core/constants.py
+++ b/detect_secrets/plugins/core/constants.py
@@ -11,7 +11,18 @@ WHITELIST_REGEXES = [
             ('\'', ''),             # e.g. visual basic .net
             ('--', ''),             # e.g. sql
             # many other inline comment syntaxes are not included,
-            # because we want to be performant for the common case
+            # because we want to be performant for
+            # any(regex.search(line) for regex in WHITELIST_REGEXES)
+            # calls. of course, this won't be a concern if detect-secrets
+            # switches over to implementing file plugins for each supported
+            # filetype.
         )
     ]
 ]
+
+# add to this mapping (and WHITELIST_REGEXES if applicable) lazily,
+# as more language specific file parsers are implemented.
+# discussion: https://github.com/Yelp/detect-secrets/pull/105
+WHITELIST_REGEX = {
+    'yaml': WHITELIST_REGEXES[0],
+}

--- a/detect_secrets/plugins/core/ini_file_parser.py
+++ b/detect_secrets/plugins/core/ini_file_parser.py
@@ -13,7 +13,7 @@ class IniFileParser(object):
 
         # Hacky way to keep track of line location
         file.seek(0)
-        self.lines = list(map(lambda x: x.strip(), file.readlines()))
+        self.lines = list(map(str.strip, file.readlines()))
         self.line_offset = 0
 
     def iterator(self):
@@ -123,10 +123,7 @@ class IniFileParser(object):
             2. For all other values, ignore blank lines.
         Then, we can parse through, and look for values only.
         """
-        values_list = values.splitlines()
-        return values_list[:1] + list(
-            filter(
-                lambda x: x,
-                values_list[1:],
-            ),
-        )
+        lines = values.splitlines()
+        values_list = lines[:1]
+        values_list.extend(filter(None, lines[1:]))
+        return values_list

--- a/detect_secrets/plugins/core/ini_file_parser.py
+++ b/detect_secrets/plugins/core/ini_file_parser.py
@@ -13,7 +13,7 @@ class IniFileParser(object):
 
         # Hacky way to keep track of line location
         file.seek(0)
-        self.lines = list(map(str.strip, file.readlines()))
+        self.lines = [line.strip() for line in file.readlines()]
         self.line_offset = 0
 
     def iterator(self):

--- a/detect_secrets/plugins/core/yaml_file_parser.py
+++ b/detect_secrets/plugins/core/yaml_file_parser.py
@@ -1,6 +1,6 @@
 import yaml
 
-from detect_secrets.plugins.core.constants import WHITELIST_REGEXES
+from detect_secrets.plugins.core.constants import WHITELIST_REGEX
 
 
 class YamlFileParser(object):
@@ -127,7 +127,7 @@ class YamlFileParser(object):
         ignored_lines = set()
 
         for line_number, line in enumerate(self.content.split('\n'), 1):
-            if any(regex.search(line) for regex in WHITELIST_REGEXES):
+            if WHITELIST_REGEX['yaml'].search(line):
                 ignored_lines.add(line_number)
 
         return ignored_lines


### PR DESCRIPTION
- moved some stuff around in `IniFileParser`; things needed in smaller scopes were lazily created and constants were moved to object-level scope.
- `YamlFileParser`: small follow up to #105; only the whitelist directive regex for YAML inline comment syntax should be used.