### PR TITLE
Catches artifactory secrets after colon

### DIFF
--- a/detect_secrets/plugins/artifactory.py
+++ b/detect_secrets/plugins/artifactory.py
@@ -11,7 +11,7 @@ class ArtifactoryDetector(RegexBasedDetector):
 
     blacklist = [
         # artifactory tokens begin with AKC
-        re.compile(r'(\s|=|"|^)AKC\w{10,}'),    # api token
+        re.compile(r'(\s|=|:|"|^)AKC\w{10,}'),    # api token
         # artifactory encrypted passwords begin with AP6
-        re.compile(r'(\s|=|"|^)AP6\w{10,}'),    # password
+        re.compile(r'(\s|=|:|"|^)AP6\w{10,}'),    # password
     ]

--- a/tests/plugins/artifactory_test.py
+++ b/tests/plugins/artifactory_test.py
@@ -18,6 +18,8 @@ class TestArtifactoryDetector(object):
             ('=AKCxxxxxxxxxx', True),
             ('\"AP6xxxxxxxxxx\"', True),
             ('\"AKCxxxxxxxxxx\"', True),
+            ('artif-key:AP6xxxxxxxxxx', True),
+            ('artif-key:AKCxxxxxxxxxx', True),
             ('X-JFrog-Art-Api: AKCxxxxxxxxxx', True),
             ('X-JFrog-Art-Api: AP6xxxxxxxxxx', True),
             ('artifactoryx:_password=AKCxxxxxxxxxx', True),


### PR DESCRIPTION
Follow up of #157. Adds feature to catch an artifactory secret after a colon, such as in a yaml file context.