### PR TITLE
[Keyword Plugin] Make quotes required for .java files

### DIFF
--- a/detect_secrets/plugins/common/filetype.py
+++ b/detect_secrets/plugins/common/filetype.py
@@ -3,11 +3,12 @@ from enum import Enum
 
 class FileType(Enum):
     CLS = 0
-    JAVASCRIPT = 1
-    PHP = 2
-    PYTHON = 3
-    YAML = 4
-    OTHER = 5
+    JAVA = 1
+    JAVASCRIPT = 2
+    PHP = 3
+    PYTHON = 4
+    YAML = 5
+    OTHER = 6
 
 
 def determine_file_type(filename):
@@ -18,6 +19,8 @@ def determine_file_type(filename):
     """
     if filename.endswith('.cls'):
         return FileType.CLS
+    elif filename.endswith('.java'):
+        return FileType.JAVA
     elif filename.endswith('.js'):
         return FileType.JAVASCRIPT
     elif filename.endswith('.php'):

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -147,6 +147,11 @@ QUOTES_REQUIRED_BLACKLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX: 9,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 5,
 }
+QUOTES_REQUIRED_FILETYPES = {
+    FileType.CLS,
+    FileType.JAVA,
+    FileType.PYTHON,
+}
 
 
 class KeywordDetector(BasePlugin):
@@ -192,10 +197,7 @@ class KeywordDetector(BasePlugin):
     def secret_generator(self, string, filetype):
         lowered_string = string.lower()
 
-        if filetype in (
-            FileType.CLS,
-            FileType.PYTHON,
-        ):
+        if filetype in QUOTES_REQUIRED_FILETYPES:
             blacklist_regex_to_group = QUOTES_REQUIRED_BLACKLIST_REGEX_TO_GROUP
         else:
             blacklist_regex_to_group = BLACKLIST_REGEX_TO_GROUP

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -8,6 +8,11 @@ from detect_secrets.plugins.keyword import KeywordDetector
 from testing.mocks import mock_file_object
 
 
+QUOTES_REQUIRED_FILE_EXTENSIONS = (
+    '.cls',
+    '.java',
+    '.py',
+)
 STANDARD_NEGATIVES = [
     # FOLLOWED_BY_COLON_RE
     'theapikey: ""',  # Nothing in the quotes
@@ -111,10 +116,7 @@ class TestKeywordDetector(object):
                     'my_password ={{h}o)p${e]nob(ody[finds>-_$#thisone}}',
                     'the_password={{h}o)p${e]nob(ody[finds>-_$#thisone}}\n',
                 }
-            ) for file_extension in (
-                '.cls',
-                '.py',
-            )
+            ) for file_extension in QUOTES_REQUIRED_FILE_EXTENSIONS
         ),
     )
     def test_analyze_quotes_required_positives(self, file_content, file_extension):
@@ -190,10 +192,7 @@ class TestKeywordDetector(object):
                     'my_password =hope]nobody[finds>-_$#thisone',
                     'the_password=hope]nobody[finds>-_$#thisone\n',
                 ]
-            ) for file_extension in (
-                '.cls',
-                '.py',
-            )
+            ) for file_extension in QUOTES_REQUIRED_FILE_EXTENSIONS
         ),
     )
     def test_analyze_quotes_required_negatives(self, file_content, file_extension):


### PR DESCRIPTION
This was a small leftover from https://github.com/Yelp/detect-secrets/pull/133 that I wanted to do before bumping the PyPI version.

#### Changes
:telescope: [Keyword Plugin] Make quotes required for .java
Make a `QUOTES_REQUIRED_FILETYPES` dict for efficiency