### PR TITLE
Support url-safe base64 secrets

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -358,7 +358,7 @@ class SecretsCollection(object):
             for line in chunk.target_lines():
                 if line.is_added:
                     output.update(
-                        plugin.analyze_string(
+                        plugin.analyze_line(
                             line.value,
                             line.target_line_no,
                             filename,

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -97,7 +97,7 @@ class BasePlugin(object):
         potential_secrets = {}
         file_lines = tuple(file.readlines())
         for line_num, line in enumerate(file_lines, start=1):
-            results = self.analyze_string(line, line_num, filename)
+            results = self.analyze_line(line, line_num, filename)
             if not self.should_verify:
                 potential_secrets.update(results)
                 continue
@@ -121,7 +121,7 @@ class BasePlugin(object):
 
         return potential_secrets
 
-    def analyze_string(self, string, line_num, filename):
+    def analyze_line(self, string, line_num, filename):
         """
         :param string:    string; the line to analyze
         :param line_num:  integer; line number that is currently being analyzed
@@ -163,7 +163,7 @@ class BasePlugin(object):
     @abstractmethod
     def secret_generator(self, string, *args, **kwargs):
         """Flags secrets in a given string, and yields the raw secret value.
-        Used in self.analyze_string for PotentialSecret creation.
+        Used in self.analyze_line for PotentialSecret creation.
 
         :type string: str
         :param string: the secret to scan
@@ -178,7 +178,7 @@ class BasePlugin(object):
         check what different plugins say regarding a single line/secret. This
         supports that.
 
-        This is very similar to self.analyze_string, but allows the flexibility
+        This is very similar to self.analyze_line, but allows the flexibility
         for subclasses to add any other notable info (rather than just a
         PotentialSecret type). e.g. HighEntropyStrings adds their Shannon
         entropy in which they made their decision.
@@ -191,7 +191,7 @@ class BasePlugin(object):
             <classname>: <returned-value>
         """
         # TODO: Handle multiple secrets on single line.
-        results = self.analyze_string(
+        results = self.analyze_line(
             string,
             line_num=0,
             filename='does_not_matter',

--- a/detect_secrets/plugins/common/filters.py
+++ b/detect_secrets/plugins/common/filters.py
@@ -3,32 +3,13 @@ False positive heuristic filters that are shared across all plugin types.
 This abstraction allows for development of later ML work, or further
 heuristical determinations (e.g. word filter, entropy comparator).
 """
+import re
 import string
 
 from detect_secrets.util import is_python_2
 
 
-def is_false_positive(secret, automaton):
-    """
-    :type secret: str
-
-    :type automaton: ahocorasick.Automaton|None
-    :param automaton: optional automaton for ignoring certain words.
-
-    :rtype: bool
-    Returns True if any false positive heuristic function returns True.
-    """
-    return any(
-        func(secret, automaton)
-        for func in
-        (
-            _is_found_with_aho_corasick,
-            _is_sequential_string,
-        )
-    )
-
-
-def _is_found_with_aho_corasick(secret, automaton):
+def is_found_with_aho_corasick(secret, automaton):
     """
     :type secret: str
 
@@ -53,7 +34,7 @@ def _is_found_with_aho_corasick(secret, automaton):
         return False
 
 
-def _is_sequential_string(secret, *args):
+def is_sequential_string(secret, *args):
     """
     :type secret: str
 
@@ -97,3 +78,80 @@ def _is_sequential_string(secret, *args):
             return True
 
     return False
+
+
+ALL_FALSE_POSITIVE_HEURISTICS = (
+    is_found_with_aho_corasick,
+    is_sequential_string,
+)
+
+
+# NOTE: this doesn't handle key-values on a line properly.
+# NOTE: words that end in "id" will be treated as ids
+_ID_DETECTOR_REGEX = re.compile(r'[iI][dD][^A-Za-z0-9]')
+
+
+def is_likely_id_string(secret, line):
+    """
+    :type secret: str
+
+    :type line: str
+    :param line: Line context for the plaintext secret
+
+    :rtype: bool
+    Returns true if the secret could be an id, false otherwise.
+    """
+    if secret not in line:
+        return False
+
+    secret_index = line.index(secret)
+    return _ID_DETECTOR_REGEX.findall(line, pos=0, endpos=secret_index)
+
+
+ALL_FALSE_POSITIVE_WITH_LINE_CONTEXT_HEURISTICS = (
+    is_likely_id_string,
+)
+
+
+def is_false_positive(secret, automaton, functions=ALL_FALSE_POSITIVE_HEURISTICS):
+    """
+    :type secret: str
+
+    :type automaton: ahocorasick.Automaton|None
+    :param automaton: optional automaton for ignoring certain words.
+
+    :type functions: Iterable[Callable]
+    :param functions: list of heuristics to use
+
+    :rtype: bool
+    Returns True if any false positive heuristic function returns True.
+    """
+    return any(
+        func(secret, automaton)
+        for func in functions
+    )
+
+
+def is_false_positive_with_line_context(
+    secret,
+    line,
+    functions=ALL_FALSE_POSITIVE_WITH_LINE_CONTEXT_HEURISTICS,
+):
+    """
+    :type secret: str
+
+    :type line: str
+    :param line: plaintext line on which secret was found
+
+    :type functions: Iterable[Callable]
+    :param functions: list of heuristics to use
+
+    :rtype: bool
+    Returns True if any false-positive heuristic which considers the whole file line
+    returns true.
+    """
+
+    return any(
+        func(secret, line)
+        for func in functions
+    )

--- a/detect_secrets/plugins/common/filters.py
+++ b/detect_secrets/plugins/common/filters.py
@@ -80,8 +80,10 @@ def is_sequential_string(secret, *args):
     return False
 
 
-# This only finds UUIDs which only have lowercase characters.
-_UUID_REGEX = re.compile(r'[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12}')
+_UUID_REGEX = re.compile(
+    r'[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12}',
+    re.IGNORECASE,
+)
 
 
 def is_potential_uuid(secret, *args):
@@ -98,7 +100,7 @@ def is_potential_uuid(secret, *args):
     # will find us more false-positives than if we just tried validate
     # the input string as a UUID (for example, if the string has a prefix
     # or suffix).
-    return len(_UUID_REGEX.findall(secret.lower())) > 0
+    return len(_UUID_REGEX.findall(secret)) > 0
 
 
 DEFAULT_FALSE_POSITIVE_HEURISTICS = [
@@ -109,7 +111,7 @@ DEFAULT_FALSE_POSITIVE_HEURISTICS = [
 
 # NOTE: this doesn't handle multiple key-values on a line properly.
 # NOTE: words that end in "id" will be treated as ids
-_ID_DETECTOR_REGEX = re.compile(r'[iI][dD][^A-Za-z0-9]')
+_ID_DETECTOR_REGEX = re.compile(r'id[^a-z0-9]', re.IGNORECASE)
 
 
 def is_likely_id_string(secret, line):

--- a/detect_secrets/plugins/common/filters.py
+++ b/detect_secrets/plugins/common/filters.py
@@ -100,7 +100,7 @@ def is_potential_uuid(secret, *args):
     # will find us more false-positives than if we just tried validate
     # the input string as a UUID (for example, if the string has a prefix
     # or suffix).
-    return len(_UUID_REGEX.findall(secret)) > 0
+    return bool(_UUID_REGEX.search(secret))
 
 
 DEFAULT_FALSE_POSITIVE_HEURISTICS = [
@@ -128,7 +128,7 @@ def is_likely_id_string(secret, line):
         return False
 
     secret_index = line.index(secret)
-    return _ID_DETECTOR_REGEX.findall(line, pos=0, endpos=secret_index)
+    return bool(_ID_DETECTOR_REGEX.search(line, pos=0, endpos=secret_index))
 
 
 DEFAULT_FALSE_POSITIVE_WITH_LINE_CONTEXT_HEURISTICS = [

--- a/detect_secrets/plugins/common/filters.py
+++ b/detect_secrets/plugins/common/filters.py
@@ -34,6 +34,19 @@ def is_found_with_aho_corasick(secret, automaton):
         return False
 
 
+def get_aho_corasick_helper(automaton):
+    """
+    Returns a function which determines if a word matches the
+    input automaton.
+
+    :type automaton: ahocorasick.Automaton
+    """
+    def fn(secret):
+        return is_found_with_aho_corasick(secret, automaton)
+
+    return fn
+
+
 def is_sequential_string(secret, *args):
     """
     :type secret: str
@@ -103,12 +116,6 @@ def is_potential_uuid(secret, *args):
     return bool(_UUID_REGEX.search(secret))
 
 
-DEFAULT_FALSE_POSITIVE_HEURISTICS = [
-    is_found_with_aho_corasick,
-    is_sequential_string,
-]
-
-
 # NOTE: this doesn't handle multiple key-values on a line properly.
 # NOTE: words that end in "id" will be treated as ids
 _ID_DETECTOR_REGEX = re.compile(r'id[^a-z0-9]', re.IGNORECASE)
@@ -134,25 +141,6 @@ def is_likely_id_string(secret, line):
 DEFAULT_FALSE_POSITIVE_WITH_LINE_CONTEXT_HEURISTICS = [
     is_likely_id_string,
 ]
-
-
-def is_false_positive(secret, automaton, functions=DEFAULT_FALSE_POSITIVE_HEURISTICS):
-    """
-    :type secret: str
-
-    :type automaton: ahocorasick.Automaton|None
-    :param automaton: optional automaton for ignoring certain words.
-
-    :type functions: Iterable[Callable]
-    :param functions: list of heuristics to use
-
-    :rtype: bool
-    Returns True if any false positive heuristic function returns True.
-    """
-    return any(
-        func(secret, automaton)
-        for func in functions
-    )
 
 
 def is_false_positive_with_line_context(

--- a/detect_secrets/plugins/common/filters.py
+++ b/detect_secrets/plugins/common/filters.py
@@ -108,9 +108,9 @@ def is_likely_id_string(secret, line):
     return _ID_DETECTOR_REGEX.findall(line, pos=0, endpos=secret_index)
 
 
-ALL_FALSE_POSITIVE_WITH_LINE_CONTEXT_HEURISTICS = (
+ALL_FALSE_POSITIVE_WITH_LINE_CONTEXT_HEURISTICS = [
     is_likely_id_string,
-)
+]
 
 
 def is_false_positive(secret, automaton, functions=ALL_FALSE_POSITIVE_HEURISTICS):
@@ -150,7 +150,6 @@ def is_false_positive_with_line_context(
     Returns True if any false-positive heuristic which considers the whole file line
     returns true.
     """
-
     return any(
         func(secret, line)
         for func in functions

--- a/detect_secrets/plugins/common/ini_file_parser.py
+++ b/detect_secrets/plugins/common/ini_file_parser.py
@@ -77,7 +77,7 @@ class IniFileParser(object):
                     key,
                     values,
                 ):
-                    yield value, offset
+                    yield key, value, offset
 
     def _get_value_and_line_offset(self, key, values):
         """Returns the index of the location of key, value pair in lines.

--- a/detect_secrets/plugins/common/yaml_file_parser.py
+++ b/detect_secrets/plugins/common/yaml_file_parser.py
@@ -100,6 +100,11 @@ class YamlFileParser(object):
                         value=str(value.tag.endswith(':binary')),
                         tag='tag:yaml.org,2002:bool',
                     ),
+                    self._create_key_value_pair_for_mapping_node_value(
+                        key='__original_key__',
+                        value=key.value,
+                        tag='tag:yaml.org,2002:str',
+                    ),
                 ],
             )
 

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -161,7 +161,7 @@ class HighEntropyStringsPlugin(BasePlugin):
                     exclude_lines_regex=self.exclude_lines_regex,
                 ).iterator():
                     potential_secrets.update(
-                        self.analyze_string(
+                        self.analyze_string_content(
                             value,
                             lineno,
                             filename,

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -20,6 +20,8 @@ from .common.filetype import determine_file_type
 from .common.filetype import FileType
 from .common.filters import is_false_positive
 from .common.filters import is_false_positive_with_line_context
+from .common.filters import is_potential_uuid
+from .common.filters import DEFAULT_FALSE_POSITIVE_HEURISTICS
 from .common.ini_file_parser import IniFileParser
 from .common.yaml_file_parser import YamlFileParser
 from detect_secrets.core.potential_secret import PotentialSecret
@@ -113,7 +115,11 @@ class HighEntropyStringsPlugin(BasePlugin):
         output = {}
 
         for result in self.secret_generator(string):
-            if is_false_positive(result, self.automaton):
+            # py2+py3 compatible way of copying a list
+            functions = list(DEFAULT_FALSE_POSITIVE_HEURISTICS)
+            functions.append(is_potential_uuid)
+
+            if is_false_positive(result, self.automaton, functions=functions):
                 continue
 
             secret = PotentialSecret(self.secret_type, filename, result, line_num)

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -217,7 +217,7 @@ class HighEntropyStringsPlugin(BasePlugin):
                     else item['__value__']
                 )
 
-                secrets = self.analyze_string(
+                secrets = self.analyze_string_content(
                     string_to_scan,
                     item['__line__'],
                     filename,

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -378,9 +378,9 @@ class Base64HighEntropyString(HighEntropyStringsPlugin):
         charset = (
             string.ascii_letters
             + string.digits
-            + '+/'  # regular base64
-            + '\\-_'  # url-safe base64
-            + '='  # padding
+            + '+/'  # Regular base64
+            + '\\-_'  # Url-safe base64
+            + '='  # Padding
         )
         super(Base64HighEntropyString, self).__init__(
             charset=charset,

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -19,6 +19,7 @@ from .base import classproperty
 from .common.filetype import determine_file_type
 from .common.filetype import FileType
 from .common.filters import is_false_positive
+from .common.filters import is_false_positive_with_line_context
 from .common.ini_file_parser import IniFileParser
 from .common.yaml_file_parser import YamlFileParser
 from detect_secrets.core.potential_secret import PotentialSecret
@@ -82,6 +83,21 @@ class HighEntropyStringsPlugin(BasePlugin):
                 entropy += - p_x * math.log(p_x, 2)
 
         return entropy
+
+    def analyze_string(self, string, line_num, filename):
+        output = super(HighEntropyStringsPlugin, self).analyze_string(
+            string,
+            line_num,
+            filename,
+        )
+
+        return {
+            key: value for key, value in output.items()
+            if not is_false_positive_with_line_context(
+                key.secret_value,
+                string,
+            )
+        }
 
     def analyze_string_content(self, string, line_num, filename):
         """Searches string for custom pattern, and captures all high entropy strings that

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -84,8 +84,8 @@ class HighEntropyStringsPlugin(BasePlugin):
 
         return entropy
 
-    def analyze_string(self, string, line_num, filename):
-        output = super(HighEntropyStringsPlugin, self).analyze_string(
+    def analyze_line(self, string, line_num, filename):
+        output = super(HighEntropyStringsPlugin, self).analyze_line(
             string,
             line_num,
             filename,
@@ -130,7 +130,7 @@ class HighEntropyStringsPlugin(BasePlugin):
         # Since it's an individual string, it's just bad UX to require quotes
         # around the expected secret.
         with self.non_quoted_string_regex():
-            results = self.analyze_string(
+            results = self.analyze_line(
                 string,
                 line_num=0,
                 filename='does_not_matter',

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -339,8 +339,15 @@ class Base64HighEntropyString(HighEntropyStringsPlugin):
     secret_type = 'Base64 High Entropy String'
 
     def __init__(self, base64_limit, exclude_lines_regex=None, automaton=None, **kwargs):
+        charset = (
+            string.ascii_letters
+            + string.digits
+            + '+/'  # regular base64
+            + '\\-_'  # url-safe base64
+            + '='  # padding
+        )
         super(Base64HighEntropyString, self).__init__(
-            charset=string.ascii_letters + string.digits + '+/=',
+            charset=charset,
             limit=base64_limit,
             exclude_lines_regex=exclude_lines_regex,
             automaton=automaton,

--- a/test_data/config.ini
+++ b/test_data/config.ini
@@ -27,3 +27,7 @@ password = 12345678901234  # pragma: allowlist secret
 
 # unicode
 foo=bår
+
+[key with id in name]
+real_secret_which_isnt_an_i_d = vh987tyw9ehy8ghis7vwyhiwbwitefy7w3ASDGYDGUASDG
+foreign_key_id = vh987tyw9ehy8ghis7vwyhiwbwitefy7w3ASDGYDGUASDG

--- a/test_data/config.yaml
+++ b/test_data/config.yaml
@@ -1,5 +1,5 @@
 credentials:
-    some_value_here: not_a_secret
+    some_value_here: not_secret
     other_value_here: 1234567890a
     CanonicalUserGetSkippedByExcludeLines: 1234567890ab
     nested:

--- a/test_data/config.yaml
+++ b/test_data/config.yaml
@@ -15,3 +15,5 @@ high_entropy_binary_secret: !!binary MjNjcnh1IDJieXJpdXYyeXJpaTJidnl1MnI4OXkyb3U
 
 # this should be ignored as a potential id
 allowlisted_id: 'ToCynx5Se4e2PtoZxEhW7lUJcOX15c54'
+
+uuid_should_be_ignored: '203db13e-70c7-462b-9a3d-bf32640cb0be'

--- a/test_data/config.yaml
+++ b/test_data/config.yaml
@@ -11,5 +11,7 @@ list_of_keys:
     - 234567890a
 
 test_agent::allowlisted_api_key: 'ToCynx5Se4e2PtoZxEhW7lUJcOX15c54'  # pragma: allowlist secret
-
 high_entropy_binary_secret: !!binary MjNjcnh1IDJieXJpdXYyeXJpaTJidnl1MnI4OXkyb3UwMg==
+
+# this should be ignored as a potential id
+allowlisted_id: 'ToCynx5Se4e2PtoZxEhW7lUJcOX15c54'

--- a/tests/plugins/artifactory_test.py
+++ b/tests/plugins/artifactory_test.py
@@ -37,8 +37,8 @@ class TestArtifactoryDetector(object):
             ('artifactory:_password=AKCxxxxxxxx', False),
         ],
     )
-    def test_analyze_string(self, payload, should_flag):
+    def test_analyze_line(self, payload, should_flag):
         logic = ArtifactoryDetector()
 
-        output = logic.analyze_string(payload, 1, 'mock_filename')
+        output = logic.analyze_line(payload, 1, 'mock_filename')
         assert len(output) == int(should_flag)

--- a/tests/plugins/basic_auth_test.py
+++ b/tests/plugins/basic_auth_test.py
@@ -18,8 +18,8 @@ class TestBasicAuthDetector(object):
             ('https://url:8000/ @something else', False),
         ],
     )
-    def test_analyze_string(self, payload, should_flag):
+    def test_analyze_line(self, payload, should_flag):
         logic = BasicAuthDetector()
 
-        output = logic.analyze_string(payload, 1, 'mock_filename')
+        output = logic.analyze_line(payload, 1, 'mock_filename')
         assert len(output) == int(should_flag)

--- a/tests/plugins/common/filters_test.py
+++ b/tests/plugins/common/filters_test.py
@@ -73,3 +73,16 @@ class TestIsLikelyIdString(object):
     )
     def test_failure(self, secret, line):
         assert not filters.is_likely_id_string(secret, line)
+
+
+class TestIsPotentialUuid(object):
+    @pytest.mark.parametrize(
+        'secret',
+        [
+            '3636dd46-ea21-11e9-81b4-2a2ae2dbcce4',  # uuid1
+            '97fb0431-46ac-41df-9ef9-1a18545ce2a0',  # uuid4
+            'prefix-3636dd46-ea21-11e9-81b4-2a2ae2dbcce4-suffix',  # uuid in middle of string
+        ],
+    )
+    def test_success(self, secret):
+        assert filters.is_potential_uuid(secret)

--- a/tests/plugins/common/yaml_file_parser_test.py
+++ b/tests/plugins/common/yaml_file_parser_test.py
@@ -44,4 +44,5 @@ class TestYamlFileParser(object):
             '__value__': expected_value,
             '__is_binary__': expected_is_binary,
             '__line__': mock.ANY,
+            '__original_key__': mock.ANY,
         }

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -139,10 +139,10 @@ class HighEntropyStringsTest(object):
             Base64HighEntropyString(15)
 
 
-class TestBase64HighEntropyStrings(HighEntropyStringsTest):
+class TestRegularBase64HighEntropyStrings(HighEntropyStringsTest):
 
     def setup(self):
-        super(TestBase64HighEntropyStrings, self).setup(
+        super(TestRegularBase64HighEntropyStrings, self).setup(
             # Testing default limit, as suggested by truffleHog.
             logic=Base64HighEntropyString(
                 base64_limit=4.5,
@@ -235,6 +235,19 @@ class TestBase64HighEntropyStrings(HighEntropyStringsTest):
             assert location in (
                 'Location:    test_data/config.env:1',
             )
+
+
+class TestUrlSafeBase64HighEntropyStrings(HighEntropyStringsTest):
+    def setup(self):
+        super(TestUrlSafeBase64HighEntropyStrings, self).setup(
+            # Testing default limit, as suggested by truffleHog.
+            logic=Base64HighEntropyString(
+                base64_limit=4.5,
+                exclude_lines_regex='CanonicalUser',
+            ),
+            non_secret_string='Zrm-ySTAq7D2sHk=',  # too short for high entropy
+            secret_string='I6FwzQZFL9l-44nviI1F04OTmorMaVQf9GS4Oe07qxL_vNkW6CRas4Lo42vqJMT0M6riJfma_f-pTAuoX2U=',  # noqa: E501
+        )
 
 
 class HexHighEntropyStringsWithStandardEntropy(HexHighEntropyString):

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -166,6 +166,7 @@ class TestRegularBase64HighEntropyStrings(HighEntropyStringsTest):
                     'Location:    test_data/config.ini:15',
                     'Location:    test_data/config.ini:21',
                     'Location:    test_data/config.ini:22',
+                    'Location:    test_data/config.ini:32',
                 ],
             ),
             (

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -120,6 +120,8 @@ class HighEntropyStringsTest(object):
             '"CanonicalUser": "{secret}"',
             # Not a string
             '{secret}',
+            # id occurs before the string, probably a false-positive
+            'id = "{secret}"',
         ],
     )
     def test_ignored_lines(self, content_to_format):

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -219,7 +219,7 @@ class TestRegularBase64HighEntropyStrings(HighEntropyStringsTest):
             assert location in (
                 'Location:    test_data/config.yaml:3',
                 'Location:    test_data/config.yaml:6',
-                'Location:    test_data/config.yaml:15',
+                'Location:    test_data/config.yaml:14',
             )
 
         with open('test_data/only_comments.yaml') as f:

--- a/tests/plugins/jwt_test.py
+++ b/tests/plugins/jwt_test.py
@@ -39,8 +39,8 @@ class TestJwtTokenDetector(object):
             ('eyJBB.eyJCC.eyJDDDD', False),  # noqa: E501
         ],
     )
-    def test_analyze_string(self, payload, should_flag):
+    def test_analyze_line(self, payload, should_flag):
         logic = JwtTokenDetector()
 
-        output = logic.analyze_string(payload, 1, 'mock_filename')
+        output = logic.analyze_line(payload, 1, 'mock_filename')
         assert len(output) == int(should_flag)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -31,11 +31,11 @@ def test_build_automaton():
     ):
         automaton, word_list_hash = util.build_automaton(word_list='will_be_mocked.txt')
         assert word_list_hash == hashlib.sha1('foam'.encode('utf-8')).hexdigest()
-        assert filters._is_found_with_aho_corasick(
+        assert filters.is_found_with_aho_corasick(
             secret='foam_roller',
             automaton=automaton,
         )
-        assert not filters._is_found_with_aho_corasick(
+        assert not filters.is_found_with_aho_corasick(
             secret='no_words_in_word_list',
             automaton=automaton,
         )


### PR DESCRIPTION
This updates the base64 plugin to support url-safe plugins by just adding `-` and `_` to the charset. However, this won't be merged until I add some additional functionality to reduce noise.