### PR TITLE
Use python instead of sed/wc during audit

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import codecs
+import itertools
 import json
 import os
 import subprocess
@@ -451,63 +453,33 @@ def _get_secret_with_context(
 
     :raises: SecretNotFoundOnSpecifiedLineError
     """
-    secret_lineno = secret['line_number']
-    start_line = 1 if secret_lineno <= lines_of_context \
-        else secret_lineno - lines_of_context
-    end_line = secret_lineno + lines_of_context
+    secret_line_idx = secret['line_number'] - 1
+    end_line = secret_line_idx + lines_of_context + 1
 
-    output = subprocess.check_output([
-        'sed',
-        '-n', '{},{}p'.format(start_line, end_line),
+    if secret_line_idx <= lines_of_context:
+        start_line = 0
+        index_of_secret_in_output = secret_line_idx
+    else:
+        start_line = secret_line_idx - lines_of_context
+        index_of_secret_in_output = lines_of_context
+
+    with codecs.open(filename, encoding='utf-8') as file:
+        output = list(itertools.islice(file.read().splitlines(), start_line, end_line))
+
+    output[index_of_secret_in_output] = _highlight_secret(
+        output[index_of_secret_in_output],
+        secret['line_number'],
+        secret,
         filename,
-    ]).decode('utf-8').splitlines()
-
-    trailing_lines_of_context = lines_of_context
-    if len(output) < end_line - start_line + 1:
-        # This handles the case of a short file.
-        num_lines_in_file = int(subprocess.check_output([
-            # https://stackoverflow.com/a/38870057
-            # - 'wc -l' cannot be used here because if the last char
-            # of the file isn't \n, then the last line isn't counted
-            'grep',
-            '-c',
-            '',
-            filename,
-        ]).decode('utf-8').split()[0])
-
-        trailing_lines_of_context = lines_of_context - \
-            (end_line - num_lines_in_file)
-
-    # -1, because that's where the secret actually is (without it,
-    # it would just be the start of the context block).
-    # NOTE: index_of_secret_in_output should *always* be negative.
-    index_of_secret_in_output = -trailing_lines_of_context - 1
-
-    try:
-        output[index_of_secret_in_output] = _highlight_secret(
-            output[index_of_secret_in_output],
-            secret_lineno,
-            secret,
-            filename,
-            plugin_settings,
-        )
-    except SecretNotFoundOnSpecifiedLineError:
-        if not force:
-            raise
-
-        output[index_of_secret_in_output] = '{}'.format(
-            colorize(
-                output[index_of_secret_in_output],
-                AnsiColor.BOLD,
-            ),
-        )
+        plugin_settings,
+    )
 
     # Adding line numbers
     return '\n'.join(
         map(
             lambda x: '{}:{}'.format(
                 colorize(
-                    str(int(x[0]) + start_line),
+                    str(int(x[0]) + start_line + 1),
                     AnsiColor.LIGHT_GREEN,
                 ),
                 x[1],

--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -466,13 +466,24 @@ def _get_secret_with_context(
     with codecs.open(filename, encoding='utf-8') as file:
         output = list(itertools.islice(file.read().splitlines(), start_line, end_line))
 
-    output[index_of_secret_in_output] = _highlight_secret(
-        output[index_of_secret_in_output],
-        secret['line_number'],
-        secret,
-        filename,
-        plugin_settings,
-    )
+    try:
+        output[index_of_secret_in_output] = _highlight_secret(
+            output[index_of_secret_in_output],
+            secret['line_number'],
+            secret,
+            filename,
+            plugin_settings,
+        )
+    except SecretNotFoundOnSpecifiedLineError:
+        if not force:
+            raise
+
+        output[index_of_secret_in_output] = '{}'.format(
+            colorize(
+                output[index_of_secret_in_output],
+                AnsiColor.BOLD,
+            ),
+        )
 
     # Adding line numbers
     return '\n'.join(

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -10,6 +10,7 @@ import pytest
 
 from detect_secrets.core import audit
 from testing.factories import potential_secret_factory
+from testing.mocks import mock_open as mock_open_base
 from testing.mocks import mock_printer as mock_printer_base
 from testing.util import uncolor
 
@@ -500,28 +501,24 @@ class TestPrintContext(object):
             plugin_settings=settings,
         )
 
-    @contextmanager
-    def _mock_sed_call(
+    def mock_open(
         self,
         start_line=10,
         secret_line=15,
         end_line=20,
         line_containing_secret='BEGIN PRIVATE KEY',
     ):
-        with mock.patch(
-            'detect_secrets.core.audit.subprocess',
-        ) as m:
-            m.check_output.return_value = '{}{}{}'.format(
-                self._make_string_into_individual_lines(
-                    string.ascii_letters[:(secret_line - start_line)],
-                ),
-                line_containing_secret + '\n',
-                self._make_string_into_individual_lines(
-                    string.ascii_letters[:(end_line - secret_line)][::-1],
-                ),
-            ).encode()
-
-            yield m.check_output
+        data = '{}{}{}{}'.format(
+            '\n' * (start_line - 1),
+            self._make_string_into_individual_lines(
+                string.ascii_letters[:(secret_line - start_line)],
+            ),
+            line_containing_secret + '\n',
+            self._make_string_into_individual_lines(
+                string.ascii_letters[:(end_line - secret_line)][::-1],
+            ),
+        )
+        return mock_open_base(data, 'detect_secrets.core.audit.codecs.open')
 
     @staticmethod
     def _make_string_into_individual_lines(string):
@@ -533,15 +530,13 @@ class TestPrintContext(object):
         )
 
     def test_basic(self, mock_printer):
-        with self._mock_sed_call(
+        with self.mock_open(
             start_line=10,
             secret_line=15,
             end_line=20,
             line_containing_secret='-----BEGIN PRIVATE KEY-----',
-        ) as sed_call:
+        ):
             self.run_logic()
-
-            assert sed_call.call_args[0][0] == 'sed -n 10,20p filenameA'.split()
 
         assert uncolor(mock_printer.message) == textwrap.dedent("""
             Secret:      1 of 2
@@ -564,17 +559,15 @@ class TestPrintContext(object):
         """)[1:-1]
 
     def test_secret_at_top_of_file(self, mock_printer):
-        with self._mock_sed_call(
+        with self.mock_open(
             start_line=1,
             secret_line=1,
             end_line=6,
             line_containing_secret='-----BEGIN PRIVATE KEY-----',
-        ) as sed_call:
+        ):
             self.run_logic(
                 secret_lineno=1,
             )
-
-            assert sed_call.call_args[0][0] == 'sed -n 1,6p filenameA'.split()
 
         assert uncolor(mock_printer.message) == textwrap.dedent("""
             Secret:      1 of 2
@@ -592,7 +585,7 @@ class TestPrintContext(object):
         """)[1:-1]
 
     def test_secret_not_found(self, mock_printer):
-        with self._mock_sed_call(), pytest.raises(
+        with self.mock_open(), pytest.raises(
             audit.SecretNotFoundOnSpecifiedLineError,
         ):
             self.run_logic(
@@ -616,7 +609,7 @@ class TestPrintContext(object):
         """)[1:-1]
 
     def test_hex_high_entropy_secret_in_yaml_file(self, mock_printer):
-        with self._mock_sed_call(
+        with self.mock_open(
             line_containing_secret='api key: 123456789a',
         ):
             self.run_logic(
@@ -655,7 +648,7 @@ class TestPrintContext(object):
         """)[1:-1]
 
     def test_keyword_secret_in_yaml_file(self, mock_printer):
-        with self._mock_sed_call(
+        with self.mock_open(
             line_containing_secret='api_key: yerba',
         ):
             self.run_logic(


### PR DESCRIPTION
Update audit code to read files using python instead of sed/wc to align the end of line character handling.

If the audit is performed on a file with non-posix end of line characters then it would incorrectly extract the line range from the file and miscalculate the index of the line the secret is on.  This would result in an error during the audit "Secret not found on line....".

The root cause of this issue was due to audit using "sed" and "wc" to extract line ranges from the file and count total lines.  When these tools encountered the non-posix end of line characters they would calculate different lines then via python which uses a universal or cross-platform end of line characters.

To ensure that it would calculate the same lines as the scan the audit code has been updated to use python to read the original file and extract the specified lines.

CC @jribm