### PR TITLE
bugfix: Import configparser in a consistent way. Filetype detection fails whe…

### DIFF
--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-import configparser
+try:
+    from backports import configparser
+except ImportError:  # pragma: no cover
+    import configparser
 import math
 import os
 import re


### PR DESCRIPTION
…n mixing backport/builtin versions. Specifically, in high_entropy_strings.analyze(), backports.configparser.Error is not caught if what we are looking for is configparse.Error.

To reproduce, pip install configparser on python 3 (i.e. the backport version) and run on a file that is not an .ini file.