### PR TITLE
Handle binary values in YAML files

### DIFF
--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -47,9 +47,17 @@ class PotentialSecret(object):
         self.type = typ
         self.filename = filename
         self.lineno = lineno
-        self.secret_hash = self.hash_secret(secret)
+        self.set_secret(secret)
         self.is_secret = is_secret
         self.is_verified = False
+
+        # If two PotentialSecrets have the same values for these fields,
+        # they are considered equal. Note that line numbers aren't included
+        # in this, because line numbers are subject to change.
+        self.fields_to_compare = ['filename', 'secret_hash', 'type']
+
+    def set_secret(self, secret):
+        self.secret_hash = self.hash_secret(secret)
 
         # NOTE: Originally, we never wanted to keep the secret value in memory,
         #       after finding it in the codebase. However, to support verifiable
@@ -60,11 +68,6 @@ class PotentialSecret(object):
         #       we don't want to create a file that contains all plaintext secrets
         #       in the repository.
         self.secret_value = secret
-
-        # If two PotentialSecrets have the same values for these fields,
-        # they are considered equal. Note that line numbers aren't included
-        # in this, because line numbers are subject to change.
-        self.fields_to_compare = ['filename', 'secret_hash', 'type']
 
     @staticmethod
     def hash_secret(secret):

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -158,7 +158,7 @@ def from_plugin_classname(
     klass = globals()[plugin_classname]
 
     # Make sure the instance is a BasePlugin type, before creating it.
-    if not issubclass(klass, BasePlugin):
+    if not issubclass(klass, BasePlugin):  # pragma: no cover
         raise TypeError
 
     try:

--- a/detect_secrets/plugins/common/yaml_file_parser.py
+++ b/detect_secrets/plugins/common/yaml_file_parser.py
@@ -88,7 +88,7 @@ class YamlFileParser(object):
                     self._create_key_value_pair_for_mapping_node_value(
                         key='__value__',
                         value=value.value,
-                        tag='tag:yaml.org,2002:str',
+                        tag=value.tag,
                     ),
                     self._create_key_value_pair_for_mapping_node_value(
                         key='__line__',

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -238,7 +238,7 @@ class HighEntropyStringsPlugin(BasePlugin):
         return potential_secrets
 
     def _encode_yaml_binary_secrets(self, secrets):
-        result = {}
+        new_secrets = {}
         """The secrets dict format is
         `{PotentialSecret: PotentialSecret}`, where both key and
         value are the same object. Therefore, we can just mutate
@@ -254,9 +254,9 @@ class HighEntropyStringsPlugin(BasePlugin):
 
             potential_secret.set_secret(secret_in_yaml_format)
 
-            result[potential_secret] = potential_secret
+            new_secrets[potential_secret] = potential_secret
 
-        return result
+        return new_secrets
 
     @abstractmethod
     def decode_binary(self, bytes_object):  # pragma: no cover

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -4,11 +4,13 @@ try:
     from backports import configparser
 except ImportError:  # pragma: no cover
     import configparser
+import base64
 import math
 import os
 import re
 import string
 from abc import ABCMeta
+from abc import abstractmethod
 from contextlib import contextmanager
 
 import yaml
@@ -206,13 +208,22 @@ class HighEntropyStringsPlugin(BasePlugin):
 
                 try:
                     if '__line__' in item and item['__line__'] not in ignored_lines:
-                        potential_secrets.update(
-                            self.analyze_string(
-                                item['__value__'],
-                                item['__line__'],
-                                filename,
-                            ),
+                        # An isinstance check doesn't work in py2
+                        # so we need the __is_binary__ field.
+                        string_to_scan = self.decode_binary(item['__value__']) \
+                            if item['__is_binary__'] \
+                            else item['__value__']
+
+                        secrets = self.analyze_string(
+                            string_to_scan,
+                            item['__line__'],
+                            filename,
                         )
+
+                        if item['__is_binary__']:
+                            secrets = self._encode_yaml_binary_secrets(secrets)
+
+                        potential_secrets.update(secrets)
 
                     if '__line__' in item:
                         continue
@@ -225,6 +236,39 @@ class HighEntropyStringsPlugin(BasePlugin):
                     pass
 
         return potential_secrets
+
+    def _encode_yaml_binary_secrets(self, secrets):
+        result = {}
+        """The secrets dict format is
+        `{PotentialSecret: PotentialSecret}`, where both key and
+        value are the same object. Therefore, we can just mutate
+        the potential secret once.
+        """
+        for potential_secret in secrets.keys():
+            secret_in_yaml_format = yaml.dump(
+                self.encode_to_binary(potential_secret.secret_value),
+            ).replace(
+                '!!binary ',
+                '',
+            )
+
+            potential_secret.set_secret(secret_in_yaml_format)
+
+            result[potential_secret] = potential_secret
+
+        return result
+
+    @abstractmethod
+    def decode_binary(self, bytes_object):  # pragma: no cover
+        """Converts the bytes to a string which can be checked for
+        high entropy."""
+        pass
+
+    @abstractmethod
+    def encode_to_binary(self, string):  # pragma: no cover
+        """Converts a string (usually a high-entropy secret) to
+        binary. Usually the inverse of decode_binary."""
+        pass
 
 
 class HexHighEntropyString(HighEntropyStringsPlugin):
@@ -278,6 +322,12 @@ class HexHighEntropyString(HighEntropyStringsPlugin):
 
         return entropy
 
+    def decode_binary(self, bytes_object):
+        return bytes_object.decode('utf-8')
+
+    def encode_to_binary(self, string):
+        return string.encode('utf-8')
+
 
 class Base64HighEntropyString(HighEntropyStringsPlugin):
     """HighEntropyStringsPlugin for base64 encoded strings"""
@@ -299,3 +349,9 @@ class Base64HighEntropyString(HighEntropyStringsPlugin):
         })
 
         return output
+
+    def decode_binary(self, bytes_object):
+        return base64.b64encode(bytes_object).decode('utf-8')
+
+    def encode_to_binary(self, string):
+        return base64.b64decode(string)

--- a/test_data/config.yaml
+++ b/test_data/config.yaml
@@ -11,3 +11,5 @@ list_of_keys:
     - 234567890a
 
 test_agent::allowlisted_api_key: 'ToCynx5Se4e2PtoZxEhW7lUJcOX15c54'  # pragma: allowlist secret
+
+high_entropy_binary_secret: !!binary MjNjcnh1IDJieXJpdXYyeXJpaTJidnl1MnI4OXkyb3UwMg==

--- a/test_data/config2.yaml
+++ b/test_data/config2.yaml
@@ -1,0 +1,2 @@
+# This is yaml.dump('2b00042f7481c7b056c4b410d28f33cf'.encode('utf-8'))
+high_entropy_hex_binary_secret: !!binary MmIwMDA0MmY3NDgxYzdiMDU2YzRiNDEwZDI4ZjMzY2Y=

--- a/tests/plugins/common/yaml_file_parser_test.py
+++ b/tests/plugins/common/yaml_file_parser_test.py
@@ -27,7 +27,7 @@ class TestYamlFileParser(object):
         ['yaml_value', 'expected_value', 'expected_is_binary'],
         [
             ('string_value', 'string_value', False),
-            ('!!binary YWJjZGVm', 'YWJjZGVm', True),
+            ('!!binary YWJjZGVm', b'abcdef', True),
         ],
     )
     def test_possible_secret_format(


### PR DESCRIPTION
(WIP as of writing)

This is step (1) in supporting binary in both YAML and non-YAML files.

This makes it so that instead of immediately converting the base64-encoded binary into a binary value in python, we just interpret the binary as a normal string, but annotate it as such with the `is_binary` flag.

This is needed so that plugins can scan a different value from the value hashed into baselines.

**Alternatives**:
* Convert the binary to the desired form discussed [here](https://github.com/Yelp/detect-secrets/issues/202#issuecomment-521033056) in `YamlFileParser` and put the desired form into `__value__`
    * Why not?: We need the original base64-format in the plugin to hash into baselines. It's possible to retrieve it, but why do extra work?
* Instead of `__value__` and `__is_binary__`, have fields `__scan_value__` and `__plaintext_value__`
    * Why not?: I think we're going to end up with a new method in the high-entropy plugin `analyze_binary_content` (in addition to [`analyze_string_content`](https://github.com/Yelp/detect-secrets/blob/master/detect_secrets/plugins/high_entropy_strings.py#L89)) which knows how to do the conversion to the "desired format", but that depends on us knowing that the string is a binary as opposed to some other special sauce, so I think the `is_binary` information is important.
    * Also my gut feeling says what I've written will be fine; I don't think there's any other data types we'll need to consider.

Closes #202

------

The next steps would be to make the high-entropy plugin actually use the `is_binary` information to do the conversion and output results correctly.