### PR TITLE
feature: support whitelist for xml

### DIFF
--- a/detect_secrets/plugins/common/constants.py
+++ b/detect_secrets/plugins/common/constants.py
@@ -6,11 +6,12 @@ WHITELIST_REGEXES = [
     for r in [
         r'[ \t]+{} *pragma: ?whitelist[ -]secret{}[ \t]*$'.format(start, end)
         for start, end in (
-            ('#', ''),              # e.g. python or yaml
-            ('//', ''),             # e.g. golang
-            (r'/\*', r' *\*/'),     # e.g. c
-            ('\'', ''),             # e.g. visual basic .net
-            ('--', ''),             # e.g. sql
+            ('#', ''),                 # e.g. python or yaml
+            ('//', ''),                # e.g. golang
+            (r'/\*', r' *\*/'),        # e.g. c
+            ('\'', ''),                # e.g. visual basic .net
+            ('--', ''),                # e.g. sql
+            ('<!--[# \t]*', ' *-->'),  # e.g. xml
             # many other inline comment syntaxes are not included,
             # because we want to be performant for
             # any(regex.search(line) for regex in WHITELIST_REGEXES)

--- a/detect_secrets/plugins/common/constants.py
+++ b/detect_secrets/plugins/common/constants.py
@@ -6,12 +6,12 @@ WHITELIST_REGEXES = [
     for r in [
         r'[ \t]+{} *pragma: ?whitelist[ -]secret{}[ \t]*$'.format(start, end)
         for start, end in (
-            ('#', ''),                 # e.g. python or yaml
-            ('//', ''),                # e.g. golang
-            (r'/\*', r' *\*/'),        # e.g. c
-            ('\'', ''),                # e.g. visual basic .net
-            ('--', ''),                # e.g. sql
-            ('<!--[# \t]*', ' *-->'),  # e.g. xml
+            ('#', ''),                    # e.g. python or yaml
+            ('//', ''),                   # e.g. golang
+            (r'/\*', r' *\*/'),           # e.g. c
+            ('\'', ''),                   # e.g. visual basic .net
+            ('--', ''),                   # e.g. sql
+            (r'<!--[# \t]*?', ' *?-->'),  # e.g. xml
             # many other inline comment syntaxes are not included,
             # because we want to be performant for
             # any(regex.search(line) for regex in WHITELIST_REGEXES)

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -110,6 +110,10 @@ class HighEntropyStringsTest(object):
             "'{secret}' '  pragma: whitelist secret",
             "'{secret}'  -- pragma: whitelist secret",
             "'{secret}' --  pragma: whitelist secret",
+            "'{secret}' <!--pragma: whitelist secret-->",
+            "'{secret}' <!-- # pragma: whitelist secret -->",
+            "'{secret}' <!-- pragma: whitelist secret -->",
+            "'{secret}' <!--  pragma: whitelist secret  -->",
             # Test high entropy exclude regex
             '"CanonicalUser": "{secret}"',
             # Not a string


### PR DESCRIPTION
Better support whitelist for XML. Currently user needs to move the XML comment closing tag --> to 2nd line to properly whitelist. This PR would allow same line whitelisting for xml.