### PR TITLE
Add performance benchmark

### DIFF
--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -115,6 +115,7 @@ def _perform_scan(args, plugins):
 
     :rtype: dict
     """
+
     old_baseline = _get_existing_baseline(args.import_filename)
     if old_baseline:
         plugins = initialize.merge_plugin_from_baseline(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 coverage
 flake8==3.5.0
 mock
+monotonic
 pre-commit==1.11.2
 pytest
 pyyaml

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+import argparse
+import subprocess
+
+from monotonic import monotonic
+
+from detect_secrets.core.usage import PluginOptions
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser(description='Run some benchmarks.')
+    parser.add_argument(
+        'rest_args',
+        nargs=argparse.REMAINDER,
+        help='filenames to check or detect-secrets compatible arguments',
+    )
+    args = parser.parse_args()
+    return ['../.'] if len(args.rest_args) == 0 else args.rest_args
+
+
+def run_bench(flags, arguments):
+    start_time = monotonic()
+    subprocess.check_output('detect-secrets scan'.split() + arguments + flags)
+    return monotonic() - start_time
+
+
+def print_line(name, time):
+    print('{:<20s}{:>20s}s'.format(name, str(time)))
+
+
+def main():
+    flag_list = list()
+    additional_arguments = get_arguments()
+
+    # Fill flags list with PluginOptions flag text
+    for flag_number, flag in enumerate(PluginOptions.all_plugins):
+        flag_list.append(flag.disable_flag_text)
+
+    # Run bechmarks for all the cases
+    for flag_number, flag in enumerate(flag_list):
+        temp = list(flag_list)
+        temp.pop(flag_number)
+        if flag_number == 0:
+            print('Scanning: ' + str(additional_arguments))
+            print('-' * 42)
+            print('{:<20s}{:>20s}'.format('benchmark', 'time'))
+            print('-' * 42)
+            print_line('all-plugins', run_bench([], additional_arguments))
+        print_line(flag[len('--no-'):], run_bench(temp, additional_arguments))
+
+
+main()


### PR DESCRIPTION
Signed-off-by: Daniel González Lopes <danielgonzalezlopes@gmail.com>

Added performance benchmark for the scan stage as said on #130. Is the startTimeMeasurement() on the proper place?

On the other side, I had to use an external monotonic [[0](https://github.com/atdt/monotonic)] package as monotonic it's only avaliable on Python 3.3+ [[1](https://docs.python.org/3/library/time.html)].

[[0](https://github.com/atdt/monotonic)] https://github.com/atdt/monotonic
[[1](https://docs.python.org/3/library/time.html)] https://docs.python.org/3/library/time.html