### PR TITLE
Exclude NOPASSWD

### DIFF
--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -96,6 +96,7 @@ FALSE_POSITIVES = {
     'none',
     'none,',
     'none}',
+    'nopasswd',
     'not',
     'not_real_key',
     'null',


### PR DESCRIPTION
Exclude NOPASSWD so that /etc/sudoers.d/* won't be false positives.