### PR TITLE
Patch backports configparser too

### DIFF
--- a/detect_secrets/plugins/common/ini_file_parser.py
+++ b/detect_secrets/plugins/common/ini_file_parser.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
-import configparser
+try:
+    from backports import configparser
+except ImportError:  # pragma: no cover
+    import configparser
 import re
 
 


### PR DESCRIPTION
:bug: Patch backports configparser too

We previously 🐒  patched configparser with `EfficientParsingError`, however this did not patch the backports version present on Python 2.

The [configparser README](https://github.com/jaraco/configparser/#configparser) says `If you’d like to use the backport on Python 2 and the built-in version on Python 3`, then use the invocation that we were using, i.e. `import configparser`. However this doesn't work when monkey-patching, so I did the more explicit `from backports import configparser`.