### PR TITLE
Add per line exclude regex via --exclude-line

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -464,7 +464,13 @@ def _get_secret_with_context(
         index_of_secret_in_output = lines_of_context
 
     with codecs.open(filename, encoding='utf-8') as file:
-        output = list(itertools.islice(file.read().splitlines(), start_line, end_line))
+        output = list(
+            itertools.islice(
+                file.read().splitlines(),
+                start_line,
+                end_line,
+            ),
+        )
 
     try:
         output[index_of_secret_in_output] = _highlight_secret(

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -10,8 +10,8 @@ from detect_secrets.core.secrets_collection import SecretsCollection
 
 def initialize(
     plugins,
-    exclude_files_re=None,
-    exclude_lines_re=None,
+    exclude_files_regex=None,
+    exclude_lines_regex=None,
     path='.',
     scan_all_files=False,
 ):
@@ -21,14 +21,18 @@ def initialize(
     :type plugins: tuple of detect_secrets.plugins.base.BasePlugin
     :param plugins: rules to initialize the SecretsCollection with.
 
-    :type exclude_files_re: str|None
-    :type exclude_lines_re: str|None
+    :type exclude_files_regex: str|None
+    :type exclude_lines_regex: str|None
     :type path: str
     :type scan_all_files: bool
 
     :rtype: SecretsCollection
     """
-    output = SecretsCollection(plugins, exclude_files_re)
+    output = SecretsCollection(
+        plugins,
+        exclude_files=exclude_files_regex,
+        exclude_lines=exclude_lines_regex,
+    )
 
     if os.path.isfile(path):
         # This option allows for much easier adhoc usage.
@@ -41,11 +45,11 @@ def initialize(
     if not files_to_scan:
         return output
 
-    if exclude_files_re:
-        exclude_files_re = re.compile(exclude_files_re, re.IGNORECASE)
+    if exclude_files_regex:
+        exclude_files_regex = re.compile(exclude_files_regex, re.IGNORECASE)
         files_to_scan = filter(
             lambda file: (
-                not exclude_files_re.search(file)
+                not exclude_files_regex.search(file)
             ),
             files_to_scan,
         )
@@ -68,13 +72,13 @@ def get_secrets_not_in_baseline(results, baseline):
     :rtype: SecretsCollection
     :returns: SecretsCollection of new results (filtering out baseline)
     """
-    exclude_files_re = None
+    exclude_files_regex = None
     if baseline.exclude_files:
-        exclude_files_re = re.compile(baseline.exclude_files, re.IGNORECASE)
+        exclude_files_regex = re.compile(baseline.exclude_files, re.IGNORECASE)
 
     new_secrets = SecretsCollection()
     for filename in results.data:
-        if exclude_files_re and exclude_files_re.search(filename):
+        if exclude_files_regex and exclude_files_regex.search(filename):
             continue
 
         if filename not in baseline.data:

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -10,7 +10,8 @@ from detect_secrets.core.secrets_collection import SecretsCollection
 
 def initialize(
     plugins,
-    exclude_regex=None,
+    exclude_files_re=None,
+    exclude_lines_re=None,
     path='.',
     scan_all_files=False,
 ):
@@ -20,13 +21,14 @@ def initialize(
     :type plugins: tuple of detect_secrets.plugins.base.BasePlugin
     :param plugins: rules to initialize the SecretsCollection with.
 
-    :type exclude_regex: str|None
+    :type exclude_files_re: str|None
+    :type exclude_lines_re: str|None
     :type path: str
     :type scan_all_files: bool
 
     :rtype: SecretsCollection
     """
-    output = SecretsCollection(plugins, exclude_regex)
+    output = SecretsCollection(plugins, exclude_files_re)
 
     if os.path.isfile(path):
         # This option allows for much easier adhoc usage.
@@ -39,11 +41,11 @@ def initialize(
     if not files_to_scan:
         return output
 
-    if exclude_regex:
-        regex = re.compile(exclude_regex, re.IGNORECASE)
+    if exclude_files_re:
+        exclude_files_re = re.compile(exclude_files_re, re.IGNORECASE)
         files_to_scan = filter(
             lambda file: (
-                not regex.search(file)
+                not exclude_files_re.search(file)
             ),
             files_to_scan,
         )
@@ -66,13 +68,13 @@ def get_secrets_not_in_baseline(results, baseline):
     :rtype: SecretsCollection
     :returns: SecretsCollection of new results (filtering out baseline)
     """
-    regex = None
-    if baseline.exclude_regex:
-        regex = re.compile(baseline.exclude_regex, re.IGNORECASE)
+    exclude_files_re = None
+    if baseline.exclude_files:
+        exclude_files_re = re.compile(baseline.exclude_files, re.IGNORECASE)
 
     new_secrets = SecretsCollection()
     for filename in results.data:
-        if regex and regex.search(filename):
+        if exclude_files_re and exclude_files_re.search(filename):
             continue
 
         if filename not in baseline.data:

--- a/detect_secrets/core/common.py
+++ b/detect_secrets/core/common.py
@@ -7,5 +7,5 @@ def write_baseline_to_file(filename, data):
     :type data: dict
     :rtype: None
     """
-    with open(filename, 'w') as f:
+    with open(filename, 'w') as f:  # pragma: no cover
         f.write(format_baseline_for_output(data) + '\n')

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -15,13 +15,21 @@ from detect_secrets.plugins.common import initialize
 
 class SecretsCollection(object):
 
-    def __init__(self, plugins=(), exclude_regex=''):
+    def __init__(
+        self,
+        plugins=(),
+        exclude_files=None,
+        exclude_lines=None,
+    ):
         """
         :type plugins: tuple of detect_secrets.plugins.base.BasePlugin
         :param plugins: rules to determine whether a string is a secret
 
-        :type exclude_regex: str
-        :param exclude_regex: for optional regex for ignored paths.
+        :type exclude_files: str|None
+        :param exclude_files: optional regex for ignored paths.
+
+        :type exclude_lines: str|None
+        :param exclude_lines: optional regex for ignored lines.
 
         :type version: str
         :param version: version of detect-secrets that SecretsCollection
@@ -29,7 +37,8 @@ class SecretsCollection(object):
         """
         self.data = {}
         self.plugins = plugins
-        self.exclude_regex = exclude_regex
+        self.exclude_files = exclude_files
+        self.exclude_lines = exclude_lines
         self.version = VERSION
 
     @classmethod
@@ -59,20 +68,32 @@ class SecretsCollection(object):
         :raises: IOError
         """
         result = SecretsCollection()
+
         if not all(key in data for key in (
-            'exclude_regex',
             'plugins_used',
             'results',
         )):
             raise IOError
 
-        result.exclude_regex = data['exclude_regex']
+        # In v0.12.0 `exclude_regex` got replaced by `exclude`
+        if not any(key in data for key in (
+            'exclude',
+            'exclude_regex',
+        )):
+            raise IOError
+
+        if 'exclude_regex' in data:
+            result.exclude_files = data['exclude_regex']
+        else:
+            result.exclude_files = data['exclude']['files']
+            result.exclude_lines = data['exclude']['lines']
 
         plugins = []
         for plugin in data['plugins_used']:
             plugin_classname = plugin.pop('name')
             plugins.append(initialize.from_plugin_classname(
                 plugin_classname,
+                exclude_lines_re=result.exclude_lines,
                 **plugin
             ))
         result.plugins = tuple(plugins)
@@ -141,13 +162,13 @@ class SecretsCollection(object):
             log.error(alert)
             raise
 
-        if self.exclude_regex:
-            regex = re.compile(self.exclude_regex, re.IGNORECASE)
+        if self.exclude_files:
+            regex = re.compile(self.exclude_files, re.IGNORECASE)
 
         for patch_file in patch_set:
             filename = patch_file.path
-            # If the file matches the exclude_regex, we skip it
-            if self.exclude_regex and regex.search(filename):
+            # If the file matches the exclude_files, we skip it
+            if self.exclude_files and regex.search(filename):
                 continue
 
             if filename == baseline_filename:
@@ -241,7 +262,10 @@ class SecretsCollection(object):
 
         return {
             'generated_at': strftime("%Y-%m-%dT%H:%M:%SZ", gmtime()),
-            'exclude_regex': self.exclude_regex,
+            'exclude': {
+                'files': self.exclude_files,
+                'lines': self.exclude_lines,
+            },
             'plugins_used': plugins_used,
             'results': results,
             'version': self.version,

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -93,7 +93,7 @@ class SecretsCollection(object):
             plugin_classname = plugin.pop('name')
             plugins.append(initialize.from_plugin_classname(
                 plugin_classname,
-                exclude_lines_re=result.exclude_lines,
+                exclude_lines_regex=result.exclude_lines,
                 **plugin
             ))
         result.plugins = tuple(plugins)

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -234,7 +234,6 @@ class PluginOptions(object):
             disable_help_text='Disables scanning for hex high entropy strings',
             related_args=[
                 ('--hex-limit', 3,),
-                ('--hex-high-entropy-exclude', None,),
             ],
         ),
         PluginDescriptor(
@@ -243,7 +242,6 @@ class PluginOptions(object):
             disable_help_text='Disables scanning for base64 high entropy strings',
             related_args=[
                 ('--base64-limit', 4.5,),
-                ('--base64-high-entropy-exclude', None,),
             ],
         ),
         PluginDescriptor(
@@ -286,7 +284,6 @@ class PluginOptions(object):
     def add_arguments(self):
         self._add_custom_limits()
         self._add_opt_out_options()
-        self._add_high_entropy_excludes()
 
         return self
 
@@ -374,18 +371,7 @@ class PluginOptions(object):
             nargs='?',
             help=high_entropy_help_text + 'defaults to 3.0.',
         )
-
-    def _add_high_entropy_excludes(self):
-        self.parser.add_argument(
-            '--base64-high-entropy-exclude',
-            type=str,
-            help='Pass in regex to exclude false positives found by base 64 high-entropy detector.',
-        )
-        self.parser.add_argument(
-            '--hex-high-entropy-exclude',
-            type=str,
-            help='Pass in regex to exclude false positives found by hex high-entropy detector.',
-        )
+        return self
 
     def _add_opt_out_options(self):
         for plugin in self.all_plugins:
@@ -395,6 +381,8 @@ class PluginOptions(object):
                 help=plugin.disable_help_text,
                 default=False,
             )
+
+        return self
 
     def _argparse_minmax_type(self, string):
         """Custom type for argparse to enforce value limits"""

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -6,6 +6,14 @@ from collections import namedtuple
 from detect_secrets import VERSION
 
 
+def add_exclude_lines_argument(parser):
+    parser.add_argument(
+        '--exclude-lines',
+        type=str,
+        help='Pass in regex to specify lines to ignore during scan.',
+    )
+
+
 def add_use_all_plugins_argument(parser):
     parser.add_argument(
         '--use-all-plugins',
@@ -25,11 +33,10 @@ class ParserBuilder(object):
         self._add_verbosity_argument()\
             ._add_version_argument()
 
-        return self
-
     def add_pre_commit_arguments(self):
         self._add_filenames_argument()\
             ._add_set_baseline_argument()\
+            ._add_exclude_lines_argument()\
             ._add_use_all_plugins_argument()
 
         PluginOptions(self.parser).add_arguments()
@@ -87,6 +94,10 @@ class ParserBuilder(object):
         )
         return self
 
+    def _add_exclude_lines_argument(self):
+        add_exclude_lines_argument(self.parser)
+        return self
+
     def _add_use_all_plugins_argument(self):
         add_use_all_plugins_argument(self.parser)
 
@@ -117,11 +128,15 @@ class ScanOptions(object):
             ),
         )
 
-        # Pairing `--exclude` with `--scan` because it's only used for the initialization.
+        # Pairing `--exclude-lines` to both pre-commit and `--scan`
+        # because it can be used for both.
+        add_exclude_lines_argument(self.parser)
+
+        # Pairing `--exclude-files` with `--scan` because it's only used for the initialization.
         # The pre-commit hook framework already has an `exclude` option that can be used instead.
         self.parser.add_argument(
-            '--exclude',
-            nargs=1,
+            '--exclude-files',
+            type=str,
             help='Pass in regex to specify ignored paths during initialization scan.',
         )
 
@@ -155,7 +170,6 @@ class ScanOptions(object):
                 'plugins\' verdict.'
             ),
         )
-        return self
 
 
 class AuditOptions(object):
@@ -371,7 +385,6 @@ class PluginOptions(object):
             nargs='?',
             help=high_entropy_help_text + 'defaults to 3.0.',
         )
-        return self
 
     def _add_opt_out_options(self):
         for plugin in self.all_plugins:
@@ -381,8 +394,6 @@ class PluginOptions(object):
                 help=plugin.disable_help_text,
                 default=False,
             )
-
-        return self
 
     def _argparse_minmax_type(self, string):
         """Custom type for argparse to enforce value limits"""

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -33,7 +33,7 @@ def main(argv=None):
         # we want to get the latest updates.
         plugins = initialize.from_parser_builder(
             args.plugins,
-            exclude_lines_re=args.exclude_lines,
+            exclude_lines_regex=args.exclude_lines,
         )
         if args.string:
             line = args.string
@@ -140,8 +140,8 @@ def _perform_scan(args, plugins):
 
     new_baseline = baseline.initialize(
         plugins=plugins,
-        exclude_files_re=args.exclude_files,
-        exclude_lines_re=args.exclude_lines,
+        exclude_files_regex=args.exclude_files,
+        exclude_lines_regex=args.exclude_lines,
         path=args.path,
         scan_all_files=args.all_files,
     ).format_for_baseline_output()
@@ -188,12 +188,12 @@ def _add_baseline_to_exclude_files(args):
     """
     Modifies args.exclude_files in-place.
     """
-    baseline_name_re = r'^{}$'.format(args.import_filename[0])
+    baseline_name_regex = r'^{}$'.format(args.import_filename[0])
 
     if not args.exclude_files:
-        args.exclude_files = baseline_name_re
-    elif baseline_name_re not in args.exclude_files:
-        args.exclude_files += r'|{}'.format(baseline_name_re)
+        args.exclude_files = baseline_name_regex
+    elif baseline_name_regex not in args.exclude_files:
+        args.exclude_files += r'|{}'.format(baseline_name_regex)
 
 
 if __name__ == '__main__':

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -15,7 +15,8 @@ from detect_secrets.plugins.common import initialize
 
 
 def parse_args(argv):
-    return ParserBuilder().add_console_use_arguments() \
+    return ParserBuilder()\
+        .add_console_use_arguments()\
         .parse_args(argv)
 
 
@@ -30,7 +31,10 @@ def main(argv=None):
     if args.action == 'scan':
         # Plugins are *always* rescanned with fresh settings, because
         # we want to get the latest updates.
-        plugins = initialize.from_parser_builder(args.plugins)
+        plugins = initialize.from_parser_builder(
+            args.plugins,
+            exclude_lines_re=args.exclude_lines,
+        )
         if args.string:
             line = args.string
 
@@ -117,26 +121,29 @@ def _perform_scan(args, plugins):
             _get_plugin_from_baseline(old_baseline), args,
         )
 
-    # Favors --exclude argument over existing baseline's regex (if exists)
-    if args.exclude:
-        args.exclude = args.exclude[0]
-    elif old_baseline and old_baseline.get('exclude_regex'):
-        args.exclude = old_baseline['exclude_regex']
+    # Favors `--exclude-files` and `--exclude-lines` CLI arguments
+    # over existing baseline's regexes (if given)
+    if old_baseline:
+        if not args.exclude_files:
+            args.exclude_files = _get_exclude_files(old_baseline)
+
+        if (
+            not args.exclude_lines
+            and old_baseline.get('exclude')
+        ):
+            args.exclude_lines = old_baseline['exclude']['lines']
 
     # If we have knowledge of an existing baseline file, we should use
-    # that knowledge and *not* scan that file.
+    # that knowledge and add it to our exclude_files regex.
     if args.import_filename:
-        payload = '^{}$'.format(args.import_filename[0])
-        if args.exclude and payload not in args.exclude:
-            args.exclude += r'|{}'.format(payload)
-        elif not args.exclude:
-            args.exclude = payload
+        _add_baseline_to_exclude_files(args)
 
     new_baseline = baseline.initialize(
-        plugins,
-        args.exclude,
-        args.path,
-        args.all_files,
+        plugins=plugins,
+        exclude_files_re=args.exclude_files,
+        exclude_lines_re=args.exclude_lines,
+        path=args.path,
+        scan_all_files=args.all_files,
     ).format_for_baseline_output()
 
     if old_baseline:
@@ -162,6 +169,31 @@ def _read_from_file(filename):  # pragma: no cover
     """Used for mocking."""
     with open(filename) as f:
         return json.loads(f.read())
+
+
+def _get_exclude_files(old_baseline):
+    """
+    Older versions of detect-secrets always had an `exclude_regex` key,
+    this was replaced by the `files` key under an `exclude` key in v0.12.0
+
+    :rtype: str|None
+    """
+    if old_baseline.get('exclude'):
+        return old_baseline['exclude']['files']
+    if old_baseline.get('exclude_regex'):
+        return old_baseline['exclude_regex']
+
+
+def _add_baseline_to_exclude_files(args):
+    """
+    Modifies args.exclude_files in-place.
+    """
+    baseline_name_re = r'^{}$'.format(args.import_filename[0])
+
+    if not args.exclude_files:
+        args.exclude_files = baseline_name_re
+    elif baseline_name_re not in args.exclude_files:
+        args.exclude_files += r'|{}'.format(baseline_name_re)
 
 
 if __name__ == '__main__':

--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -9,7 +9,9 @@ from .base import RegexBasedDetector
 
 
 class AWSKeyDetector(RegexBasedDetector):
+
     secret_type = 'AWS Access Key'
+
     blacklist = (
         re.compile(r'AKIA[0-9A-Z]{16}'),
     )

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -65,14 +65,14 @@ class BasePlugin(object):
         ):
             return {}
 
-        return self._analyze_string(
+        return self.analyze_string_content(
             string,
             line_num,
             filename,
         )
 
     @abstractmethod
-    def _analyze_string(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename):
         """
         :param string:    string; the line to analyze
         :param line_num:  integer; line number that is currently being analyzed
@@ -152,7 +152,7 @@ class RegexBasedDetector(BasePlugin):
     def blacklist(self):
         raise NotImplementedError
 
-    def _analyze_string(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename):
         output = {}
 
         for identifier in self.secret_generator(string):

--- a/detect_secrets/plugins/basic_auth.py
+++ b/detect_secrets/plugins/basic_auth.py
@@ -12,6 +12,7 @@ SUB_DELIMITER_CHARACTERS = '!$&\';'  # and anything else we might need
 class BasicAuthDetector(RegexBasedDetector):
 
     secret_type = 'Basic Auth Credentials'
+
     blacklist = [
         re.compile(
             r'://[^{}\s]+:([^{}\s]+)@'.format(

--- a/detect_secrets/plugins/common/ini_file_parser.py
+++ b/detect_secrets/plugins/common/ini_file_parser.py
@@ -6,9 +6,11 @@ class IniFileParser(object):
 
     _comment_regex = re.compile(r'\s*[;#]')
 
-    def __init__(self, file, add_header=False):
+    def __init__(self, file, add_header=False, exclude_lines_re=None):
         self.parser = configparser.ConfigParser()
         self.parser.optionxform = str
+
+        self.exclude_lines_re = exclude_lines_re
 
         if not add_header:
             self.parser.read_file(file)
@@ -75,6 +77,12 @@ class IniFileParser(object):
             # Check ignored lines before checking values, because
             # you can write comments *after* the value.
             if not line.strip() or self._comment_regex.match(line):
+                continue
+
+            if (
+                self.exclude_lines_re
+                and self.exclude_lines_re.search(line)
+            ):
                 continue
 
             if current_value_list_index == 0:

--- a/detect_secrets/plugins/common/ini_file_parser.py
+++ b/detect_secrets/plugins/common/ini_file_parser.py
@@ -6,11 +6,20 @@ class IniFileParser(object):
 
     _comment_regex = re.compile(r'\s*[;#]')
 
-    def __init__(self, file, add_header=False, exclude_lines_re=None):
+    def __init__(self, file, add_header=False, exclude_lines_regex=None):
+        """
+        :type file: file object
+
+        :type add_header: bool
+        :param add_header: whether or not to add a top-level [global] header.
+
+        :type exclude_lines_regex: regex object
+        :param exclude_lines_regex: optional regex for ignored lines.
+        """
         self.parser = configparser.ConfigParser()
         self.parser.optionxform = str
 
-        self.exclude_lines_re = exclude_lines_re
+        self.exclude_lines_regex = exclude_lines_regex
 
         if not add_header:
             self.parser.read_file(file)
@@ -80,8 +89,8 @@ class IniFileParser(object):
                 continue
 
             if (
-                self.exclude_lines_re
-                and self.exclude_lines_re.search(line)
+                self.exclude_lines_regex
+                and self.exclude_lines_regex.search(line)
             ):
                 continue
 

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -1,7 +1,7 @@
 """Intelligent initialization of plugins."""
 try:
     from functools import lru_cache
-except ImportError:
+except ImportError:  # pragma: no cover
     from functools32 import lru_cache
 
 from ..aws import AWSKeyDetector                            # noqa: F401

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -16,17 +16,21 @@ from detect_secrets.core.log import log
 from detect_secrets.core.usage import PluginOptions
 
 
-def from_parser_builder(plugins_dict, exclude_lines_re):
+def from_parser_builder(plugins_dict, exclude_lines_regex):
     """
     :param plugins_dict: plugins dictionary received from ParserBuilder.
         See example in tests.core.usage_test.
+
+    :type exclude_lines_regex: str|None
+    :param exclude_lines_regex: optional regex for ignored lines.
+
     :returns: tuple of initialized plugins
     """
     output = []
     for plugin_name in plugins_dict:
         output.append(from_plugin_classname(
             plugin_name,
-            exclude_lines_re=exclude_lines_re,
+            exclude_lines_regex=exclude_lines_regex,
             **plugins_dict[plugin_name]
         ))
 
@@ -95,7 +99,7 @@ def merge_plugin_from_baseline(baseline_plugins, args):
 
         return from_parser_builder(
             plugins_dict,
-            exclude_lines_re=args.exclude_lines,
+            exclude_lines_regex=args.exclude_lines,
         )
 
     # Use baseline plugin as starting point
@@ -123,18 +127,18 @@ def merge_plugin_from_baseline(baseline_plugins, args):
 
     return from_parser_builder(
         plugins_dict,
-        exclude_lines_re=args.exclude_lines,
+        exclude_lines_regex=args.exclude_lines,
     )
 
 
-def from_plugin_classname(plugin_classname, exclude_lines_re=None, **kwargs):
+def from_plugin_classname(plugin_classname, exclude_lines_regex=None, **kwargs):
     """Initializes a plugin class, given a classname and kwargs.
 
     :type plugin_classname: str
-    :param plugin_classname: subclass of BasePlugin
+    :param plugin_classname: subclass of BasePlugin.
 
-    :type exclude_lines_re: str|None
-    :param exclude_lines_re: subclass of BasePlugin
+    :type exclude_lines_regex: str|None
+    :param exclude_lines_regex: optional regex for ignored lines.
     """
     klass = globals()[plugin_classname]
 
@@ -143,7 +147,7 @@ def from_plugin_classname(plugin_classname, exclude_lines_re=None, **kwargs):
         raise TypeError
 
     try:
-        instance = klass(exclude_lines_re=exclude_lines_re, **kwargs)
+        instance = klass(exclude_lines_regex=exclude_lines_regex, **kwargs)
     except TypeError:
         log.warning(
             'Unable to initialize plugin!',

--- a/detect_secrets/plugins/common/yaml_file_parser.py
+++ b/detect_secrets/plugins/common/yaml_file_parser.py
@@ -38,9 +38,15 @@ class YamlFileParser(object):
     This parsing method is inspired by https://stackoverflow.com/a/13319530.
     """
 
-    def __init__(self, file, exclude_lines_re=None):
+    def __init__(self, file, exclude_lines_regex=None):
+        """
+        :type file: file object
+
+        :type exclude_lines_regex: regex object
+        :param exclude_lines_regex: optional regex for ignored lines.
+        """
         self.content = file.read()
-        self.exclude_lines_re = exclude_lines_re
+        self.exclude_lines_regex = exclude_lines_regex
 
         self.loader = yaml.SafeLoader(self.content)
         self.loader.compose_node = self._compose_node_shim
@@ -131,8 +137,8 @@ class YamlFileParser(object):
                 WHITELIST_REGEX['yaml'].search(line)
 
                 or (
-                    self.exclude_lines_re and
-                    self.exclude_lines_re.search(line)
+                    self.exclude_lines_regex and
+                    self.exclude_lines_regex.search(line)
                 )
             ):
                 ignored_lines.add(line_number)

--- a/detect_secrets/plugins/common/yaml_file_parser.py
+++ b/detect_secrets/plugins/common/yaml_file_parser.py
@@ -38,10 +38,11 @@ class YamlFileParser(object):
     This parsing method is inspired by https://stackoverflow.com/a/13319530.
     """
 
-    def __init__(self, file):
+    def __init__(self, file, exclude_lines_re=None):
         self.content = file.read()
-        self.loader = yaml.SafeLoader(self.content)
+        self.exclude_lines_re = exclude_lines_re
 
+        self.loader = yaml.SafeLoader(self.content)
         self.loader.compose_node = self._compose_node_shim
 
     def json(self):
@@ -123,11 +124,17 @@ class YamlFileParser(object):
 
         :return: set
         """
-
         ignored_lines = set()
 
         for line_number, line in enumerate(self.content.split('\n'), 1):
-            if WHITELIST_REGEX['yaml'].search(line):
+            if (
+                WHITELIST_REGEX['yaml'].search(line)
+
+                or (
+                    self.exclude_lines_re and
+                    self.exclude_lines_re.search(line)
+                )
+            ):
                 ignored_lines.add(line_number)
 
         return ignored_lines

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -101,7 +101,7 @@ class HighEntropyStringsPlugin(BasePlugin):
                 return True
         return False
 
-    def _analyze_string(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename):
         """Searches string for custom pattern, and captures all high entropy strings that
         match self.regex, with a limit defined as self.entropy_limit.
         """

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -18,12 +18,12 @@ from detect_secrets.plugins.common.yaml_file_parser import YamlFileParser
 
 IGNORED_SEQUENTIAL_STRINGS = (
     (
-        string.ascii_uppercase
-        + string.ascii_uppercase
-        + string.digits
-        + string.ascii_uppercase
-        + string.ascii_uppercase
-        + '+/'
+        string.ascii_uppercase +
+        string.ascii_uppercase +
+        string.digits +
+        string.ascii_uppercase +
+        string.ascii_uppercase +
+        '+/'
     ),
     string.hexdigits.upper() + string.hexdigits.upper(),
     string.ascii_uppercase + '=/',
@@ -39,7 +39,7 @@ class HighEntropyStringsPlugin(BasePlugin):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, charset, limit, high_entropy_exclude, *args):
+    def __init__(self, charset, limit, *args):
         if limit < 0 or limit > 8:
             raise ValueError(
                 'The limit set for HighEntropyStrings must be between 0.0 and 8.0',
@@ -48,13 +48,6 @@ class HighEntropyStringsPlugin(BasePlugin):
         self.charset = charset
         self.entropy_limit = limit
         self.regex = re.compile(r'([\'"])([%s]+)(\1)' % charset)
-
-        self.high_entropy_exclude = None
-        if high_entropy_exclude:
-            self.high_entropy_exclude = re.compile(
-                high_entropy_exclude,
-                re.IGNORECASE,
-            )
 
     def analyze(self, file, filename):
         file_type_analyzers = (
@@ -107,12 +100,6 @@ class HighEntropyStringsPlugin(BasePlugin):
         match self.regex, with a limit defined as self.entropy_limit.
         """
         output = {}
-
-        if (
-            self.high_entropy_exclude
-            and self.high_entropy_exclude.search(string)
-        ):
-            return output
 
         for result in self.secret_generator(string):
             if self.is_sequential_string(result):
@@ -240,11 +227,10 @@ class HexHighEntropyString(HighEntropyStringsPlugin):
 
     secret_type = 'Hex High Entropy String'
 
-    def __init__(self, hex_limit, hex_high_entropy_exclude=None, **kwargs):
+    def __init__(self, hex_limit, **kwargs):
         super(HexHighEntropyString, self).__init__(
-            charset=string.hexdigits,
-            limit=hex_limit,
-            high_entropy_exclude=hex_high_entropy_exclude,
+            string.hexdigits,
+            hex_limit,
         )
 
     @property
@@ -292,11 +278,10 @@ class Base64HighEntropyString(HighEntropyStringsPlugin):
 
     secret_type = 'Base64 High Entropy String'
 
-    def __init__(self, base64_limit, base64_high_entropy_exclude=None, **kwargs):
+    def __init__(self, base64_limit, **kwargs):
         super(Base64HighEntropyString, self).__init__(
-            charset=string.ascii_letters + string.digits + '+/=',
-            limit=base64_limit,
-            high_entropy_exclude=base64_high_entropy_exclude,
+            string.ascii_letters + string.digits + '+/=',
+            base64_limit,
         )
 
     @property

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -139,7 +139,7 @@ class KeywordDetector(BasePlugin):
 
     secret_type = 'Secret Keyword'
 
-    def _analyze_string(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename):
         output = {}
 
         for identifier in self.secret_generator(

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -90,45 +90,45 @@ FALSE_POSITIVES = {
     'true;',
     '{',
 }
-FOLLOWED_BY_COLON_RE = re.compile(
+FOLLOWED_BY_COLON_REGEX = re.compile(
     # e.g. api_key: foo
     r'({})(("|\')?):(\s*?)(("|\')?)([^\s]+)(\5)'.format(
         r'|'.join(BLACKLIST),
     ),
 )
-FOLLOWED_BY_COLON_QUOTES_REQUIRED_RE = re.compile(
+FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. api_key: "foo"
     r'({})(("|\')?):(\s*?)(("|\'))([^\s]+)(\5)'.format(
         r'|'.join(BLACKLIST),
     ),
 )
-FOLLOWED_BY_EQUAL_SIGNS_RE = re.compile(
+FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password = bar
     r'({})((\'|")])?()(\s*?)=(\s*?)(("|\')?)([^\s]+)(\7)'.format(
         r'|'.join(BLACKLIST),
     ),
 )
-FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_RE = re.compile(
+FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. my_password = "bar"
     r'({})((\'|")])?()(\s*?)=(\s*?)(("|\'))([^\s]+)(\7)'.format(
         r'|'.join(BLACKLIST),
     ),
 )
-FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE = re.compile(
+FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
     # e.g. private_key "something";
     r'({})([^\s]*?)(\s*?)("|\')([^\s]+)(\4);'.format(
         r'|'.join(BLACKLIST),
     ),
 )
 BLACKLIST_REGEX_TO_GROUP = {
-    FOLLOWED_BY_COLON_RE: 7,
-    FOLLOWED_BY_EQUAL_SIGNS_RE: 9,
-    FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE: 5,
+    FOLLOWED_BY_COLON_REGEX: 7,
+    FOLLOWED_BY_EQUAL_SIGNS_REGEX: 9,
+    FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 5,
 }
 PYTHON_BLACKLIST_REGEX_TO_GROUP = {
-    FOLLOWED_BY_COLON_QUOTES_REQUIRED_RE: 7,
-    FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_RE: 9,
-    FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE: 5,
+    FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX: 7,
+    FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX: 9,
+    FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 5,
 }
 
 
@@ -139,7 +139,7 @@ class KeywordDetector(BasePlugin):
 
     secret_type = 'Secret Keyword'
 
-    def analyze_string(self, string, line_num, filename):
+    def _analyze_string(self, string, line_num, filename):
         output = {}
 
         for identifier in self.secret_generator(
@@ -160,12 +160,12 @@ class KeywordDetector(BasePlugin):
         lowered_string = string.lower()
 
         if filetype == FileType.PYTHON:
-            blacklist_RE_to_group = PYTHON_BLACKLIST_REGEX_TO_GROUP
+            blacklist_regex_to_group = PYTHON_BLACKLIST_REGEX_TO_GROUP
         else:
-            blacklist_RE_to_group = BLACKLIST_REGEX_TO_GROUP
+            blacklist_regex_to_group = BLACKLIST_REGEX_TO_GROUP
 
-        for REGEX, group_number in blacklist_RE_to_group.items():
-            match = REGEX.search(lowered_string)
+        for blacklist_regex, group_number in blacklist_regex_to_group.items():
+            match = blacklist_regex.search(lowered_string)
             if match:
                 lowered_secret = match.group(group_number)
 

--- a/detect_secrets/plugins/private_key.py
+++ b/detect_secrets/plugins/private_key.py
@@ -37,16 +37,17 @@ class PrivateKeyDetector(RegexBasedDetector):
     """
 
     secret_type = 'Private Key'
+
     blacklist = [
         re.compile(regexp)
         for regexp in (
-            r'BEGIN RSA PRIVATE KEY',
             r'BEGIN DSA PRIVATE KEY',
             r'BEGIN EC PRIVATE KEY',
             r'BEGIN OPENSSH PRIVATE KEY',
-            r'BEGIN PRIVATE KEY',
-            r'PuTTY-User-Key-File-2',
-            r'BEGIN SSH2 ENCRYPTED PRIVATE KEY',
             r'BEGIN PGP PRIVATE KEY BLOCK',
+            r'BEGIN PRIVATE KEY',
+            r'BEGIN RSA PRIVATE KEY',
+            r'BEGIN SSH2 ENCRYPTED PRIVATE KEY',
+            r'PuTTY-User-Key-File-2',
         )
     ]

--- a/detect_secrets/plugins/slack.py
+++ b/detect_secrets/plugins/slack.py
@@ -9,7 +9,9 @@ from .base import RegexBasedDetector
 
 
 class SlackDetector(RegexBasedDetector):
+
     secret_type = 'Slack Token'
+
     blacklist = (
         re.compile(r'xox(?:a|b|p|o|s|r)-(?:\d+-)+[a-z0-9]+', flags=re.IGNORECASE),
     )

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -38,7 +38,7 @@ def main(argv=None):
 
     plugins = initialize.from_parser_builder(
         args.plugins,
-        exclude_lines_re=args.exclude_lines,
+        exclude_lines_regex=args.exclude_lines,
     )
 
     # Merge plugin from baseline

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -18,7 +18,8 @@ log = get_logger(format_string='%(message)s')
 
 
 def parse_args(argv):
-    return ParserBuilder().add_pre_commit_arguments()\
+    return ParserBuilder()\
+        .add_pre_commit_arguments()\
         .parse_args(argv)
 
 
@@ -35,11 +36,17 @@ def main(argv=None):
         # Error logs handled within logic.
         return 1
 
-    plugins = initialize.from_parser_builder(args.plugins)
+    plugins = initialize.from_parser_builder(
+        args.plugins,
+        exclude_lines_re=args.exclude_lines,
+    )
 
     # Merge plugin from baseline
     if baseline_collection:
-        plugins = initialize.merge_plugin_from_baseline(baseline_collection.plugins, args)
+        plugins = initialize.merge_plugin_from_baseline(
+            baseline_collection.plugins,
+            args,
+        )
         baseline_collection.plugins = plugins
 
     results = find_secrets_in_files(args, plugins)

--- a/test_data/config.yaml
+++ b/test_data/config.yaml
@@ -1,6 +1,7 @@
 credentials:
     some_value_here: not_a_secret
     other_value_here: 1234567890a
+    CanonicalUserGetSkippedByExcludeLines: 1234567890ab
     nested:
         value: AKIAabcdefghijklmnop
         other_value: abcdefghijklmnop

--- a/testing/factories.py
+++ b/testing/factories.py
@@ -11,20 +11,20 @@ def potential_secret_factory(type_='type', filename='filename', secret='secret',
     return PotentialSecret(type_, filename, secret, lineno)
 
 
-def secrets_collection_factory(secrets=None, plugins=(), exclude_files_re=''):
+def secrets_collection_factory(secrets=None, plugins=(), exclude_files_regex=None):
     """
     :type secrets: list(dict)
     :param secrets: list of params to pass to add_secret.
                     E.g. [ {'secret': 'blah'}, ]
 
     :type plugins: tuple
-    :type exclude_files_re: str
+    :type exclude_files_regex: str|None
 
     :rtype: SecretsCollection
     """
     collection = SecretsCollection(
         plugins,
-        exclude_files=exclude_files_re,
+        exclude_files=exclude_files_regex,
     )
 
     if plugins:

--- a/testing/factories.py
+++ b/testing/factories.py
@@ -11,18 +11,21 @@ def potential_secret_factory(type_='type', filename='filename', secret='secret',
     return PotentialSecret(type_, filename, secret, lineno)
 
 
-def secrets_collection_factory(secrets=None, plugins=(), exclude_regex=''):
+def secrets_collection_factory(secrets=None, plugins=(), exclude_files_re=''):
     """
     :type secrets: list(dict)
     :param secrets: list of params to pass to add_secret.
                     E.g. [ {'secret': 'blah'}, ]
 
     :type plugins: tuple
-    :type exclude_regex: str
+    :type exclude_files_re: str
 
     :rtype: SecretsCollection
     """
-    collection = SecretsCollection(plugins, exclude_regex)
+    collection = SecretsCollection(
+        plugins,
+        exclude_files=exclude_files_re,
+    )
 
     if plugins:
         collection.plugins = plugins

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -32,13 +32,13 @@ class TestInitializeBaseline(object):
     def get_results(
         self,
         path='./test_data/files',
-        exclude_files_re=None,
+        exclude_files_regex=None,
         scan_all_files=False,
     ):
         return baseline.initialize(
             self.plugins,
             path=path,
-            exclude_files_re=exclude_files_re,
+            exclude_files_regex=exclude_files_regex,
             scan_all_files=scan_all_files,
         ).json()
 
@@ -59,13 +59,13 @@ class TestInitializeBaseline(object):
         assert len(results['test_data/files/tmp/file_with_secrets.py']) == 2
 
     def test_exclude_regex(self):
-        results = self.get_results(exclude_files_re='tmp*')
+        results = self.get_results(exclude_files_regex='tmp*')
 
         assert len(results.keys()) == 1
         assert 'test_data/files/file_with_secrets.py' in results
 
     def test_exclude_regex_at_root_level(self):
-        results = self.get_results(exclude_files_re='file_with_secrets.py')
+        results = self.get_results(exclude_files_regex='file_with_secrets.py')
 
         # All files_with_secrets.py should be ignored, both at the root
         # level, and the nested file in tmp.

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -32,13 +32,13 @@ class TestInitializeBaseline(object):
     def get_results(
         self,
         path='./test_data/files',
-        exclude_regex=None,
+        exclude_files_re=None,
         scan_all_files=False,
     ):
         return baseline.initialize(
             self.plugins,
             path=path,
-            exclude_regex=exclude_regex,
+            exclude_files_re=exclude_files_re,
             scan_all_files=scan_all_files,
         ).json()
 
@@ -59,13 +59,13 @@ class TestInitializeBaseline(object):
         assert len(results['test_data/files/tmp/file_with_secrets.py']) == 2
 
     def test_exclude_regex(self):
-        results = self.get_results(exclude_regex='tmp*')
+        results = self.get_results(exclude_files_re='tmp*')
 
         assert len(results.keys()) == 1
         assert 'test_data/files/file_with_secrets.py' in results
 
     def test_exclude_regex_at_root_level(self):
-        results = self.get_results(exclude_regex='file_with_secrets.py')
+        results = self.get_results(exclude_files_re='file_with_secrets.py')
 
         # All files_with_secrets.py should be ignored, both at the root
         # level, and the nested file in tmp.
@@ -154,7 +154,7 @@ class TestGetSecretsNotInBaseline(object):
         ])
 
         backup_baseline = baseline.data.copy()
-        baseline.exclude_regex = 'filename1'
+        baseline.exclude_files = 'filename1'
         results = get_secrets_not_in_baseline(new_findings, baseline)
 
         assert len(results.data) == 1

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -179,7 +179,9 @@ class TestScanDiff(object):
     def load_from_diff(self, existing_secrets=None, baseline_filename='', exclude_files_re=''):
         collection = secrets_collection_factory(
             secrets=existing_secrets,
-            plugins=(HexHighEntropyString(3),),
+            plugins=(
+                HexHighEntropyString(hex_limit=3),
+            ),
             exclude_files_re=exclude_files_re,
         )
 

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -396,7 +396,7 @@ class TestBaselineInputOutput(object):
 class MockBasePlugin(BasePlugin):  # pragma: no cover
     """Abstract testing class, to implement abstract methods."""
 
-    def _analyze_string(self, value):
+    def analyze_string_content(self, value):
         pass
 
     def secret_generator(self, string):

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -170,17 +170,17 @@ class TestScanDiff(object):
 
     def test_exclude_regex_skips_files_appropriately(self):
         secrets = self.load_from_diff(
-            exclude_regex='tests/*',
+            exclude_files_re='tests/*',
         ).format_for_baseline_output()['results']
 
         assert len(secrets) == 2
         assert 'tests/core/secrets_collection_test.py' not in secrets
 
-    def load_from_diff(self, existing_secrets=None, baseline_filename='', exclude_regex=''):
+    def load_from_diff(self, existing_secrets=None, baseline_filename='', exclude_files_re=''):
         collection = secrets_collection_factory(
             secrets=existing_secrets,
             plugins=(HexHighEntropyString(3),),
-            exclude_regex=exclude_regex,
+            exclude_files_re=exclude_files_re,
         )
 
         with open('test_data/sample.diff') as f:
@@ -276,41 +276,80 @@ class TestBaselineInputOutput(object):
                 HexHighEntropyString(3),
                 PrivateKeyDetector(),
             ),
+            exclude_files_re='foo',
         )
 
     def test_output(self, mock_gmtime):
-        assert self.logic.format_for_baseline_output() == self.get_baseline_dict(mock_gmtime)
+        assert self.logic.format_for_baseline_output() == self.get_new_baseline_dict(mock_gmtime)
 
-    def test_load_baseline_from_string(self, mock_gmtime):
+    def test_old_load_baseline_from_string(self, mock_gmtime):
         """
         We use load_baseline_from_string as a proxy to testing load_baseline_from_dict,
         because it's the most entry into the private function.
         """
-        original = self.get_baseline_dict(mock_gmtime)
+        old_original = self.get_old_baseline_dict(mock_gmtime)
+
+        secrets = SecretsCollection.load_baseline_from_string(
+            json.dumps(old_original),
+        ).format_for_baseline_output()
+
+        # exclude_regex got updated to exclude: files
+        assert old_original['exclude_regex'] == secrets['exclude']['files']
+        assert secrets['exclude']['lines'] is None
+        assert old_original['results'] == secrets['results']
+
+    def test_new_load_baseline_from_string(self, mock_gmtime):
+        """
+        We use load_baseline_from_string as a proxy to testing load_baseline_from_dict,
+        because it's the most entry into the private function.
+        """
+        original = self.get_new_baseline_dict(mock_gmtime)
 
         secrets = SecretsCollection.load_baseline_from_string(
             json.dumps(original),
         ).format_for_baseline_output()
 
-        self.assert_loaded_collection_is_original_collection(original, secrets)
+        assert original['exclude']['files'] == secrets['exclude']['files']
+        assert secrets['exclude']['lines'] is None
+        assert original['results'] == secrets['results']
 
-    def test_load_baseline_with_invalid_input(self, mock_log):
+    def test_load_baseline_without_any_valid_fields(self, mock_log):
         with pytest.raises(IOError):
             SecretsCollection.load_baseline_from_string(
                 json.dumps({
                     'junk': 'dictionary',
                 }),
             )
-
         assert mock_log.error_messages == 'Incorrectly formatted baseline!\n'
 
-    def get_baseline_dict(self, gmtime):
+    def test_load_baseline_without_exclude(self, mock_log):
+        with pytest.raises(IOError):
+            SecretsCollection.load_baseline_from_string(
+                json.dumps({
+                    'plugins_used': (),
+                    'results': {},
+                }),
+            )
+        assert mock_log.error_messages == 'Incorrectly formatted baseline!\n'
+
+    def get_new_baseline_dict(self, gmtime):
+        baseline = self._get_baseline_dict(gmtime)
+        baseline['exclude'] = {}
+        baseline['exclude']['files'] = 'foo'
+        baseline['exclude']['lines'] = None
+        return baseline
+
+    def get_old_baseline_dict(self, gmtime):
+        baseline = self._get_baseline_dict(gmtime)
+        baseline['exclude_regex'] = 'foo'
+        return baseline
+
+    def _get_baseline_dict(self, gmtime):
         # They are all the same secret, so they should all have the same secret hash.
         secret_hash = PotentialSecret.hash_secret('secret')
 
         return {
             'generated_at': strftime('%Y-%m-%dT%H:%M:%SZ', gmtime),
-            'exclude_regex': '',
             'plugins_used': [
                 {
                     'name': 'HexHighEntropyString',
@@ -344,10 +383,6 @@ class TestBaselineInputOutput(object):
             },
             'version': VERSION,
         }
-
-    def assert_loaded_collection_is_original_collection(self, original, new):
-        for key in ['results', 'exclude_regex']:
-            assert original[key] == new[key]
 
 
 class MockBasePlugin(BasePlugin):  # pragma: no cover

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -27,12 +27,10 @@ class TestPluginOptions(object):
         assert args.plugins == {
             'HexHighEntropyString': {
                 'hex_limit': 3,
-                'hex_high_entropy_exclude': None,
             },
             'BasicAuthDetector': {},
             'Base64HighEntropyString': {
                 'base64_limit': 4.5,
-                'base64_high_entropy_exclude': None,
             },
             'KeywordDetector': {},
             'PrivateKeyDetector': {},

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -59,22 +59,46 @@ class TestMain(object):
             scan_all_files=False,
         )
 
-    def test_scan_string_basic(self, mock_baseline_initialize):
+    @pytest.mark.parametrize(
+        'string, expected_base64_result, expected_hex_result',
+        [
+            (
+                '012345678ab',
+                'False (3.459)',
+                'True  (3.459)',
+            ),
+            (
+                'Benign',
+                'False (2.252)',
+                'False',
+            ),
+        ],
+    )
+    def test_scan_string_basic(
+        self,
+        mock_baseline_initialize,
+        string,
+        expected_base64_result,
+        expected_hex_result,
+    ):
         with mock_stdin(
-            '012345678ab',
+            string,
         ), mock_printer(
             main_module,
         ) as printer_shim:
             assert main('scan --string'.split()) == 0
             assert uncolor(printer_shim.message) == textwrap.dedent("""
                 AWSKeyDetector         : False
-                Base64HighEntropyString: False (3.459)
+                Base64HighEntropyString: {}
                 BasicAuthDetector      : False
-                HexHighEntropyString   : True  (3.459)
+                HexHighEntropyString   : {}
                 KeywordDetector        : False
                 PrivateKeyDetector     : False
                 SlackDetector          : False
-            """)[1:]
+            """.format(
+                expected_base64_result,
+                expected_hex_result,
+            ))[1:]
 
         mock_baseline_initialize.assert_not_called()
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -27,8 +27,8 @@ class TestMain(object):
 
         mock_baseline_initialize.assert_called_once_with(
             plugins=Any(tuple),
-            exclude_files_re=None,
-            exclude_lines_re=None,
+            exclude_files_regex=None,
+            exclude_lines_regex=None,
             path='.',
             scan_all_files=False,
         )
@@ -39,8 +39,8 @@ class TestMain(object):
 
         mock_baseline_initialize.assert_called_once_with(
             plugins=Any(tuple),
-            exclude_files_re=None,
-            exclude_lines_re=None,
+            exclude_files_regex=None,
+            exclude_lines_regex=None,
             path='test_data',
             scan_all_files=False,
         )
@@ -53,8 +53,8 @@ class TestMain(object):
 
         mock_baseline_initialize.assert_called_once_with(
             plugins=Any(tuple),
-            exclude_files_re='some_pattern_here',
-            exclude_lines_re='other_patt',
+            exclude_files_regex='some_pattern_here',
+            exclude_lines_regex='other_patt',
             path='.',
             scan_all_files=False,
         )
@@ -125,8 +125,8 @@ class TestMain(object):
 
         mock_baseline_initialize.assert_called_once_with(
             plugins=Any(tuple),
-            exclude_files_re=None,
-            exclude_lines_re=None,
+            exclude_files_regex=None,
+            exclude_lines_regex=None,
             path='.',
             scan_all_files=True,
         )
@@ -533,10 +533,10 @@ def mock_stdin(response=None):
 
 @pytest.fixture
 def mock_baseline_initialize():
-    def mock_initialize_function(plugins, exclude_files_re, *args, **kwargs):
+    def mock_initialize_function(plugins, exclude_files_regex, *args, **kwargs):
         return secrets_collection_factory(
             plugins=plugins,
-            exclude_files_re=exclude_files_re,
+            exclude_files_regex=exclude_files_regex,
         )
 
     with mock.patch(

--- a/tests/plugins/base_test.py
+++ b/tests/plugins/base_test.py
@@ -8,7 +8,7 @@ from detect_secrets.plugins.base import BasePlugin
 def test_fails_if_no_secret_type_defined():
     class MockPlugin(BasePlugin):  # pragma: no cover
 
-        def _analyze_string(self, *args, **kwargs):
+        def analyze_string_content(self, *args, **kwargs):
             pass
 
         def secret_generator(self, *args, **kwargs):

--- a/tests/plugins/base_test.py
+++ b/tests/plugins/base_test.py
@@ -7,7 +7,8 @@ from detect_secrets.plugins.base import BasePlugin
 
 def test_fails_if_no_secret_type_defined():
     class MockPlugin(BasePlugin):  # pragma: no cover
-        def analyze_string(self, *args, **kwargs):
+
+        def _analyze_string(self, *args, **kwargs):
             pass
 
         def secret_generator(self, *args, **kwargs):

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -11,9 +11,6 @@ from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
 from testing.mocks import mock_file_object
 
 
-HIGH_ENTROPY_EXCLUDE = '(CanonicalUser)'
-
-
 class HighEntropyStringsTest(object):
     """
     Some explaining should be done regarding the "enforced" format of the parametrized
@@ -102,8 +99,6 @@ class HighEntropyStringsTest(object):
             "'{secret}'  /* pragma: whitelist secret */",
             "'{secret}'  ' pragma: whitelist secret",
             "'{secret}'  -- pragma: whitelist secret",
-            # Test high entropy exclude regex
-            '"CanonicalUser": "{secret}"',
             # Not a string
             "{secret}",
         ],
@@ -130,10 +125,7 @@ class TestBase64HighEntropyStrings(HighEntropyStringsTest):
     def setup(self):
         super(TestBase64HighEntropyStrings, self).setup(
             # Testing default limit, as suggested by truffleHog.
-            Base64HighEntropyString(
-                base64_limit=4.5,
-                base64_high_entropy_exclude=HIGH_ENTROPY_EXCLUDE,
-            ),
+            Base64HighEntropyString(4.5),
             'c3VwZXIgc2VjcmV0IHZhbHVl',     # too short for high entropy
             'c3VwZXIgbG9uZyBzdHJpbmcgc2hvdWxkIGNhdXNlIGVub3VnaCBlbnRyb3B5',
         )
@@ -204,19 +196,15 @@ class TestHexHighEntropyStrings(HighEntropyStringsTest):
     def setup(self):
         super(TestHexHighEntropyStrings, self).setup(
             # Testing default limit, as suggested by truffleHog.
-            HexHighEntropyString(
-                hex_limit=3,
-                hex_high_entropy_exclude=HIGH_ENTROPY_EXCLUDE,
-            ),
+            HexHighEntropyString(3),
             'aaaaaa',
             '2b00042f7481c7b056c4b410d28f33cf',
         )
 
     def test_discounts_when_all_numbers(self):
         original_scanner = HighEntropyStringsPlugin(
-            charset=string.hexdigits,
-            limit=3,
-            high_entropy_exclude=HIGH_ENTROPY_EXCLUDE,
+            string.hexdigits,
+            3,
         )
 
         # This makes sure discounting works.

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -40,7 +40,7 @@ class HighEntropyStringsTest(object):
         self.secret = secret_string
 
     @pytest.mark.parametrize(
-        'content_to_format,should_be_caught',
+        'content_to_format, should_be_caught',
         [
             (
                 "'{non_secret}'",
@@ -50,7 +50,7 @@ class HighEntropyStringsTest(object):
                 "'{secret}'",
                 True,
             ),
-            # Matches exclude_lines_re
+            # Matches exclude_lines_regex
             (
                 "CanonicalUser: {secret}",
                 False,
@@ -67,10 +67,10 @@ class HighEntropyStringsTest(object):
 
         results = self.logic.analyze(f, 'does_not_matter')
 
-        assert len(results) == bool(should_be_caught)
+        assert len(results) == should_be_caught
 
     @pytest.mark.parametrize(
-        'content_to_format,expected_results',
+        'content_to_format, expected_results',
         [
             (
                 'String #1: "{non_secret}"; String #2: "{secret}"',
@@ -139,7 +139,7 @@ class TestBase64HighEntropyStrings(HighEntropyStringsTest):
             # Testing default limit, as suggested by truffleHog.
             logic=Base64HighEntropyString(
                 base64_limit=4.5,
-                exclude_lines_re='(CanonicalUser)',
+                exclude_lines_regex='CanonicalUser',
             ),
             non_secret_string='c3VwZXIgc2VjcmV0IHZhbHVl',  # too short for high entropy
             secret_string='c3VwZXIgbG9uZyBzdHJpbmcgc2hvdWxkIGNhdXNlIGVub3VnaCBlbnRyb3B5',
@@ -182,7 +182,7 @@ class TestBase64HighEntropyStrings(HighEntropyStringsTest):
     def test_yaml_file(self):
         plugin = Base64HighEntropyString(
             base64_limit=3,
-            exclude_lines_re='(CanonicalUser)',
+            exclude_lines_regex='CanonicalUser',
         )
 
         with open('test_data/config.yaml') as f:
@@ -216,7 +216,7 @@ class TestHexHighEntropyStrings(HighEntropyStringsTest):
             # Testing default limit, as suggested by truffleHog.
             logic=HexHighEntropyString(
                 hex_limit=3,
-                exclude_lines_re='(CanonicalUser)',
+                exclude_lines_regex='CanonicalUser',
             ),
             non_secret_string='aaaaaa',
             secret_string='2b00042f7481c7b056c4b410d28f33cf',
@@ -226,7 +226,7 @@ class TestHexHighEntropyStrings(HighEntropyStringsTest):
         original_scanner = HighEntropyStringsPlugin(
             charset=string.hexdigits,
             limit=3,
-            exclude_lines_re=None,
+            exclude_lines_regex=None,
         )
 
         # This makes sure discounting works.


### PR DESCRIPTION
So this reverts https://github.com/Yelp/detect-secrets/commit/15a6e6a0fe4884925c15f4378667b2d8f2e16cab in favor of a line exclude arg for all plugins. If at a later date we would like a regex specifically for e.g. `KeywordDetector`, then we can add that feature then.

💥 This removes the `--exclude` CLI arg

:tada: Replace `--exclude with` `--exclude-files` and `--exclude-lines`
    
    Change baseline format to replace `exclude_regex` with
    ```
    "exclude":{
      "files": "foo",
      "lines": "bar"
    }
    ```
    
    Pass `exclude_lines_re` to all plugins in `from_plugin_classname`, and use 'em