### PR TITLE
Add (b)ack audit functionality when secret not found

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -84,7 +84,10 @@ def audit_baseline(baseline_filename):
             )
             decision = _get_user_decision(can_step_back=secret_iterator.can_step_back())
         except SecretNotFoundOnSpecifiedLineError:
-            decision = _get_user_decision(prompt_secret_decision=False)
+            decision = _get_user_decision(
+                prompt_secret_decision=False,
+                can_step_back=secret_iterator.can_step_back(),
+            )
 
         if decision == 'q':
             print('Quitting...')


### PR DESCRIPTION
Small PR adding (b)ack option in audit mode to prevent the 'point of no return' when a secret isn't found.

Resolves: #204

Signed-off-by: dgzlopes <danielgonzalezlopes@gmail.com>