### PR TITLE
Add Stripe detector to plugins

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -295,6 +295,11 @@ class PluginOptions(object):
             disable_flag_text='--no-artifactory-scan',
             disable_help_text='Disable scanning for Artifactory credentials',
         ),
+        PluginDescriptor(
+            classname='StripeDetector',
+            disable_flag_text='--no-stripe-scan',
+            disable_help_text='Disable scanning for Stripe keys',
+        ),
     ]
 
     def __init__(self, parser):

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -13,7 +13,7 @@ from ..high_entropy_strings import HexHighEntropyString     # noqa: F401
 from ..keyword import KeywordDetector                       # noqa: F401
 from ..private_key import PrivateKeyDetector                # noqa: F401
 from ..slack import SlackDetector                           # noqa: F401
-from ..stripe import StripeDetector                          # noqa: F401
+from ..stripe import StripeDetector                         # noqa: F401
 from detect_secrets.core.log import log
 from detect_secrets.core.usage import PluginOptions
 

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -13,6 +13,7 @@ from ..high_entropy_strings import HexHighEntropyString     # noqa: F401
 from ..keyword import KeywordDetector                       # noqa: F401
 from ..private_key import PrivateKeyDetector                # noqa: F401
 from ..slack import SlackDetector                           # noqa: F401
+from ..stripe import StripeDetector                          # noqa: F401
 from detect_secrets.core.log import log
 from detect_secrets.core.usage import PluginOptions
 

--- a/detect_secrets/plugins/stripe.py
+++ b/detect_secrets/plugins/stripe.py
@@ -13,6 +13,6 @@ class StripeDetector(RegexBasedDetector):
     secret_type = 'Stripe Access Key'
 
     blacklist = (
-            # stripe standard keys begin with sk_live and restricted with rk_live
-            re.compile(r'(r|s)k_live_[0-9a-zA-Z]{24}'),
+        # stripe standard keys begin with sk_live and restricted with rk_live
+        re.compile(r'(r|s)k_live_[0-9a-zA-Z]{24}'),
     )

--- a/detect_secrets/plugins/stripe.py
+++ b/detect_secrets/plugins/stripe.py
@@ -1,0 +1,18 @@
+"""
+This plugin searches for Stripe keys
+"""
+from __future__ import absolute_import
+
+import re
+
+from .base import RegexBasedDetector
+
+
+class StripeDetector(RegexBasedDetector):
+
+    secret_type = 'Stripe Access Key'
+
+    blacklist = (
+            # stripe standard keys begin with sk_live and restricted with rk_live
+            re.compile(r'(r|s)k_live_[0-9a-zA-Z]{24}'),
+    )

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -40,6 +40,7 @@ class TestPluginOptions(object):
             'AWSKeyDetector': {},
             'SlackDetector': {},
             'ArtifactoryDetector': {},
+            'StripeDetector': {},
         }
         assert not hasattr(args, 'no_private_key_scan')
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -96,6 +96,7 @@ class TestMain(object):
                 KeywordDetector        : False
                 PrivateKeyDetector     : False
                 SlackDetector          : False
+                StripeDetector         : False
             """.format(
                 expected_base64_result,
                 expected_hex_result,
@@ -119,6 +120,7 @@ class TestMain(object):
                 KeywordDetector        : False
                 PrivateKeyDetector     : False
                 SlackDetector          : False
+                StripeDetector         : False
             """)[1:]
 
     def test_scan_with_all_files_flag(self, mock_baseline_initialize):
@@ -257,6 +259,9 @@ class TestMain(object):
                     {
                         "name": "SlackDetector",
                     },
+                    {
+                        "name": "StripeDetector",
+                    },
                 ],
             ),
             (  # remove some plugins from all plugins
@@ -287,6 +292,9 @@ class TestMain(object):
                     },
                     {
                         "name": "SlackDetector",
+                    },
+                    {
+                        "name": "StripeDetector",
                     },
                 ],
             ),
@@ -375,6 +383,9 @@ class TestMain(object):
                     {
                         "name": "SlackDetector",
                     },
+                    {
+                        "name": "StripeDetector",
+                    },
                 ],
             ),
             (  # use plugin limit from baseline when using --use-all-plugins and no input limit
@@ -407,6 +418,9 @@ class TestMain(object):
                     },
                     {
                         "name": "SlackDetector",
+                    },
+                    {
+                        "name": "StripeDetector",
                     },
                 ],
             ),

--- a/tests/plugins/stripe_key_test.py
+++ b/tests/plugins/stripe_key_test.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pytest
+
+from detect_secrets.plugins.stripe import StripeDetector
+from testing.mocks import mock_file_object
+
+
+class TestAWSKeyDetector(object):
+
+    @pytest.mark.parametrize(
+        'file_content,should_flag',
+        [
+            (
+                'sk_live_ReTllpYQYfIZu2Jnf2lAPFjD',
+                True,
+            ),
+            (
+                'rk_live_5TcWfjKmJgpql9hjpRnwRXbT',
+                True,
+            ),
+            (
+                'pk_live_j5krY8XTgIcDaHDb3YrsAfCl',
+                False,
+            ),
+            (
+                'sk_live_',
+                False,
+            ),
+        ],
+    )
+    def test_analyze(self, file_content, should_flag):
+        logic = StripeDetector()
+
+        f = mock_file_object(file_content)
+        output = logic.analyze(f, 'mock_filename')
+        assert len(output) == (1 if should_flag else 0)
+        for potential_secret in output:
+            assert 'mock_filename' == potential_secret.filename

--- a/tests/plugins/stripe_key_test.py
+++ b/tests/plugins/stripe_key_test.py
@@ -7,7 +7,7 @@ from detect_secrets.plugins.stripe import StripeDetector
 from testing.mocks import mock_file_object
 
 
-class TestAWSKeyDetector(object):
+class TestStripeKeyDetector(object):
 
     @pytest.mark.parametrize(
         'file_content,should_flag',

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -194,6 +194,9 @@ class TestPreCommitHook(object):
                 {
                     'name': 'SlackDetector',
                 },
+                {
+                    'name': 'StripeDetector',
+                },
             ]
 
     def test_writes_new_baseline_if_modified(self):


### PR DESCRIPTION
Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>
From paper cited on #159. Supports both standard and restricted keys.
