### PR TITLE
 handle golang string assignments

### DIFF
--- a/detect_secrets/plugins/common/filetype.py
+++ b/detect_secrets/plugins/common/filetype.py
@@ -3,12 +3,13 @@ from enum import Enum
 
 class FileType(Enum):
     CLS = 0
-    JAVA = 1
-    JAVASCRIPT = 2
-    PHP = 3
-    PYTHON = 4
-    YAML = 5
-    OTHER = 6
+    GO = 1
+    JAVA = 2
+    JAVASCRIPT = 3
+    PHP = 4
+    PYTHON = 5
+    YAML = 6
+    OTHER = 7
 
 
 def determine_file_type(filename):
@@ -19,6 +20,8 @@ def determine_file_type(filename):
     """
     if filename.endswith('.cls'):
         return FileType.CLS
+    elif filename.endswith('.go'):
+        return FileType.GO
     elif filename.endswith('.java'):
         return FileType.JAVA
     elif filename.endswith('.js'):

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -178,6 +178,16 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
         secret=SECRET,
     ),
 )
+FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
+    # e.g. my_password := "bar" or my_password := bar
+    r'({blacklist})({closing})?{whitespace}:=?{whitespace}({quote}?)({secret})(\3)'.format(
+        blacklist=BLACKLIST_REGEX,
+        closing=CLOSING,
+        quote=QUOTE,
+        whitespace=OPTIONAL_WHITESPACE,
+        secret=SECRET,
+    ),
+)
 BLACKLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_REGEX: 4,
     FOLLOWED_BY_EQUAL_SIGNS_REGEX: 4,
@@ -187,6 +197,11 @@ QUOTES_REQUIRED_BLACKLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX: 5,
     FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX: 4,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
+}
+GOLANG_BLACKLIST_REGEX_TO_GROUP = {
+    FOLLOWED_BY_EQUAL_SIGNS_REGEX: 4,
+    FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
+    FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX: 4,
 }
 QUOTES_REQUIRED_FILETYPES = {
     FileType.CLS,
@@ -240,6 +255,8 @@ class KeywordDetector(BasePlugin):
 
         if filetype in QUOTES_REQUIRED_FILETYPES:
             blacklist_regex_to_group = QUOTES_REQUIRED_BLACKLIST_REGEX_TO_GROUP
+        elif filetype == FileType.GO:
+            blacklist_regex_to_group = GOLANG_BLACKLIST_REGEX_TO_GROUP
         else:
             blacklist_regex_to_group = BLACKLIST_REGEX_TO_GROUP
 

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -137,7 +137,6 @@ STANDARD_NEGATIVES.extend(
     + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get("negatives").get("quotes_required")
     + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get("negatives").get("quotes_not_required"),
 )
-
 STANDARD_POSITIVES.extend(
     FOLLOWED_BY_COLON_RE.get("positives").get("quotes_required")
     + FOLLOWED_BY_COLON_RE.get("positives").get("quotes_not_required")

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -133,7 +133,9 @@ STANDARD_NEGATIVES.extend(
     + FOLLOWED_BY_COLON_RE.get("negatives").get("quotes_not_required")
     + FOLLOWED_BY_EQUAL_SIGNS_RE.get("negatives").get("quotes_required")
     + FOLLOWED_BY_EQUAL_SIGNS_RE.get("negatives").get("quotes_not_required")
-    + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get("negatives").get("quotes_required"),
+    + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get("negatives").get("quotes_required")
+    + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get("negatives").get("quotes_required")
+    + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get("negatives").get("quotes_not_required"),
 )
 STANDARD_POSITIVES.extend(
     FOLLOWED_BY_COLON_RE.get("positives").get("quotes_required")

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -137,6 +137,7 @@ STANDARD_NEGATIVES.extend(
     + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get("negatives").get("quotes_required")
     + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get("negatives").get("quotes_not_required"),
 )
+
 STANDARD_POSITIVES.extend(
     FOLLOWED_BY_COLON_RE.get("positives").get("quotes_required")
     + FOLLOWED_BY_COLON_RE.get("positives").get("quotes_not_required")


### PR DESCRIPTION
Support for string assignments in golang, currently detect secrets will catch:
```
password = ewijeiwbf98th9u4bgi4ub49uigbigj
password:ewijeiwbf98th9u4bgi4ub49uigbigj
```
but golang short assignments, support doing

```
password := "ewijeiwbf98th9u4bgi4ub49uigbigj"
```