### PR TITLE
Don't crash audit when highlighter fails in audit

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -614,7 +614,10 @@ def _get_secret_with_context(
             filename,
         )
 
-        snippet.highlight_line(raw_secret_value)
+        try:
+            snippet.highlight_line(raw_secret_value)
+        except ValueError:
+            raise SecretNotFoundOnSpecifiedLineError(secret['line_number'])
     except SecretNotFoundOnSpecifiedLineError:
         if not force:
             raise

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -141,7 +141,7 @@ def raise_exception_if_baseline_file_is_unstaged(filename):
                 '--name-only',
             ],
         ).split()
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError:  # pragma: no cover
         # Since we don't pipe stderr, we get free logging through git.
         raise ValueError
 


### PR DESCRIPTION
Manually verified that YAML multiline secrets will just display the `ERROR: Secret not found on line X! Try recreating your baseline to fix this issue.` instead of crashing the program completely.

Addresses #227