### PR TITLE
Fix pre-commit example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ detect-secrets scan > .secrets.baseline
 ```
 $ cat .pre-commit-config.yaml
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: 0.12.0
+    rev: v0.12.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']


### PR DESCRIPTION
Git tags are named `v0.12.0`, not `0.12.0`, so pre-commit cannot pull the correct reference