### PR TITLE
fix: support unicode in markdown

### DIFF
--- a/detect_secrets/plugins/common/ini_file_parser.py
+++ b/detect_secrets/plugins/common/ini_file_parser.py
@@ -17,23 +17,26 @@ class IniFileParser(object):
         :param exclude_lines_regex: optional regex for ignored lines.
         """
         self.parser = configparser.ConfigParser()
-        self.parser.optionxform = str
+        try:
+            # python2.7 compatible
+            self.parser.optionxform = unicode
+        except NameError:
+            self.parser.optionxform = str
 
         self.exclude_lines_regex = exclude_lines_regex
 
-        if not add_header:
-            self.parser.read_file(file)
-        else:
+        content = file.read()
+        if add_header:
             # This supports environment variables, or other files that look
             # like config files, without a section header.
-            content = '[global]\n' + file.read()
+            content = '[global]\n' + content
 
-            try:
-                # python2.7 compatible
-                self.parser.read_string(unicode(content))
-            except NameError:
-                # python3 compatible
-                self.parser.read_string(content)
+        try:
+            # python2.7 compatible
+            self.parser.read_string(unicode(content))
+        except NameError:
+            # python3 compatible
+            self.parser.read_string(content)
 
         # Hacky way to keep track of line location
         file.seek(0)

--- a/test_data/config.md
+++ b/test_data/config.md
@@ -1,0 +1,10 @@
+# Sample markdown file
+
+[guides](http://localhost/guilds)
+
+Test Unicode in non ini file would not fail on python 2.7.
+
+╭─ diagnose
+╰» ssh to server x:22324241234423414
+
+key="ToCynx5Se4e2PtoZxEhW7lUJcOX15c54"


### PR DESCRIPTION
## What's in the PR
- Fixes an `UnicodeEncodeError` when scanning non-ini file (such as markdown) containing unicode.
- Add one more ini test case
- Parametrize ini test cases

## Offending File content
```markdown
# Sample markdown file

[guides](http://localhost/guilds)

Test Unicode in non ini file would not fail on python 2.7.

╭─ diagnose
╰» ssh to server x:22324241234423414

key="ToCynx5Se4e2PtoZxEhW7lUJcOX15c54"
```

## Current error message (fixed after using the PR)
```
Traceback (most recent call last):
  File "detect_secrets/main.py", line 200, in <module>
    sys.exit(main())
  File "detect_secrets/main.py", line 47, in main
    baseline_dict = _perform_scan(args, plugins)
  File "detect_secrets/main.py", line 146, in _perform_scan
    scan_all_files=args.all_files,
  File "/Users/killua/workspace/ww/whitewater-detect-secrets/detect_secrets/core/baseline.py", line 58, in initialize
    output.scan_file(file)
  File "/Users/killua/workspace/ww/whitewater-detect-secrets/detect_secrets/core/secrets_collection.py", line 206, in scan_file
    self._extract_secrets_from_file(f, filename_key)
  File "/Users/killua/workspace/ww/whitewater-detect-secrets/detect_secrets/core/secrets_collection.py", line 306, in _extract_secrets_from_file
    results.update(plugin.analyze(f, filename))
  File "/Users/killua/workspace/ww/whitewater-detect-secrets/detect_secrets/plugins/high_entropy_strings.py", line 68, in analyze
    output = analyze_function(file, filename)
  File "/Users/killua/workspace/ww/whitewater-detect-secrets/detect_secrets/plugins/high_entropy_strings.py", line 184, in wrapped
    exclude_lines_regex=self.exclude_lines_regex,
  File "/Users/killua/workspace/ww/whitewater-detect-secrets/detect_secrets/plugins/common/ini_file_parser.py", line 25, in __init__
    self.parser.read_file(file)
  File "/Users/killua/.pyenv/versions/2.7.15/lib/python2.7/site-packages/backports/configparser/__init__.py", line 715, in read_file
    self._read(f, source)
  File "/Users/killua/.pyenv/versions/2.7.15/lib/python2.7/site-packages/backports/configparser/__init__.py", line 1100, in _read
    optname = self.optionxform(optname.rstrip())
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

