### PR TITLE
JWT Detector Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ The current heuristic searches we implement out of the box include:
 
 * **RegexBasedDetector**: checks for any keys matching certain regular expressions (Artifactory, AWS, Slack, Stripe, Mailchimp).
 
+**JwtTokenDetector**: checks for formally correct JWTs.
+
 See [detect_secrets/
 plugins](https://github.com/Yelp/detect-secrets/tree/master/detect_secrets/plugins)
 for more details.

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -335,6 +335,11 @@ class PluginOptions(object):
             disable_flag_text='--no-mailchimp-scan',
             disable_help_text='Disable scanning for Mailchimp keys',
         ),
+        PluginDescriptor(
+            classname='JwtTokenDetector',
+            disable_flag_text='--no-jwt-scan',
+            disable_help_text='Disable scanning for JWTs',
+        ),
     ]
 
     def __init__(self, parser):

--- a/detect_secrets/plugins/common/initialize.py
+++ b/detect_secrets/plugins/common/initialize.py
@@ -6,6 +6,7 @@ from ..basic_auth import BasicAuthDetector                  # noqa: F401
 from ..common.util import get_mapping_from_secret_type_to_class_name
 from ..high_entropy_strings import Base64HighEntropyString  # noqa: F401
 from ..high_entropy_strings import HexHighEntropyString     # noqa: F401
+from ..jwt import JwtTokenDetector                          # noqa: F401
 from ..keyword import KeywordDetector                       # noqa: F401
 from ..mailchimp import MailchimpDetector                   # noqa: F401
 from ..private_key import PrivateKeyDetector                # noqa: F401

--- a/detect_secrets/plugins/common/util.py
+++ b/detect_secrets/plugins/common/util.py
@@ -11,6 +11,7 @@ from ..base import BasePlugin
 from ..basic_auth import BasicAuthDetector                  # noqa: F401
 from ..high_entropy_strings import Base64HighEntropyString  # noqa: F401
 from ..high_entropy_strings import HexHighEntropyString     # noqa: F401
+from ..jwt import JwtTokenDetector                          # noqa: F401
 from ..keyword import KeywordDetector                       # noqa: F401
 from ..private_key import PrivateKeyDetector                # noqa: F401
 from ..slack import SlackDetector                           # noqa: F401

--- a/detect_secrets/plugins/jwt.py
+++ b/detect_secrets/plugins/jwt.py
@@ -1,0 +1,41 @@
+"""
+This plugin finds JWT tokens
+"""
+from __future__ import absolute_import
+
+import base64
+import json
+import re
+
+from .base import RegexBasedDetector
+from detect_secrets.core.constants import VerifiedResult
+
+
+class JwtTokenDetector(RegexBasedDetector):
+    secret_type = 'JSON Web Token'
+    denylist = [
+        re.compile(r'eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*'),
+    ]
+
+    def verify(self, token, content=''):
+        parts = token.split('.')
+        for idx, part in enumerate(parts):
+            try:
+                part = part.encode('ascii')
+                # https://github.com/magical/jwt-python/blob/2fd976b41111031313107792b40d5cfd1a8baf90/jwt.py#L49
+                # https://github.com/jpadilla/pyjwt/blob/3d47b0ea9e5d489f9c90ee6dde9e3d9d69244e3a/jwt/utils.py#L33
+                m = len(part) % 4
+                if m == 1:
+                    raise TypeError('Incorrect padding')
+                elif m == 2:
+                    part += '=='.encode('ascii')
+                elif m == 3:
+                    part += '==='.encode('ascii')
+                b64_decoded = base64.urlsafe_b64decode(part)
+                if idx < 2:
+                    _ = json.loads(b64_decoded.decode('ascii'))
+            except (TypeError, ValueError, UnicodeDecodeError) as error:
+                print(error)
+                return VerifiedResult.VERIFIED_FALSE
+
+        return VerifiedResult.UNVERIFIED

--- a/detect_secrets/plugins/jwt.py
+++ b/detect_secrets/plugins/jwt.py
@@ -20,7 +20,7 @@ except ImportError:
 class JwtTokenDetector(RegexBasedDetector):
     secret_type = 'JSON Web Token'
     denylist = [
-        re.compile(r'eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*'),
+        re.compile(r'eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*?'),
     ]
 
     def secret_generator(self, string, *args, **kwargs):

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -42,6 +42,7 @@ class TestPluginOptions(object):
             'ArtifactoryDetector': {},
             'StripeDetector': {},
             'MailchimpDetector': {},
+            'JwtTokenDetector': {},
         }
         assert not hasattr(args, 'no_private_key_scan')
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -94,6 +94,7 @@ class TestMain(object):
                 Base64HighEntropyString: {}
                 BasicAuthDetector      : False
                 HexHighEntropyString   : {}
+                JwtTokenDetector       : False
                 KeywordDetector        : False
                 MailchimpDetector      : False
                 PrivateKeyDetector     : False
@@ -120,6 +121,7 @@ class TestMain(object):
                 Base64HighEntropyString: False (2.585)
                 BasicAuthDetector      : False
                 HexHighEntropyString   : False (2.121)
+                JwtTokenDetector       : False
                 KeywordDetector        : False
                 MailchimpDetector      : False
                 PrivateKeyDetector     : False
@@ -255,6 +257,9 @@ class TestMain(object):
                         'name': 'HexHighEntropyString',
                     },
                     {
+                        'name': 'JwtTokenDetector',
+                    },
+                    {
                         'name': 'KeywordDetector',
                     },
                     {
@@ -293,6 +298,9 @@ class TestMain(object):
                     {
                         'hex_limit': 3,
                         'name': 'HexHighEntropyString',
+                    },
+                    {
+                        'name': 'JwtTokenDetector',
                     },
                     {
                         'name': 'KeywordDetector',
@@ -388,6 +396,9 @@ class TestMain(object):
                         'name': 'BasicAuthDetector',
                     },
                     {
+                        'name': 'JwtTokenDetector',
+                    },
+                    {
                         'name': 'MailchimpDetector',
                     },
                     {
@@ -425,6 +436,9 @@ class TestMain(object):
                     },
                     {
                         'name': 'BasicAuthDetector',
+                    },
+                    {
+                        'name': 'JwtTokenDetector',
                     },
                     {
                         'name': 'MailchimpDetector',

--- a/tests/plugins/jwt_test.py
+++ b/tests/plugins/jwt_test.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+import pytest
+
+from detect_secrets.core.constants import VerifiedResult
+from detect_secrets.plugins.jwt import JwtTokenDetector
+
+
+class TestJwtTokenDetector(object):
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', True),  # noqa: E501
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', True),  # noqa: E501
+            ('{"alg":"HS256","typ":"JWT"}.{"name":"Jon Doe"}.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', False),  # noqa: E501
+            ('bm90X3ZhbGlkX2pzb25fYXRfYWxs.bm90X3ZhbGlkX2pzb25fYXRfYWxs.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', False),  # noqa: E501
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', False),  # noqa: E501
+            ('test', False),  # noqa: E501
+        ],
+    )
+    def test_analyze_string(self, payload, should_flag):
+        logic = JwtTokenDetector()
+
+        output = logic.analyze_string(payload, 1, 'mock_filename')
+        assert len(output) == int(should_flag)
+
+    @pytest.mark.parametrize(
+        'payload, result',
+        [
+            ('yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.bm90X3ZhbGlkX2pzb25fYXRfYWxs.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.UNVERIFIED),  # noqa: E501
+            (u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.UNVERIFIED),  # noqa: E501
+            ('eyJhbasdGciOiJIUaddasdasfsasdasdzI1NiIasdsInR5cCI6IkpXVCasdJasd9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', VerifiedResult.UNVERIFIED),  # noqa: E501
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVC.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+            ('eyJAAAA.eyJBBB', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+            ('eyJBB.eyJCC.eyJDDDD', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+            ('eyJasdasdraWQiOadfssdmgkandjgnjidfnsgiIyMDE5MDUxMyIsImFsZyI6IlasdJTMjU2Iasdnasd0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfasdQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
+        ],
+    )
+    def test_verify(self, payload, result):
+        logic = JwtTokenDetector()
+        output = logic.verify(payload)
+
+        assert output == result

--- a/tests/plugins/jwt_test.py
+++ b/tests/plugins/jwt_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import pytest
 
-from detect_secrets.core.constants import VerifiedResult
 from detect_secrets.plugins.jwt import JwtTokenDetector
 
 
@@ -11,12 +10,33 @@ class TestJwtTokenDetector(object):
     @pytest.mark.parametrize(
         'payload, should_flag',
         [
+            # valid jwt
             ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', True),  # noqa: E501
+            # valid jwt - but header contains CR/LF-s
+            ('eyJ0eXAiOiJKV1QiLA0KImFsZyI6IkhTMjU2In0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', True),  # noqa: E501
+            # valid jwt - but claims contain bunch of LF newlines
+            ('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9lIiwKInN0YXR1cyI6ImVtcGxveWVlIgp9', True),  # noqa: E501
+            # valid jwt - claims contain strings with unicode accents
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IsWww6HFkcOtIMOWxZHDqcOoIiwiaWF0IjoxNTE2MjM5MDIyfQ.k5HibI_uLn_RTuPcaCNkaVaQH2y5q6GvJg8GPpGMRwQ', True),  # noqa: E501
+            # as unicode literal
+            (u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', True),  # noqa: E501
+            # no signature - but still valid
             ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', True),  # noqa: E501
+            # decoded - invalid
             ('{"alg":"HS256","typ":"JWT"}.{"name":"Jon Doe"}.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', False),  # noqa: E501
+            # invalid json - invalid (caught by regex)
             ('bm90X3ZhbGlkX2pzb25fYXRfYWxs.bm90X3ZhbGlkX2pzb25fYXRfYWxs.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', False),  # noqa: E501
+            # missing claims - invalid
             ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', False),  # noqa: E501
-            ('test', False),  # noqa: E501
+            # totally not a jwt
+            ('jwt', False),  # noqa: E501
+            # invalid json with random bytes
+            ('eyJhbasdGciOiJIUaddasdasfsasdasdzI1NiIasdsInR5cCI6IkpXVCasdJasd9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', False),  # noqa: E501
+            # invalid json in jwt header - invalid (caught by parsing)
+            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', False),  # noqa: E501
+            # good by regex, but otherwise totally not JWT
+            ('eyJAAAA.eyJBBB', False),  # noqa: E501
+            ('eyJBB.eyJCC.eyJDDDD', False),  # noqa: E501
         ],
     )
     def test_analyze_string(self, payload, should_flag):
@@ -24,24 +44,3 @@ class TestJwtTokenDetector(object):
 
         output = logic.analyze_string(payload, 1, 'mock_filename')
         assert len(output) == int(should_flag)
-
-    @pytest.mark.parametrize(
-        'payload, result',
-        [
-            ('yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.bm90X3ZhbGlkX2pzb25fYXRfYWxs.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.UNVERIFIED),  # noqa: E501
-            (u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.UNVERIFIED),  # noqa: E501
-            ('eyJhbasdGciOiJIUaddasdasfsasdasdzI1NiIasdsInR5cCI6IkpXVCasdJasd9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', VerifiedResult.UNVERIFIED),  # noqa: E501
-            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-            ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVC.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-            ('eyJAAAA.eyJBBB', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-            ('eyJBB.eyJCC.eyJDDDD', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-            ('eyJasdasdraWQiOadfssdmgkandjgnjidfnsgiIyMDE5MDUxMyIsImFsZyI6IlasdJTMjU2Iasdnasd0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfasdQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', VerifiedResult.VERIFIED_FALSE),  # noqa: E501
-        ],
-    )
-    def test_verify(self, payload, result):
-        logic = JwtTokenDetector()
-        output = logic.verify(payload)
-
-        assert output == result

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -192,6 +192,9 @@ class TestPreCommitHook(object):
                     'name': 'HexHighEntropyString',
                 },
                 {
+                    'name': 'JwtTokenDetector',
+                },
+                {
                     'name': 'KeywordDetector',
                 },
                 {


### PR DESCRIPTION
# New plugin checking for JWTs

## Motivation
The current high entropy base64 string checker would not find JWTs because they contain dots too. JWTs are more and more widespread - one very good example is Kubernetes API server tokens. The following very typical way of using detect-secrets for example would not detect a kubeconfig file committed in the codebase:

`detect-secrets scan --use-all-plugins --no-keyword-scan`

Of course, Kubernetes is not the only use case and because JWTs have an easy-to-validate format, I thought it would be worth checking for them as well - I think it's reasonable to expect low false positive ratio from this plugin.

## How does it work?
I have implemented a simple regex based plugin that first filters for potential tokens just by looking at the character set and format (see https://tools.ietf.org/html/rfc7519 for details). Then it refines the search by validating the JWT format and encoding (base64url+json). I choose not to include a full JWT library just for this as I do not need to support signature validation or expiry checking here - I only intend to check that the JWT is formally correct. It shouldn't want to be too smart anyways. It is generally not possible to know where that JWT is accepted just by looking at it, so verification by network call is not supported by this plugin.

Test cases are documented in the source code for easier review.