### PR TITLE
Support scanning multiple git repositories in one invocation

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -5,8 +5,10 @@ import os
 import re
 import subprocess
 
+from detect_secrets import util
 from detect_secrets.core.log import get_logger
 from detect_secrets.core.secrets_collection import SecretsCollection
+
 
 log = get_logger(format_string='%(message)s')
 
@@ -37,13 +39,15 @@ def initialize(
         exclude_lines=exclude_lines_regex,
     )
 
-    files_to_scan = list()
+    files_to_scan = []
     for element in path:
         if os.path.isdir(element):
             if scan_all_files:
                 files_to_scan.extend(_get_files_recursively(element))
             else:
-                files_to_scan.extend(_get_git_tracked_files(element))
+                files = _get_git_tracked_files(element)
+                if files:
+                    files_to_scan.extend(files)
         elif os.path.isfile(element):
             files_to_scan.append(element)
         else:
@@ -268,13 +272,16 @@ def _get_git_tracked_files(rootdir='.'):
             git_files = subprocess.check_output(
                 [
                     'git',
+                    '-C', rootdir,
                     'ls-files',
-                    rootdir,
                 ],
                 stderr=fnull,
             )
 
-        return set(git_files.decode('utf-8').split())
+        return set([
+            util.get_relative_path(rootdir, filename)
+            for filename in git_files.decode('utf-8').split()
+        ])
     except subprocess.CalledProcessError:
         return None
 
@@ -284,8 +291,8 @@ def _get_files_recursively(rootdir):
     This function allows us to do so.
     """
     output = []
-    for root, dirs, files in os.walk(rootdir):
+    for root, _, files in os.walk(rootdir):
         for filename in files:
-            output.append(os.path.join(root, filename))
+            output.append(util.get_relative_path(root, filename))
 
     return output

--- a/detect_secrets/util.py
+++ b/detect_secrets/util.py
@@ -8,3 +8,10 @@ def get_root_directory():
             '../',
         ),
     )
+
+
+def get_relative_path(root, path):
+    """Returns relative path, after following symlinks."""
+    return os.path.realpath(
+        os.path.join(root, path),
+    )[len(os.getcwd() + '/'):]


### PR DESCRIPTION
### Description

With the changes made in https://github.com/Yelp/detect-secrets/pull/188, this supports scanning for multiple git repositories at once.

There are several benefits to this:

1. With this, you can generate one giant baseline for all repositories that you track. This is especially handy for plugin development, when you want to compare baselines across multiple repositories.

2. Scanning multiple repositories, without needing to scan *every* file (with `--all-files` flag).

I also threw in a bug fix to ignore files, if no git tracked files are found.

### Example

```
~ $ git status
fatal: Not a git repository (or any parent up to mount point /home/aaronloo)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
~ $ detect-secrets scan detect-secrets/test_data detect-secrets-server
{
  "exclude": {
    "files": null,
    "lines": null
  },
  "generated_at": "2019-06-15T02:59:26Z",
  "plugins_used": [...],
  "results": {
    "detect-secrets-server/README.md": [
      {
        "hashed_secret": "cdd5f4b553c63f87de1a4fce14f1ad8fa2a1d1f6",
        "line_number": 191,
        "type": "Hex High Entropy String"
      }
    ],
    ...
    "detect-secrets/test_data/config.env": [
      {
        "hashed_secret": "513e0a36963ae1e8431c041b744679ee578b7c44",
        "line_number": 1,
        "type": "Base64 High Entropy String"
      }
    ]
}
```