### PR TITLE
Use a unique exit code to identify baseline changes

### DIFF
--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -88,7 +88,7 @@ def main(argv=None):
             'Probably to keep line numbers of secrets up-to-date.\n'
             'Please `git add {}`, thank you.\n\n'.format(args.baseline[0]),
         )
-        return 1
+        return 3
 
     return 0
 

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -18,6 +18,8 @@ from testing.mocks import SubprocessMock
 def assert_commit_blocked(command):
     assert pre_commit_hook.main(command.split()) == 1
 
+def assert_commit_blocked_with_diff_exit_code(command):
+    assert pre_commit_hook.main(command.split()) == 3
 
 def assert_commit_succeeds(command):
     assert pre_commit_hook.main(command.split()) == 0
@@ -154,7 +156,7 @@ class TestPreCommitHook(object):
             ), mock.patch(
                 'detect_secrets.pre_commit_hook.write_baseline_to_file',
             ) as m:
-                assert_commit_blocked(
+                assert_commit_blocked_with_diff_exit_code(
                     '--baseline will_be_mocked --use-all-plugins' +
                     ' test_data/files/file_with_secrets.py',
                 )
@@ -210,7 +212,7 @@ class TestPreCommitHook(object):
         ), mock.patch(
             'detect_secrets.pre_commit_hook.write_baseline_to_file',
         ) as m:
-            assert_commit_blocked(
+            assert_commit_blocked_with_diff_exit_code(
                 '--baseline will_be_mocked test_data/files/file_with_secrets.py',
             )
 


### PR DESCRIPTION
Addresses the issue raised in https://github.com/Yelp/detect-secrets/issues/212 to exit with a unique exit code number so that this can be identified by scripts and programs wrapping and invoking the `detect-secrets-hook` to run specific flows.

Note: I intentionally didn't use exit code 2 since that is part of standardised error numbers such as those used for shell related errors so to avoid a conflict.