### PR TITLE
Ignore SVG files

### DIFF
--- a/detect_secrets/core/constants.py
+++ b/detect_secrets/core/constants.py
@@ -23,6 +23,7 @@ IGNORED_FILE_EXTENSIONS = {
     'rar',
     'realm',
     's7z',
+    'svg',
     'tar',
     'tif',
     'tiff',


### PR DESCRIPTION
Internally we found that svg files can sometimes make scanning take a long time. Considering that most SVGs are machine-generated and people probably won't put secrets into SVGs in normal contexts, I think this is a reasonable addition to the ignorelist.