### PR TITLE
Fix signal metric calculation in audit

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -292,7 +292,7 @@ def determine_audit_results(baseline, baseline_path):
         total += 1
     audit_results['stats']['signal'] = str(
         (
-            audit_results['stats']['true-positives']['count']
+            float(audit_results['stats']['true-positives']['count'])
             /
             total
         ) * 100,


### PR DESCRIPTION
:floats-triggered:

Before, the results view would show 0% signal for everything, making the metric useless. This PR fixes the calculation to give us an actual number.

Testing done: Manual testing on internal repos