### PR TITLE
Use plugin `analyze` function in audit functionality

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -10,6 +10,11 @@ from builtins import input
 from collections import defaultdict
 from copy import deepcopy
 
+try:
+    from functools import lru_cache
+except ImportError:  # pragma: no cover
+    from functools32 import lru_cache
+
 from ..plugins.common import initialize
 from ..plugins.common.filetype import determine_file_type
 from ..plugins.common.util import get_mapping_from_secret_type_to_class_name
@@ -28,8 +33,8 @@ from .potential_secret import PotentialSecret
 class SecretNotFoundOnSpecifiedLineError(Exception):
     def __init__(self, line):
         super(SecretNotFoundOnSpecifiedLineError, self).__init__(
-            'ERROR: Secret not found on line {}!\n'.format(line) +
-            'Try recreating your baseline to fix this issue.',
+            'ERROR: Secret not found on line {}!\n'.format(line)
+            + 'Try recreating your baseline to fix this issue.',
         )
 
 
@@ -529,15 +534,30 @@ def _handle_user_decision(decision, secret):
         del secret['is_secret']
 
 
+@lru_cache(maxsize=1)
+def _open_file_with_cache(filename):
+    """
+    Reads the input file and returns the result as a string.
+
+    This caches opened files to ensure that the audit functionality
+    doesn't unnecessarily re-open the same file.
+    """
+    try:
+        with codecs.open(filename, encoding='utf-8') as f:
+            return f.read()
+    except (OSError, IOError):
+        return None
+
+
 def _get_file_line(filename, line_number):
     """
     Attempts to read a given line from the input file.
     """
-    try:
-        with codecs.open(filename, encoding='utf-8') as f:
-            return f.read().splitlines()[line_number - 1]  # line numbers are 1-indexed
-    except (OSError, IOError, IndexError):
+    file_content = _open_file_with_cache(filename)
+    if not file_content:
         return None
+
+    return file_content.splitlines()[line_number - 1]
 
 
 def _get_secret_with_context(
@@ -569,13 +589,20 @@ def _get_secret_with_context(
 
     :raises: SecretNotFoundOnSpecifiedLineError
     """
-    snippet = CodeSnippetHighlighter().get_code_snippet(
-        filename,
-        secret['line_number'],
-        lines_of_context=lines_of_context,
-    )
 
     try:
+        file_content = _open_file_with_cache(filename)
+        if not file_content:
+            raise SecretNotFoundOnSpecifiedLineError(secret['line_number'])
+
+        file_lines = file_content.splitlines()
+
+        snippet = CodeSnippetHighlighter().get_code_snippet(
+            file_lines,
+            secret['line_number'],
+            lines_of_context=lines_of_context,
+        )
+
         raw_secret_value = get_raw_secret_value(
             snippet.target_line,
             secret,

--- a/detect_secrets/core/bidirectional_iterator.py
+++ b/detect_secrets/core/bidirectional_iterator.py
@@ -21,7 +21,7 @@ class BidirectionalIterator(object):
 
         return result
 
-    def next(self):
+    def next(self):  # pragma: no cover
         return self.__next__()
 
     def step_back_on_next_iteration(self):
@@ -30,5 +30,5 @@ class BidirectionalIterator(object):
     def can_step_back(self):
         return self.index > 0
 
-    def __iter__(self):
+    def __iter__(self):  # pragma: no cover
         return self

--- a/detect_secrets/core/code_snippet.py
+++ b/detect_secrets/core/code_snippet.py
@@ -45,7 +45,7 @@ class CodeSnippetHighlighter:
         )
 
 
-class CodeSnippet:
+class CodeSnippet(object):
 
     def __init__(self, snippet, start_line, target_index):
         """

--- a/detect_secrets/core/code_snippet.py
+++ b/detect_secrets/core/code_snippet.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import codecs
 import itertools
 
 from .color import AnsiColor
@@ -9,9 +8,10 @@ from .color import colorize
 
 class CodeSnippetHighlighter:
 
-    def get_code_snippet(self, filename, line_number, lines_of_context=5):
+    def get_code_snippet(self, file_lines, line_number, lines_of_context=5):
         """
-        :type filename: str
+        :type file_lines: iterable of str
+        :param file_lines: an iterator of lines in the file
 
         :type line_number: int
         :param line_number: line which you want to focus on
@@ -35,7 +35,7 @@ class CodeSnippetHighlighter:
         return CodeSnippet(
             list(
                 itertools.islice(
-                    self._get_lines_in_file(filename),
+                    file_lines,
                     start_line,
                     end_line,
                 ),
@@ -44,19 +44,12 @@ class CodeSnippetHighlighter:
             index_of_secret_in_output,
         )
 
-    def _get_lines_in_file(self, filename):
-        """
-        :rtype: list
-        """
-        with codecs.open(filename, encoding='utf-8') as file:
-            return file.read().splitlines()
-
 
 class CodeSnippet:
 
     def __init__(self, snippet, start_line, target_index):
         """
-        :type snippet: list
+        :type snippet: iterable and indexable of str
         :param snippet: lines of code extracted from file
 
         :type start_line: int

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -53,7 +53,8 @@ class BasePlugin(object):
                                detect_secrets.core.potential_secret         }
         """
         potential_secrets = {}
-        for line_num, line in enumerate(file.readlines(), start=1):
+        file_lines = tuple(file.readlines())
+        for line_num, line in enumerate(file_lines, start=1):
             results = self.analyze_string(line, line_num, filename)
             if not self.should_verify:
                 potential_secrets.update(results)
@@ -62,7 +63,7 @@ class BasePlugin(object):
             filtered_results = {}
             for result in results:
                 snippet = CodeSnippetHighlighter().get_code_snippet(
-                    filename,
+                    file_lines,
                     result.lineno,
                     lines_of_context=LINES_OF_CONTEXT,
                 )

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -203,7 +203,7 @@ class HighEntropyStringsPlugin(BasePlugin):
                 item = to_search.pop()
 
                 try:
-                    if '__line__' in item and not item['__line__'] in ignored_lines:
+                    if '__line__' in item and item['__line__'] not in ignored_lines:
                         potential_secrets.update(
                             self.analyze_string(
                                 item['__value__'],

--- a/tests/core/audit_test.py
+++ b/tests/core/audit_test.py
@@ -16,6 +16,11 @@ from testing.mocks import mock_printer as mock_printer_base
 from testing.util import uncolor
 
 
+@pytest.fixture(autouse=True)
+def reset_file_cache():
+    audit._open_file_with_cache.cache_clear()
+
+
 class TestAuditBaseline(object):
 
     def test_no_baseline(self, mock_printer):
@@ -740,7 +745,7 @@ class TestPrintContext(object):
                 string.ascii_letters[:(end_line - secret_line)][::-1],
             ),
         )
-        return mock_open_base(data, 'detect_secrets.core.code_snippet.codecs.open')
+        return mock_open_base(data, 'detect_secrets.core.audit.codecs.open')
 
     @staticmethod
     def _make_string_into_individual_lines(string):


### PR DESCRIPTION
## Old algo

The audit functionality used to use the following algorithm to get the plaintext of a secret:
(1) Take the secret type and get the right plugin `PluginA`.
(2) Take the secret file `FileA` and line number `x`.
(3) Get a list of secrets in `FileA` on line `x` using `PluginA.secret_generator()`.
(4) Return the plaintext which matches the input secret's hash, or raise if the secret isn't found.

## New algo

This PR changes the algorithm. Specifically, it replaces (3) with:

(a) Scan the whole file `FileA` for secrets using `PluginA.analyze()`.

## Benefits

The immediate motivation for this PR was #189.

This adjustment makes the `audit` functionality less flakey. Plugins can implement more specific behaviour regarding splitting lines in its `analyze` function, and this PR makes it so that we can use that information in `audit` as well, making it more likely we'll be able to rediscover the secret.

As @KevinHock also points out, this will allow `audit` to be more flexible, in that the secret can change lines, but `audit` will still find the secret.

## Why not just run `scan` over the whole codebase again?

It would be a waste of time to scan literally every file with every plugin when we have a list of `(file, plugin)` pairs which actually yielded secrets in the baseline.

This approach was also easier to code IMO.

## Why are there also random new tests?

Replacing the old algorithm resulted in less LOC in `detect_secrets/`, which reduced overall code coverage, which `make test` complained about :)

## Notes for reviewing

`get_raw_secret_value` was completely rewritten so the `Split` code-review view is a lot more useful.

Auto close tags: Fixes #189.