### PR TITLE
Add Mailchimp detector to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The current heuristic searches we implement out of the box include:
 
 * **KeywordDetector**: checks to see if certain keywords are being used e.g. `password` or `secret`
 
-* **RegexBasedDetector**: checks for any keys matching certain regular expressions (Artifactory, AWS, Slack, Stripe).
+* **RegexBasedDetector**: checks for any keys matching certain regular expressions (Artifactory, AWS, Slack, Stripe, Mailchimp).
 
 See [detect_secrets/
 plugins](https://github.com/Yelp/detect-secrets/tree/master/detect_secrets/plugins)

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -328,6 +328,11 @@ class PluginOptions(object):
             disable_flag_text='--no-stripe-scan',
             disable_help_text='Disable scanning for Stripe keys',
         ),
+        PluginDescriptor(
+            classname='MailchimpDetector',
+            disable_flag_text='--no-mailchimp-scan',
+            disable_help_text='Disable scanning for Mailchimp keys',
+        ),
     ]
 
     def __init__(self, parser):

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -7,6 +7,7 @@ from ..common.util import get_mapping_from_secret_type_to_class_name
 from ..high_entropy_strings import Base64HighEntropyString  # noqa: F401
 from ..high_entropy_strings import HexHighEntropyString     # noqa: F401
 from ..keyword import KeywordDetector                       # noqa: F401
+from ..mailchimp import MailchimpDetector                   # noqa: F401
 from ..private_key import PrivateKeyDetector                # noqa: F401
 from ..slack import SlackDetector                           # noqa: F401
 from ..stripe import StripeDetector                         # noqa: F401

--- a/detect_secrets/plugins/mailchimp.py
+++ b/detect_secrets/plugins/mailchimp.py
@@ -1,0 +1,18 @@
+"""
+This plugin searches for Mailchimp keys
+"""
+from __future__ import absolute_import
+
+import re
+
+from .base import RegexBasedDetector
+
+
+class MailchimpDetector(RegexBasedDetector):
+
+    secret_type = 'Mailchimp Access Key'
+
+    denylist = (
+        # Mailchimp key
+        re.compile(r'[0-9a-z]{32}(-us[0-9]{1,2})'),
+    )

--- a/scripts/run_performance_tests.py
+++ b/scripts/run_performance_tests.py
@@ -208,6 +208,7 @@ def generate_content(separator, length):
         'BasicAuthDetector': 'http://username:password@example.com',
         'HexHighEntropyString': '123456abcd',
         'KeywordDetector': 'api_key = foobar',
+        'MailchimpDetector': '376a2953ed38c31a43ea46e2b19257db-us2',
         'PrivateKeyDetector': 'BEGIN PRIVATE KEY',
         'SlackDetector': 'xoxb-1-test',
         'StripeDetector': 'rk_live_TESTtestTESTtestTESTtest',

--- a/test_data/performance/long-file.test.json
+++ b/test_data/performance/long-file.test.json
@@ -13,6 +13,7 @@
         "BasicAuthDetector": 1.35538,
         "HexHighEntropyString": 2.8728,
         "KeywordDetector": 2.45626,
+        "MailchimpDetector": 1.85307,
         "PrivateKeyDetector": 1.85466,
         "SlackDetector": 1.50198,
         "StripeDetector": 1.40959,

--- a/test_data/performance/long-lines.test.json
+++ b/test_data/performance/long-lines.test.json
@@ -13,6 +13,7 @@
         "BasicAuthDetector": 1.3325,
         "HexHighEntropyString": 22.31473,
         "KeywordDetector": 1.64396,
+        "MailchimpDetector": 1.45022,
         "PrivateKeyDetector": 1.35953,
         "SlackDetector": 1.41018,
         "StripeDetector": 1.49091,

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -41,6 +41,7 @@ class TestPluginOptions(object):
             'SlackDetector': {},
             'ArtifactoryDetector': {},
             'StripeDetector': {},
+            'MailchimpDetector': {},
         }
         assert not hasattr(args, 'no_private_key_scan')
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -94,6 +94,7 @@ class TestMain(object):
                 BasicAuthDetector      : False
                 HexHighEntropyString   : {}
                 KeywordDetector        : False
+                MailchimpDetector      : False
                 PrivateKeyDetector     : False
                 SlackDetector          : False
                 StripeDetector         : False
@@ -118,6 +119,7 @@ class TestMain(object):
                 BasicAuthDetector      : False
                 HexHighEntropyString   : False (2.121)
                 KeywordDetector        : False
+                MailchimpDetector      : False
                 PrivateKeyDetector     : False
                 SlackDetector          : False
                 StripeDetector         : False
@@ -254,6 +256,9 @@ class TestMain(object):
                         'name': 'KeywordDetector',
                     },
                     {
+                        'name': 'MailchimpDetector',
+                    },
+                    {
                         'name': 'PrivateKeyDetector',
                     },
                     {
@@ -289,6 +294,9 @@ class TestMain(object):
                     },
                     {
                         'name': 'KeywordDetector',
+                    },
+                    {
+                        'name': 'MailchimpDetector',
                     },
                     {
                         'name': 'SlackDetector',
@@ -378,6 +386,9 @@ class TestMain(object):
                         'name': 'BasicAuthDetector',
                     },
                     {
+                        'name': 'MailchimpDetector',
+                    },
+                    {
                         'name': 'PrivateKeyDetector',
                     },
                     {
@@ -412,6 +423,9 @@ class TestMain(object):
                     },
                     {
                         'name': 'BasicAuthDetector',
+                    },
+                    {
+                        'name': 'MailchimpDetector',
                     },
                     {
                         'name': 'PrivateKeyDetector',

--- a/tests/plugins/mailchimp_key_test.py
+++ b/tests/plugins/mailchimp_key_test.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pytest
+
+from detect_secrets.plugins.mailchimp import MailchimpDetector
+from testing.mocks import mock_file_object
+
+
+class TestMailchimpKeyDetector(object):
+
+    @pytest.mark.parametrize(
+        'file_content,should_flag',
+        [
+            (
+                '343ea45721923ed956e2b38c31db76aa-us30',
+                True,
+            ),
+            (
+                'a2937653ed38c31a43ea46e2b19257db-us2',
+                True,
+            ),
+            (
+                '3ea4572956e2b381923ed34c31db76aa-2',
+                False,
+            ),
+            (
+                'aea462953eb192d38c31a433e76257db-al32',
+                False,
+            ),
+            (
+                '9276a43e2951aa46e2b1c33ED38357DB-us2',
+                False,
+            ),
+            (
+                '3a5633e829d3c71-us2',
+                False,
+            ),
+        ],
+    )
+    def test_analyze(self, file_content, should_flag):
+        logic = MailchimpDetector()
+
+        f = mock_file_object(file_content)
+        output = logic.analyze(f, 'mock_filename')
+        assert len(output) == (1 if should_flag else 0)
+        for potential_secret in output:
+            assert 'mock_filename' == potential_secret.filename

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -193,6 +193,9 @@ class TestPreCommitHook(object):
                     'name': 'KeywordDetector',
                 },
                 {
+                    'name': 'MailchimpDetector',
+                },
+                {
                     'name': 'PrivateKeyDetector',
                 },
                 {


### PR DESCRIPTION
This PR adds Mailchimp regex-based detector to plugins. Includes tests and addition to benchmark scripts/results.

Signed-off-by: dgzlopes <danielgonzalezlopes@gmail.com>