### PR TITLE
Add high entropy exclude regex option for each high entropy plugin

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -219,6 +219,7 @@ class PluginOptions(object):
             disable_help_text='Disables scanning for hex high entropy strings',
             related_args=[
                 ('--hex-limit', 3,),
+                ('--hex-high-entropy-exclude', None,),
             ],
         ),
         PluginDescriptor(
@@ -227,6 +228,7 @@ class PluginOptions(object):
             disable_help_text='Disables scanning for base64 high entropy strings',
             related_args=[
                 ('--base64-limit', 4.5,),
+                ('--base64-high-entropy-exclude', None,),
             ],
         ),
         PluginDescriptor(
@@ -264,6 +266,7 @@ class PluginOptions(object):
     def add_arguments(self):
         self._add_custom_limits()
         self._add_opt_out_options()
+        self._add_high_entropy_excludes()
 
         return self
 
@@ -340,7 +343,18 @@ class PluginOptions(object):
             nargs='?',
             help=high_entropy_help_text + 'defaults to 3.0.',
         )
-        return self
+
+    def _add_high_entropy_excludes(self):
+        self.parser.add_argument(
+            '--base64-high-entropy-exclude',
+            type=str,
+            help='Pass in regex to exclude false positives found by base 64 high-entropy detector.',
+        )
+        self.parser.add_argument(
+            '--hex-high-entropy-exclude',
+            type=str,
+            help='Pass in regex to exclude false positives found by hex high-entropy detector.',
+        )
 
     def _add_opt_out_options(self):
         for plugin in self.all_plugins:
@@ -350,8 +364,6 @@ class PluginOptions(object):
                 help=plugin.disable_help_text,
                 default=False,
             )
-
-        return self
 
     def _argparse_minmax_type(self, string):
         """Custom type for argparse to enforce value limits"""

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -46,7 +46,7 @@ BLACKLIST = (
     'secret',
     'secrete',
 )
-FALSE_POSITIVES = (
+FALSE_POSITIVES = {
     "''",
     "''):",
     "')",
@@ -86,7 +86,7 @@ FALSE_POSITIVES = (
     'true,',
     'true;',
     '{',
-)
+}
 FOLLOWED_BY_COLON_RE = re.compile(
     # e.g. api_key: foo
     r'({})(("|\')?):(\s*?)(("|\')?)([^\s]+)(\5)'.format(

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -27,10 +27,12 @@ class TestPluginOptions(object):
         assert args.plugins == {
             'HexHighEntropyString': {
                 'hex_limit': 3,
+                'hex_high_entropy_exclude': None,
             },
             'BasicAuthDetector': {},
             'Base64HighEntropyString': {
                 'base64_limit': 4.5,
+                'base64_high_entropy_exclude': None,
             },
             'KeywordDetector': {},
             'PrivateKeyDetector': {},

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -11,6 +11,9 @@ from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
 from testing.mocks import mock_file_object
 
 
+HIGH_ENTROPY_EXCLUDE = '(CanonicalUser)'
+
+
 class HighEntropyStringsTest(object):
     """
     Some explaining should be done regarding the "enforced" format of the parametrized
@@ -99,6 +102,8 @@ class HighEntropyStringsTest(object):
             "'{secret}'  /* pragma: whitelist secret */",
             "'{secret}'  ' pragma: whitelist secret",
             "'{secret}'  -- pragma: whitelist secret",
+            # Test high entropy exclude regex
+            '"CanonicalUser": "{secret}"',
             # Not a string
             "{secret}",
         ],
@@ -125,7 +130,10 @@ class TestBase64HighEntropyStrings(HighEntropyStringsTest):
     def setup(self):
         super(TestBase64HighEntropyStrings, self).setup(
             # Testing default limit, as suggested by truffleHog.
-            Base64HighEntropyString(4.5),
+            Base64HighEntropyString(
+                base64_limit=4.5,
+                base64_high_entropy_exclude=HIGH_ENTROPY_EXCLUDE,
+            ),
             'c3VwZXIgc2VjcmV0IHZhbHVl',     # too short for high entropy
             'c3VwZXIgbG9uZyBzdHJpbmcgc2hvdWxkIGNhdXNlIGVub3VnaCBlbnRyb3B5',
         )
@@ -196,15 +204,19 @@ class TestHexHighEntropyStrings(HighEntropyStringsTest):
     def setup(self):
         super(TestHexHighEntropyStrings, self).setup(
             # Testing default limit, as suggested by truffleHog.
-            HexHighEntropyString(3),
+            HexHighEntropyString(
+                hex_limit=3,
+                hex_high_entropy_exclude=HIGH_ENTROPY_EXCLUDE,
+            ),
             'aaaaaa',
             '2b00042f7481c7b056c4b410d28f33cf',
         )
 
     def test_discounts_when_all_numbers(self):
         original_scanner = HighEntropyStringsPlugin(
-            string.hexdigits,
-            3,
+            charset=string.hexdigits,
+            limit=3,
+            high_entropy_exclude=HIGH_ENTROPY_EXCLUDE,
         )
 
         # This makes sure discounting works.

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     coverage erase
     coverage run -m pytest tests
     coverage report --show-missing --include=tests/* --fail-under 100
-    coverage report --show-missing --include=detect_secrets/* --fail-under 97
+    coverage report --show-missing --include=detect_secrets/* --fail-under 98
     pre-commit run --all-files
 
 [testenv:venv]


### PR DESCRIPTION
The emojis say it all :sparkles::cake::sparkles:

Primary commit:
🎉 Add high entropy exclude options  …
This is so you can specifically ignore lines with false-positives
that often trigger the high entropy plugins, e.g.
```
"AWS": [
    "CanonicalUser: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
]
```
can be ignored with e.g.
```
detect-secrets scan test.py --hex-high-entropy-exclude "(CanonicalUser)"
```

