### PR TITLE
Update pre-commit config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ detect-secrets scan > .secrets.baseline
 ```
 $ cat .pre-commit-config.yaml
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: 0.10.1
+    rev: 0.12.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']


### PR DESCRIPTION
The version in the pre-commit hook caused me some trouble during my
first set up(I needed to switch to a newer version of detect-secrets to
make it work). Updates the readme to the latest version