### PR TITLE
Travis CI and tox.ini: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
           python: 3.5
         - env: TOXENV=py36
           python: 3.6
+        - env: TOXENV=py37
+          python: 3.7
+          dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
         - env: TOXENV=pypy
           python: pypy
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = detect_secrets
 # These should match the travis env list
-envlist = py27,py35,py36,pypy
+envlist = py27,py35,py36,py37,pypy
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 project = detect_secrets
 # These should match the travis env list
 envlist = py27,py35,py36,py37,pypy
+skip_missing_interpreters = true
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 


### PR DESCRIPTION
One warning to be aware of for Python 3.8...
```
=============================== warnings summary ===============================
tests/main_test.py::TestMain::test_reads_from_stdin
  /home/travis/build/Yelp/detect-secrets/.tox/py37/lib/python3.7/site-packages/yaml/constructor.py:126:
  DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if not isinstance(key, collections.Hashable):
```