### PR TITLE
Fix unicode on RHS in ini scan

### DIFF
--- a/detect_secrets/plugins/common/ini_file_parser.py
+++ b/detect_secrets/plugins/common/ini_file_parser.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import configparser
 import re
 
@@ -20,7 +22,8 @@ class IniFileParser(object):
         try:
             # python2.7 compatible
             self.parser.optionxform = unicode
-        except NameError:
+        except NameError:  # pragma: no cover
+            # python3 compatible
             self.parser.optionxform = str
 
         self.exclude_lines_regex = exclude_lines_regex
@@ -34,7 +37,7 @@ class IniFileParser(object):
         try:
             # python2.7 compatible
             self.parser.read_string(unicode(content))
-        except NameError:
+        except NameError:  # pragma: no cover
             # python3 compatible
             self.parser.read_string(content)
 

--- a/test_data/config.ini
+++ b/test_data/config.ini
@@ -24,3 +24,6 @@ keyB = 456789123
 keyC =
 
 password = 12345678901234  # pragma: whitelist secret
+
+# unicode
+foo=bår


### PR DESCRIPTION
#### Changes
- 🐛 Handle unicode in ini_file_parser.py

This bug was trigged only when Unicode was on the RHS e.g.
```
foo=bår
```

&
- merged in master to get coverage back up to the minimum (98%)

#### Why this works
To clarify why `unicode_literals` fixes this, we format things into a string literal when doing `re.compile`, so this [makes sure it's unicode and not bytes](https://stackoverflow.com/questions/23370025/what-is-unicode-literals-used-for).