### PR TITLE
Verifiable secrets scaffolding

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -16,7 +16,7 @@ def initialize(
     plugins,
     exclude_files_regex=None,
     exclude_lines_regex=None,
-    scan_all_files=False,
+    should_scan_all_files=False,
 ):
     """Scans the entire codebase for secrets, and returns a
     SecretsCollection object.
@@ -27,7 +27,7 @@ def initialize(
     :type exclude_files_regex: str|None
     :type exclude_lines_regex: str|None
     :type path: list
-    :type scan_all_files: bool
+    :type should_scan_all_files: bool
 
     :rtype: SecretsCollection
     """
@@ -40,7 +40,7 @@ def initialize(
     files_to_scan = list()
     for element in path:
         if os.path.isdir(element):
-            if scan_all_files:
+            if should_scan_all_files:
                 files_to_scan.extend(_get_files_recursively(element))
             else:
                 files_to_scan.extend(_get_git_tracked_files(element))

--- a/detect_secrets/core/constants.py
+++ b/detect_secrets/core/constants.py
@@ -1,3 +1,6 @@
+from enum import Enum
+
+
 # We don't scan files with these extensions.
 # NOTE: We might be able to do this better with
 #       `subprocess.check_output(['file', filename])`
@@ -26,3 +29,9 @@ IGNORED_FILE_EXTENSIONS = {
     'webp',
     'zip',
 }
+
+
+class VerifiedResult(Enum):
+    UNVERIFIED = 1
+    VERIFIED_FALSE = 2
+    VERIFIED_TRUE = 3

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -40,12 +40,26 @@ class PotentialSecret(object):
 
         :type is_secret: bool|None
         :param is_secret: whether or not the secret is a true- or false- positive
+
+        :type is_verified: bool
+        :param is_verified: whether the secret has been externally verified
         """
         self.type = typ
         self.filename = filename
         self.lineno = lineno
         self.secret_hash = self.hash_secret(secret)
         self.is_secret = is_secret
+        self.is_verified = False
+
+        # NOTE: Originally, we never wanted to keep the secret value in memory,
+        #       after finding it in the codebase. However, to support verifiable
+        #       secrets (and avoid the pain of re-scanning again), we need to
+        #       keep the plaintext in memory as such.
+        #
+        #       This value should never appear in the baseline though, seeing that
+        #       we don't want to create a file that contains all plaintext secrets
+        #       in the repository.
+        self.secret_value = secret
 
         # If two PotentialSecrets have the same values for these fields,
         # they are considered equal. Note that line numbers aren't included
@@ -69,6 +83,7 @@ class PotentialSecret(object):
             'filename': self.filename,
             'line_number': self.lineno,
             'hashed_secret': self.secret_hash,
+            'is_verified': self.is_verified,
         }
 
         if self.is_secret is not None:

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -92,11 +92,14 @@ class SecretsCollection(object):
         plugins = []
         for plugin in data['plugins_used']:
             plugin_classname = plugin.pop('name')
-            plugins.append(initialize.from_plugin_classname(
-                plugin_classname,
-                exclude_lines_regex=result.exclude_lines,
-                **plugin
-            ))
+            plugins.append(
+                initialize.from_plugin_classname(
+                    plugin_classname,
+                    exclude_lines_regex=result.exclude_lines,
+                    should_verify_secrets=False,
+                    **plugin
+                ),
+            )
         result.plugins = tuple(plugins)
 
         for filename in data['results']:

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -22,6 +22,15 @@ def add_use_all_plugins_argument(parser):
     )
 
 
+def add_no_verify_flag(parser):
+    parser.add_argument(
+        '-n',
+        '--no-verify',
+        action='store_true',
+        help='Disables additional verification of secrets via network call.',
+    )
+
+
 class ParserBuilder(object):
 
     def __init__(self):
@@ -37,7 +46,8 @@ class ParserBuilder(object):
         self._add_filenames_argument()\
             ._add_set_baseline_argument()\
             ._add_exclude_lines_argument()\
-            ._add_use_all_plugins_argument()
+            ._add_use_all_plugins_argument()\
+            ._add_no_verify_flag()
 
         PluginOptions(self.parser).add_arguments()
 
@@ -100,6 +110,11 @@ class ParserBuilder(object):
 
     def _add_use_all_plugins_argument(self):
         add_use_all_plugins_argument(self.parser)
+        return self
+
+    def _add_no_verify_flag(self):
+        add_no_verify_flag(self.parser)
+        return self
 
 
 class ScanOptions(object):
@@ -160,6 +175,8 @@ class ScanOptions(object):
             action='store_true',
             help='Scan all files recursively (as compared to only scanning git tracked files).',
         )
+
+        add_no_verify_flag(self.parser)
 
         return self
 

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -34,6 +34,7 @@ def main(argv=None):
         plugins = initialize.from_parser_builder(
             args.plugins,
             exclude_lines_regex=args.exclude_lines,
+            should_verify_secrets=not args.no_verify,
         )
         if args.string:
             line = args.string
@@ -115,7 +116,6 @@ def _perform_scan(args, plugins):
 
     :rtype: dict
     """
-
     old_baseline = _get_existing_baseline(args.import_filename)
     if old_baseline:
         plugins = initialize.merge_plugin_from_baseline(
@@ -144,7 +144,7 @@ def _perform_scan(args, plugins):
         exclude_files_regex=args.exclude_files,
         exclude_lines_regex=args.exclude_lines,
         path=args.path,
-        scan_all_files=args.all_files,
+        should_scan_all_files=args.all_files,
     ).format_for_baseline_output()
 
     if old_baseline:

--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -3,9 +3,17 @@ This plugin searches for AWS key IDs
 """
 from __future__ import absolute_import
 
+import hashlib
+import hmac
 import re
+import string
+import textwrap
+from datetime import datetime
+
+import requests
 
 from .base import RegexBasedDetector
+from detect_secrets.core.constants import VerifiedResult
 
 
 class AWSKeyDetector(RegexBasedDetector):
@@ -15,3 +23,161 @@ class AWSKeyDetector(RegexBasedDetector):
     denylist = (
         re.compile(r'AKIA[0-9A-Z]{16}'),
     )
+
+    def verify(self, token, content):
+        secret_access_key = get_secret_access_key(content)
+        if not secret_access_key:
+            return VerifiedResult.UNVERIFIED
+
+        for candidate in secret_access_key:
+            if verify_aws_secret_access_key(token, candidate):
+                return VerifiedResult.VERIFIED_TRUE
+
+        return VerifiedResult.VERIFIED_FALSE
+
+
+def get_secret_access_key(content):
+    # AWS secret access keys are 40 characters long.
+    regex = re.compile(
+        r'= *([\'"]?)([%s]{40})(\1)$' % (
+            string.ascii_letters + string.digits + '+/='
+        ),
+    )
+
+    return [
+        match[1]
+        for line in content.splitlines()
+        for match in regex.findall(line)
+    ]
+
+
+def verify_aws_secret_access_key(key, secret):
+    """
+    Using requests, because we don't want to require boto3 for this one
+    optional verification step.
+
+    Loosely based off:
+    https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
+
+    :type key: str
+    :type secret: str
+    """
+    now = datetime.utcnow()
+    amazon_datetime = now.strftime('%Y%m%dT%H%M%SZ')
+
+    headers = {
+        # This is a required header for the signing process
+        'Host': 'sts.amazonaws.com',
+        'X-Amz-Date': amazon_datetime,
+    }
+    body = {
+        'Action': 'GetCallerIdentity',
+        'Version': '2011-06-15',
+    }
+
+    # Step #1: Canonical Request
+    signed_headers = ';'.join(
+        map(
+            lambda x: x.lower(),
+            headers.keys(),
+        ),
+    )
+    canonical_request = textwrap.dedent("""
+        POST
+        /
+
+        {headers}
+        {signed_headers}
+        {hashed_payload}
+    """)[1:-1].format(
+
+        headers='\n'.join([
+            '{}:{}'.format(key.lower(), value)
+            for key, value in headers.items()
+        ]),
+        signed_headers=signed_headers,
+
+        # Poor man's method, but works for this use case.
+        hashed_payload=hashlib.sha256(
+            '&'.join([
+                '{}={}'.format(key, value)
+                for key, value in body.items()
+            ]).encode('utf-8'),
+        ).hexdigest(),
+    )
+
+    # Step #2: String to Sign
+    region = 'us-east-1'
+    scope = '{request_date}/{region}/sts/aws4_request'.format(
+        request_date=now.strftime('%Y%m%d'),
+
+        # STS is a global service; this is just for latency control.
+        region=region,
+    )
+
+    string_to_sign = textwrap.dedent("""
+        AWS4-HMAC-SHA256
+        {request_datetime}
+        {scope}
+        {hashed_canonical_request}
+    """)[1:-1].format(
+        request_datetime=amazon_datetime,
+        scope=scope,
+        hashed_canonical_request=hashlib.sha256(
+            canonical_request.encode('utf-8'),
+        ).hexdigest(),
+    )
+
+    # Step #3: Calculate signature
+    signing_key = _sign(
+        _sign(
+            _sign(
+                _sign(
+                    'AWS4{}'.format(secret).encode('utf-8'),
+                    now.strftime('%Y%m%d'),
+                ),
+                region,
+            ),
+            'sts',
+        ),
+        'aws4_request',
+    )
+
+    signature = _sign(
+        signing_key,
+        string_to_sign,
+        hex=True,
+    )
+
+    # Step #4: Add to request headers
+    headers['Authorization'] = (
+        'AWS4-HMAC-SHA256 '
+        'Credential={access_key}/{scope}, '
+        'SignedHeaders={signed_headers}, '
+        'Signature={signature}'
+    ).format(
+        access_key=key,
+        scope=scope,
+        signed_headers=signed_headers,
+        signature=signature,
+    )
+
+    # Step #5: Finally send the request
+    response = requests.post(
+        'https://sts.amazonaws.com',
+        headers=headers,
+        data=body,
+    )
+
+    if response.status_code == 403:
+        return False
+
+    return True
+
+
+def _sign(key, message, hex=False):
+    value = hmac.new(key, message.encode('utf-8'), hashlib.sha256)
+    if not hex:
+        return value.digest()
+
+    return value.hexdigest()

--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -87,6 +87,7 @@ def verify_aws_secret_access_key(key, secret):  # pragma: no cover
         /
 
         {headers}
+
         {signed_headers}
         {hashed_payload}
     """)[1:-1].format(

--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -51,7 +51,7 @@ def get_secret_access_key(content):
     ]
 
 
-def verify_aws_secret_access_key(key, secret):
+def verify_aws_secret_access_key(key, secret):  # pragma: no cover
     """
     Using requests, because we don't want to require boto3 for this one
     optional verification step.
@@ -92,16 +92,16 @@ def verify_aws_secret_access_key(key, secret):
     """)[1:-1].format(
 
         headers='\n'.join([
-            '{}:{}'.format(key.lower(), value)
-            for key, value in headers.items()
+            '{}:{}'.format(header.lower(), value)
+            for header, value in headers.items()
         ]),
         signed_headers=signed_headers,
 
         # Poor man's method, but works for this use case.
         hashed_payload=hashlib.sha256(
             '&'.join([
-                '{}={}'.format(key, value)
-                for key, value in body.items()
+                '{}={}'.format(header, value)
+                for header, value in body.items()
             ]).encode('utf-8'),
         ).hexdigest(),
     )
@@ -175,7 +175,7 @@ def verify_aws_secret_access_key(key, secret):
     return True
 
 
-def _sign(key, message, hex=False):
+def _sign(key, message, hex=False):   # pragma: no cover
     value = hmac.new(key, message.encode('utf-8'), hashlib.sha256)
     if not hex:
         return value.digest()

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -3,9 +3,20 @@ from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
 
+from detect_secrets.core.code_snippet import CodeSnippetHighlighter
 from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.common.constants import ALLOWLIST_REGEXES
+
+
+# NOTE: In this whitepaper (Section V-D), it suggests that there's an
+#       80% chance of finding a multi-factor secret (e.g. username +
+#       password) within five lines of context, before and after a secret.
+#
+#       This number can be tweaked if desired, at the cost of performance.
+#
+#       https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf
+LINES_OF_CONTEXT = 5
 
 
 class BasePlugin(object):
@@ -47,7 +58,13 @@ class BasePlugin(object):
 
             filtered_results = {}
             for result in results:
-                is_verified = self.verify(result.secret_value)
+                snippet = CodeSnippetHighlighter().get_code_snippet(
+                    filename,
+                    result.lineno,
+                    lines_of_context=LINES_OF_CONTEXT,
+                )
+
+                is_verified = self.verify(result.secret_value, content=str(snippet))
                 if is_verified != VerifiedResult.UNVERIFIED:
                     result.is_verified = True
 
@@ -150,13 +167,16 @@ class BasePlugin(object):
 
         return output[verified_result]
 
-    def verify(self, token):
+    def verify(self, token, content=''):
         """
         To increase accuracy and reduce false positives, plugins can also
         optionally declare a method to verify their status.
 
         :type token: str
         :param token: secret found by current plugin
+
+        :type context: str
+        :param context: lines of context around identified secret
 
         :rtype: VerifiedResult
         """

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -26,10 +26,12 @@ class BasePlugin(object):
 
     secret_type = None
 
-    def __init__(self, exclude_lines_regex=None, should_verify=True, **kwargs):
+    def __init__(self, exclude_lines_regex=None, should_verify=False, **kwargs):
         """
         :type exclude_lines_regex: str|None
         :param exclude_lines_regex: optional regex for ignored lines.
+
+        :type should_verify: bool
         """
         if not self.secret_type:
             raise ValueError('Plugins need to declare a secret_type.')

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -3,6 +3,7 @@ from abc import ABCMeta
 from abc import abstractmethod
 from abc import abstractproperty
 
+from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.common.constants import ALLOWLIST_REGEXES
 
@@ -14,7 +15,7 @@ class BasePlugin(object):
 
     secret_type = None
 
-    def __init__(self, exclude_lines_regex=None, **kwargs):
+    def __init__(self, exclude_lines_regex=None, should_verify=True, **kwargs):
         """
         :type exclude_lines_regex: str|None
         :param exclude_lines_regex: optional regex for ignored lines.
@@ -24,9 +25,9 @@ class BasePlugin(object):
 
         self.exclude_lines_regex = None
         if exclude_lines_regex:
-            self.exclude_lines_regex = re.compile(
-                exclude_lines_regex,
-            )
+            self.exclude_lines_regex = re.compile(exclude_lines_regex)
+
+        self.should_verify = should_verify
 
     def analyze(self, file, filename):
         """
@@ -39,8 +40,21 @@ class BasePlugin(object):
         """
         potential_secrets = {}
         for line_num, line in enumerate(file.readlines(), start=1):
-            secrets = self.analyze_string(line, line_num, filename)
-            potential_secrets.update(secrets)
+            results = self.analyze_string(line, line_num, filename)
+            if not self.should_verify:
+                potential_secrets.update(results)
+                continue
+
+            filtered_results = {}
+            for result in results:
+                is_verified = self.verify(result.secret_value)
+                if is_verified != VerifiedResult.UNVERIFIED:
+                    result.is_verified = True
+
+                if is_verified != VerifiedResult.VERIFIED_FALSE:
+                    filtered_results[result] = result
+
+            potential_secrets.update(filtered_results)
 
         return potential_secrets
 
@@ -117,8 +131,36 @@ class BasePlugin(object):
         results = self.analyze_string(string, 0, 'does_not_matter')
         if not results:
             return 'False'
-        else:
+
+        if not self.should_verify:
             return 'True'
+
+        verified_result = VerifiedResult.UNVERIFIED
+        for result in results:
+            is_verified = self.verify(result.secret_value)
+            if is_verified != VerifiedResult.UNVERIFIED:
+                verified_result = is_verified
+                break
+
+        output = {
+            VerifiedResult.VERIFIED_FALSE: 'False (verified)',
+            VerifiedResult.VERIFIED_TRUE: 'True  (verified)',
+            VerifiedResult.UNVERIFIED: 'True  (unverified)',
+        }
+
+        return output[verified_result]
+
+    def verify(self, token):
+        """
+        To increase accuracy and reduce false positives, plugins can also
+        optionally declare a method to verify their status.
+
+        :type token: str
+        :param token: secret found by current plugin
+
+        :rtype: VerifiedResult
+        """
+        return VerifiedResult.UNVERIFIED
 
     @property
     def __dict__(self):

--- a/detect_secrets/plugins/slack.py
+++ b/detect_secrets/plugins/slack.py
@@ -19,7 +19,7 @@ class SlackDetector(RegexBasedDetector):
         re.compile(r'xox(?:a|b|p|o|s|r)-(?:\d+-)+[a-z0-9]+', flags=re.IGNORECASE),
     )
 
-    def verify(self, token, **kwargs):
+    def verify(self, token, **kwargs):    # pragma: no cover
         response = requests.post(
             'https://slack.com/api/auth.test',
             data={

--- a/detect_secrets/plugins/slack.py
+++ b/detect_secrets/plugins/slack.py
@@ -5,7 +5,10 @@ from __future__ import absolute_import
 
 import re
 
+import requests
+
 from .base import RegexBasedDetector
+from detect_secrets.core.constants import VerifiedResult
 
 
 class SlackDetector(RegexBasedDetector):
@@ -15,3 +18,14 @@ class SlackDetector(RegexBasedDetector):
     denylist = (
         re.compile(r'xox(?:a|b|p|o|s|r)-(?:\d+-)+[a-z0-9]+', flags=re.IGNORECASE),
     )
+
+    def verify(self, token, **kwargs):
+        response = requests.post(
+            'https://slack.com/api/auth.test',
+            data={
+                'token': token,
+            },
+        ).json()
+
+        return VerifiedResult.VERIFIED_TRUE if response['ok'] \
+            else VerifiedResult.VERIFIED_FALSE

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -39,6 +39,7 @@ def main(argv=None):
     plugins = initialize.from_parser_builder(
         args.plugins,
         exclude_lines_regex=args.exclude_lines,
+        should_verify_secrets=not args.no_verify,
     )
 
     # Merge plugin from baseline

--- a/detect_secrets/util.py
+++ b/detect_secrets/util.py
@@ -1,7 +1,7 @@
 import os
 
 
-def get_root_directory():
+def get_root_directory():       # pragma: no cover
     return os.path.realpath(
         os.path.join(
             os.path.dirname(__file__),

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     keywords=['secret-management', 'pre-commit', 'security', 'entropy-checks'],
     install_requires=[
         'pyyaml',
+        'requests',
     ],
     extras_require={
         ':python_version=="2.7"': [

--- a/test_data/each_secret.py
+++ b/test_data/each_secret.py
@@ -3,3 +3,6 @@ red_herring = 'DEADBEEF'
 base64_secret = 'c2VjcmV0IG1lc3NhZ2Ugc28geW91J2xsIG5ldmVyIGd1ZXNzIG15IHBhc3N3b3Jk'
 hex_secret = '8b1118b376c313ed420e5133ba91307817ed52c2'
 basic_auth = 'http://username:whywouldyouusehttpforpasswords@example.com'
+
+aws_access_key = 'AKIAIOSFODNN7EXAMPLE'
+aws_secret_access_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/testing/factories.py
+++ b/testing/factories.py
@@ -28,6 +28,10 @@ def secrets_collection_factory(secrets=None, plugins=(), exclude_files_regex=Non
     )
 
     if plugins:
+        for plugin in plugins:
+            # We don't want to incur network calls during test cases
+            plugin.should_verify = False
+
         collection.plugins = plugins
 
     # Handle secrets

--- a/tests/core/baseline_test.py
+++ b/tests/core/baseline_test.py
@@ -39,7 +39,7 @@ class TestInitializeBaseline(object):
             path,
             self.plugins,
             exclude_files_regex=exclude_files_regex,
-            scan_all_files=scan_all_files,
+            should_scan_all_files=scan_all_files,
         ).json()
 
     @pytest.mark.parametrize(
@@ -126,7 +126,10 @@ class TestInitializeBaseline(object):
         assert len(results['will_be_mocked']) == 1
 
     def test_scan_all_files(self):
-        results = self.get_results(path=['test_data/files'], scan_all_files=True)
+        results = self.get_results(
+            path=['test_data/files'],
+            scan_all_files=True,
+        )
         assert len(results.keys()) == 2
 
 

--- a/tests/core/potential_secret_test.py
+++ b/tests/core/potential_secret_test.py
@@ -35,5 +35,10 @@ class TestPotentialSecret(object):
         assert (a != b) is not is_equal
 
     def test_secret_storage(self):
-        secret = potential_secret_factory()
+        secret = potential_secret_factory(secret='secret')
         assert secret.secret_hash != 'secret'
+
+    def test_json(self):
+        secret = potential_secret_factory(secret='blah')
+        for value in secret.json().values():
+            assert value != 'blah'

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -372,11 +372,13 @@ class TestBaselineInputOutput(object):
                     # Line numbers should be sorted, for better readability
                     {
                         'type': 'B',
+                        'is_verified': False,
                         'line_number': 2,
                         'hashed_secret': secret_hash,
                     },
                     {
                         'type': 'A',
+                        'is_verified': False,
                         'line_number': 3,
                         'hashed_secret': secret_hash,
                     },
@@ -384,6 +386,7 @@ class TestBaselineInputOutput(object):
                 'fileB': [
                     {
                         'type': 'C',
+                        'is_verified': False,
                         'line_number': 1,
                         'hashed_secret': secret_hash,
                     },

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -30,7 +30,7 @@ class TestMain(object):
             exclude_files_regex=None,
             exclude_lines_regex=None,
             path='.',
-            scan_all_files=False,
+            should_scan_all_files=False,
         )
 
     def test_scan_with_rootdir(self, mock_baseline_initialize):
@@ -42,7 +42,7 @@ class TestMain(object):
             exclude_files_regex=None,
             exclude_lines_regex=None,
             path=['test_data'],
-            scan_all_files=False,
+            should_scan_all_files=False,
         )
 
     def test_scan_with_exclude_args(self, mock_baseline_initialize):
@@ -56,7 +56,7 @@ class TestMain(object):
             exclude_files_regex='some_pattern_here',
             exclude_lines_regex='other_patt',
             path='.',
-            scan_all_files=False,
+            should_scan_all_files=False,
         )
 
     @pytest.mark.parametrize(
@@ -132,7 +132,7 @@ class TestMain(object):
             exclude_files_regex=None,
             exclude_lines_regex=None,
             path='.',
-            scan_all_files=True,
+            should_scan_all_files=True,
         )
 
     def test_reads_from_stdin(self, mock_merge_baseline):

--- a/tests/plugins/aws_key_test.py
+++ b/tests/plugins/aws_key_test.py
@@ -1,13 +1,24 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import textwrap
+
+import mock
 import pytest
 
+from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.plugins.aws import AWSKeyDetector
+from detect_secrets.plugins.aws import get_secret_access_key
 from testing.mocks import mock_file_object
 
 
+EXAMPLE_SECRET = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+
+
 class TestAWSKeyDetector(object):
+
+    def setup(self):
+        self.example_key = 'AKIAZZZZZZZZZZZZZZZZ'
 
     @pytest.mark.parametrize(
         'file_content,should_flag',
@@ -34,3 +45,101 @@ class TestAWSKeyDetector(object):
         assert len(output) == (1 if should_flag else 0)
         for potential_secret in output:
             assert 'mock_filename' == potential_secret.filename
+
+    def test_verify_no_secret(self):
+        logic = AWSKeyDetector()
+
+        assert logic.verify(self.example_key, '') == VerifiedResult.UNVERIFIED
+
+    def test_verify_valid_secret(self):
+        with mock.patch(
+            'detect_secrets.plugins.aws.verify_aws_secret_access_key',
+            return_value=True,
+        ):
+            assert AWSKeyDetector().verify(
+                self.example_key,
+                '={}'.format(EXAMPLE_SECRET),
+            ) == VerifiedResult.VERIFIED_TRUE
+
+    def test_verify_invalid_secret(self):
+        with mock.patch(
+            'detect_secrets.plugins.aws.verify_aws_secret_access_key',
+            return_value=False,
+        ):
+            assert AWSKeyDetector().verify(
+                self.example_key,
+                '={}'.format(EXAMPLE_SECRET),
+            ) == VerifiedResult.VERIFIED_FALSE
+
+    def test_verify_keep_trying_until_found_something(self):
+        data = {'count': 0}
+
+        def counter(*args, **kwargs):
+            output = data['count']
+            data['count'] += 1
+
+            return bool(output)
+
+        with mock.patch(
+            'detect_secrets.plugins.aws.verify_aws_secret_access_key',
+            counter,
+        ):
+            assert AWSKeyDetector().verify(
+                self.example_key,
+                textwrap.dedent("""
+                    false_secret = {}
+                    real_secret = {}
+                """)[1:-1].format(
+                    'TEST' * 10,
+                    EXAMPLE_SECRET,
+                ),
+            ) == VerifiedResult.VERIFIED_TRUE
+
+
+@pytest.mark.parametrize(
+    'content, expected_output',
+    (
+        # No quotes
+        (
+            textwrap.dedent("""
+                aws_secret_access_key = {}
+            """)[1:-1].format(
+                EXAMPLE_SECRET,
+            ),
+            [EXAMPLE_SECRET],
+        ),
+
+        # With quotes
+        (
+            textwrap.dedent("""
+                secret_key = "{}"
+            """)[1:-1].format(
+                EXAMPLE_SECRET,
+            ),
+            [EXAMPLE_SECRET],
+        ),
+
+        # multiple candidates
+        (
+            textwrap.dedent("""
+                base64_keyA = '{}'
+                aws_secret = '{}'
+                base64_keyB = '{}'
+            """)[1:-1].format(
+                'TEST' * 10,
+
+                EXAMPLE_SECRET,
+
+                # This should not be a candidate, because it's not exactly
+                # 40 chars long.
+                'EXAMPLE' * 7,
+            ),
+            [
+                'TEST' * 10,
+                EXAMPLE_SECRET,
+            ],
+        ),
+    ),
+)
+def test_get_secret_access_key(content, expected_output):
+    assert get_secret_access_key(content) == expected_output

--- a/tests/plugins/base_test.py
+++ b/tests/plugins/base_test.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from contextlib import contextmanager
+
+import mock
 import pytest
 
 from detect_secrets.core.constants import VerifiedResult
@@ -42,49 +45,47 @@ class TestVerify:
         ),
     )
     def test_adhoc_scan_values(self, result, output):
-        plugin = self.create_test_plugin(result)
-        assert plugin.adhoc_scan('test value') == output
+        with self.create_test_plugin(result) as plugin:
+            assert plugin.adhoc_scan('test value') == output
 
     def test_adhoc_scan_should_abide_by_no_verify_flag(self):
-        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_TRUE)
-        plugin.should_verify = False
+        with self.create_test_plugin(VerifiedResult.VERIFIED_TRUE) as plugin:
+            plugin.should_verify = False
 
         assert plugin.adhoc_scan('test value') == 'True'
 
     def test_analyze_verified_false_ignores_value(self):
-        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_FALSE)
-
-        file = mock_file_object('does not matter')
-        result = plugin.analyze(file, 'does not matter')
+        with self.create_test_plugin(VerifiedResult.VERIFIED_FALSE) as plugin:
+            file = mock_file_object('does not matter')
+            result = plugin.analyze(file, 'does not matter')
 
         assert len(result) == 0
 
     def test_analyze_verified_true_adds_intel(self):
-        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_TRUE)
-
-        file = mock_file_object('does not matter')
-        result = plugin.analyze(file, 'does not matter')
+        with self.create_test_plugin(VerifiedResult.VERIFIED_TRUE) as plugin:
+            file = mock_file_object('does not matter')
+            result = plugin.analyze(file, 'does not matter')
 
         assert list(result.keys())[0].is_verified
 
     def test_analyze_unverified_stays_the_same(self):
-        plugin = self.create_test_plugin(VerifiedResult.UNVERIFIED)
-
-        file = mock_file_object('does not matter')
-        result = plugin.analyze(file, 'does not matter')
+        with self.create_test_plugin(VerifiedResult.UNVERIFIED) as plugin:
+            file = mock_file_object('does not matter')
+            result = plugin.analyze(file, 'does not matter')
 
         assert not list(result.keys())[0].is_verified
 
     def test_analyze_should_abide_by_no_verify_flag(self):
-        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_FALSE)
-        plugin.should_verify = False
+        with self.create_test_plugin(VerifiedResult.VERIFIED_FALSE) as plugin:
+            plugin.should_verify = False
 
-        file = mock_file_object('does not matter')
-        result = plugin.analyze(file, 'does not matter')
+            file = mock_file_object('does not matter')
+            result = plugin.analyze(file, 'does not matter')
 
         # If it is verified, this value should be 0.
         assert len(result) == 1
 
+    @contextmanager
     def create_test_plugin(self, result):
         """
         :type result: VerifiedResult
@@ -104,4 +105,13 @@ class TestVerify:
             def verify(self, *args, **kwargs):
                 return result
 
-        return MockPlugin()
+        with mock.patch(
+            'detect_secrets.plugins.base.CodeSnippetHighlighter',
+            autospec=True,
+        ) as mock_snippet:
+            plugin = MockPlugin()
+            plugin.should_verify = True
+
+            mock_snippet().get_code_snippet.return_value = ''
+
+            yield plugin

--- a/tests/plugins/base_test.py
+++ b/tests/plugins/base_test.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 
 import pytest
 
+from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.plugins.base import BasePlugin
+from testing.factories import potential_secret_factory
+from testing.mocks import mock_file_object
 
 
 def test_fails_if_no_secret_type_defined():
@@ -14,5 +17,91 @@ def test_fails_if_no_secret_type_defined():
         def secret_generator(self, *args, **kwargs):
             pass
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         MockPlugin()
+
+    assert 'Plugins need to declare a secret_type.' == str(excinfo.value)
+
+
+class TestVerify:
+    @pytest.mark.parametrize(
+        'result, output',
+        (
+            (
+                VerifiedResult.UNVERIFIED,
+                'True  (unverified)',
+            ),
+            (
+                VerifiedResult.VERIFIED_FALSE,
+                'False (verified)',
+            ),
+            (
+                VerifiedResult.VERIFIED_TRUE,
+                'True  (verified)',
+            ),
+        ),
+    )
+    def test_adhoc_scan_values(self, result, output):
+        plugin = self.create_test_plugin(result)
+        assert plugin.adhoc_scan('test value') == output
+
+    def test_adhoc_scan_should_abide_by_no_verify_flag(self):
+        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_TRUE)
+        plugin.should_verify = False
+
+        assert plugin.adhoc_scan('test value') == 'True'
+
+    def test_analyze_verified_false_ignores_value(self):
+        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_FALSE)
+
+        file = mock_file_object('does not matter')
+        result = plugin.analyze(file, 'does not matter')
+
+        assert len(result) == 0
+
+    def test_analyze_verified_true_adds_intel(self):
+        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_TRUE)
+
+        file = mock_file_object('does not matter')
+        result = plugin.analyze(file, 'does not matter')
+
+        assert list(result.keys())[0].is_verified
+
+    def test_analyze_unverified_stays_the_same(self):
+        plugin = self.create_test_plugin(VerifiedResult.UNVERIFIED)
+
+        file = mock_file_object('does not matter')
+        result = plugin.analyze(file, 'does not matter')
+
+        assert not list(result.keys())[0].is_verified
+
+    def test_analyze_should_abide_by_no_verify_flag(self):
+        plugin = self.create_test_plugin(VerifiedResult.VERIFIED_FALSE)
+        plugin.should_verify = False
+
+        file = mock_file_object('does not matter')
+        result = plugin.analyze(file, 'does not matter')
+
+        # If it is verified, this value should be 0.
+        assert len(result) == 1
+
+    def create_test_plugin(self, result):
+        """
+        :type result: VerifiedResult
+        """
+        class MockPlugin(BasePlugin):  # pragma: no cover
+            secret_type = 'test_verify'
+
+            def analyze_string_content(self, *args, **kwargs):
+                secret = potential_secret_factory()
+                return {
+                    secret: secret,
+                }
+
+            def secret_generator(self, *args, **kwargs):
+                pass
+
+            def verify(self, *args, **kwargs):
+                return result
+
+        return MockPlugin()

--- a/tests/plugins/base_test.py
+++ b/tests/plugins/base_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from contextlib import contextmanager
 

--- a/tests/plugins/slack_test.py
+++ b/tests/plugins/slack_test.py
@@ -36,7 +36,7 @@ class TestSlackDetector(object):
         ],
     )
     def test_analyze(self, file_content):
-        logic = SlackDetector()
+        logic = SlackDetector(should_verify=False)
 
         f = mock_file_object(file_content)
         output = logic.analyze(f, 'mock_filename')

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -308,6 +308,7 @@ def _create_baseline_template(has_result, use_private_key_scan):
                 {
                     'type': 'Base64 High Entropy String',
                     'is_secret': True,
+                    'is_verified': False,
                     'line_number': 3,
                     'hashed_secret': PotentialSecret.hash_secret(base64_secret),
                 },


### PR DESCRIPTION
### Summary

After talking with @killuazhu (and referencing the whitepaper from https://github.com/Yelp/detect-secrets/issues/159), this seems like a completely feasible option.

This is my first take of supporting this.

I've written a Slack verifier (as an example usage for bearer secrets), and an AWS verifier (as an example usage for multi-factor secrets). Test cases were run with no network connectivity, just to make sure that test cases don't rely on network calls.

The `verify` functions are manually tested, because (obviously) we don't want to commit real secrets to have automated tests for it.

### Example Usage

```
$ cat slack_token.txt | detect-secrets scan --string
```

or

```
$ detect-secrets scan test_data/each_secret.py --no-verify
```

