### PR TITLE
Add one debug option to output raw secret

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -21,6 +21,7 @@ def initialize(
     word_list_file=None,
     word_list_hash=None,
     should_scan_all_files=False,
+    output_raw=False,
 ):
     """Scans the entire codebase for secrets, and returns a
     SecretsCollection object.
@@ -40,7 +41,7 @@ def initialize(
     :param word_list_hash: optional iterated sha1 hash of the words in the word list.
 
     :type should_scan_all_files: bool
-
+    :type output_raw: bool
     :rtype: SecretsCollection
     """
     output = SecretsCollection(
@@ -49,6 +50,7 @@ def initialize(
         exclude_lines=exclude_lines_regex,
         word_list_file=word_list_file,
         word_list_hash=word_list_hash,
+        output_raw=output_raw,
     )
 
     files_to_scan = []

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -21,7 +21,7 @@ def initialize(
     word_list_file=None,
     word_list_hash=None,
     should_scan_all_files=False,
-    output_raw=False,
+    debug_output_raw=False,
 ):
     """Scans the entire codebase for secrets, and returns a
     SecretsCollection object.
@@ -41,7 +41,7 @@ def initialize(
     :param word_list_hash: optional iterated sha1 hash of the words in the word list.
 
     :type should_scan_all_files: bool
-    :type output_raw: bool
+    :type debug_output_raw: bool
     :rtype: SecretsCollection
     """
     output = SecretsCollection(
@@ -50,7 +50,7 @@ def initialize(
         exclude_lines=exclude_lines_regex,
         word_list_file=word_list_file,
         word_list_hash=word_list_hash,
-        output_raw=output_raw,
+        debug_output_raw=debug_output_raw,
     )
 
     files_to_scan = []

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -52,9 +52,9 @@ class PotentialSecret(object):
         self.filename = filename
         self.lineno = lineno
         self.set_secret(secret)
-        self.secret_hash = self.hash_secret(secret)
         self.is_secret = is_secret
         self.is_verified = False
+        self.output_raw = output_raw
 
         # If two PotentialSecrets have the same values for these fields,
         # they are considered equal. Note that line numbers aren't included
@@ -99,7 +99,7 @@ class PotentialSecret(object):
         }
 
         if self.output_raw:
-            attributes['secret'] = self.secret
+            attributes['secret'] = self.secret_value
 
         if self.is_secret is not None:
             attributes['is_secret'] = self.is_secret

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -21,6 +21,7 @@ class PotentialSecret(object):
         secret,
         lineno=0,
         is_secret=None,
+        output_raw=False,
     ):
         """
         :type typ: str
@@ -43,11 +44,15 @@ class PotentialSecret(object):
 
         :type is_verified: bool
         :param is_verified: whether the secret has been externally verified
+
+        :type output_raw: bool|None
+        :param output_raw: whether or not to output the raw, unhashed secret
         """
         self.type = typ
         self.filename = filename
         self.lineno = lineno
         self.set_secret(secret)
+        self.secret_hash = self.hash_secret(secret)
         self.is_secret = is_secret
         self.is_verified = False
 
@@ -68,6 +73,10 @@ class PotentialSecret(object):
         #       we don't want to create a file that contains all plaintext secrets
         #       in the repository.
         self.secret_value = secret
+        # If two PotentialSecrets have the same values for these fields,
+        # they are considered equal. Note that line numbers aren't included
+        # in this, because line numbers are subject to change.
+        self.fields_to_compare = ['filename', 'secret_hash', 'type']
 
     @staticmethod
     def hash_secret(secret):
@@ -88,6 +97,9 @@ class PotentialSecret(object):
             'hashed_secret': self.secret_hash,
             'is_verified': self.is_verified,
         }
+
+        if self.output_raw:
+            attributes['secret'] = self.secret
 
         if self.is_secret is not None:
             attributes['is_secret'] = self.is_secret

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -21,7 +21,7 @@ class PotentialSecret(object):
         secret,
         lineno=0,
         is_secret=None,
-        output_raw=False,
+        debug_output_raw=False,
     ):
         """
         :type typ: str
@@ -45,8 +45,8 @@ class PotentialSecret(object):
         :type is_verified: bool
         :param is_verified: whether the secret has been externally verified
 
-        :type output_raw: bool|None
-        :param output_raw: whether or not to output the raw, unhashed secret
+        :type debug_output_raw: bool|None
+        :param debug_output_raw: whether or not to output the raw, unhashed secret
         """
         self.type = typ
         self.filename = filename
@@ -54,7 +54,7 @@ class PotentialSecret(object):
         self.set_secret(secret)
         self.is_secret = is_secret
         self.is_verified = False
-        self.output_raw = output_raw
+        self.debug_output_raw = debug_output_raw
 
         # If two PotentialSecrets have the same values for these fields,
         # they are considered equal. Note that line numbers aren't included
@@ -98,7 +98,7 @@ class PotentialSecret(object):
             'is_verified': self.is_verified,
         }
 
-        if self.output_raw:
+        if self.debug_output_raw:
             attributes['secret'] = self.secret_value
 
         if self.is_secret is not None:

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -24,6 +24,7 @@ class SecretsCollection(object):
         exclude_lines=None,
         word_list_file=None,
         word_list_hash=None,
+        output_raw=False,
     ):
         """
         :type plugins: tuple of detect_secrets.plugins.base.BasePlugin
@@ -40,6 +41,12 @@ class SecretsCollection(object):
 
         :type word_list_hash: str|None
         :param word_list_hash: optional iterated sha1 hash of the words in the word list.
+        :type version: str
+        :param version: version of detect-secrets that SecretsCollection
+            is valid at.
+
+        :type output_raw: bool|None
+        :param output_raw: whether or not to output the raw, unhashed secret
         """
         self.data = {}
         self.plugins = plugins
@@ -47,6 +54,7 @@ class SecretsCollection(object):
         self.exclude_lines = exclude_lines
         self.word_list_file = word_list_file
         self.word_list_hash = word_list_hash
+        self.output_raw = output_raw
         self.version = VERSION
 
     @classmethod
@@ -258,7 +266,10 @@ class SecretsCollection(object):
         if type_:
             # Optimized lookup, because we know the type of secret
             # (and therefore, its hash)
-            tmp_secret = PotentialSecret(type_, filename, secret='will be overriden')
+            tmp_secret = PotentialSecret(
+                type_, filename, secret='will be overriden',
+                output_raw=self.output_raw,
+            )
             tmp_secret.secret_hash = secret
 
             if tmp_secret in self.data[filename]:
@@ -337,7 +348,7 @@ class SecretsCollection(object):
             log.info('Checking file: %s', filename)
 
             for results, plugin in self._results_accumulator(filename):
-                results.update(plugin.analyze(f, filename))
+                results.update(plugin.analyze(f, filename, self.output_raw))
                 f.seek(0)
 
         except UnicodeDecodeError:

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -24,7 +24,7 @@ class SecretsCollection(object):
         exclude_lines=None,
         word_list_file=None,
         word_list_hash=None,
-        output_raw=False,
+        debug_output_raw=False,
     ):
         """
         :type plugins: tuple of detect_secrets.plugins.base.BasePlugin
@@ -45,8 +45,8 @@ class SecretsCollection(object):
         :param version: version of detect-secrets that SecretsCollection
             is valid at.
 
-        :type output_raw: bool|None
-        :param output_raw: whether or not to output the raw, unhashed secret
+        :type debug_output_raw: bool|None
+        :param debug_output_raw: whether or not to output the raw, unhashed secret
         """
         self.data = {}
         self.plugins = plugins
@@ -54,7 +54,7 @@ class SecretsCollection(object):
         self.exclude_lines = exclude_lines
         self.word_list_file = word_list_file
         self.word_list_hash = word_list_hash
-        self.output_raw = output_raw
+        self.debug_output_raw = debug_output_raw
         self.version = VERSION
 
     @classmethod
@@ -268,7 +268,7 @@ class SecretsCollection(object):
             # (and therefore, its hash)
             tmp_secret = PotentialSecret(
                 type_, filename, secret='will be overriden',
-                output_raw=self.output_raw,
+                debug_output_raw=self.debug_output_raw,
             )
             tmp_secret.secret_hash = secret
 
@@ -348,7 +348,7 @@ class SecretsCollection(object):
             log.info('Checking file: %s', filename)
 
             for results, plugin in self._results_accumulator(filename):
-                results.update(plugin.analyze(f, filename, self.output_raw))
+                results.update(plugin.analyze(f, filename, self.debug_output_raw))
                 f.seek(0)
 
         except UnicodeDecodeError:

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -145,7 +145,7 @@ class ScanOptions(object):
     def add_arguments(self):
         self._add_initialize_baseline_argument()\
             ._add_adhoc_scanning_argument()\
-            ._add_output_raw_argument()
+            ._add_debug_output_raw_argument()
 
         PluginOptions(self.parser).add_arguments()
 
@@ -212,14 +212,14 @@ class ScanOptions(object):
         )
         return self
 
-    def _add_output_raw_argument(self):
+    def _add_debug_output_raw_argument(self):
         self.parser.add_argument(
-            '--output-raw',
+            '--debug-output-raw',
             action='store_true',
             help=(
                 'Outputs the raw secret in the baseline file.'
-                'For development/extension purposes.'
-                'Do not use this option in a repo monitoring context.'
+                'For development/debug purposes.'
+                'Do NOT use this option in a repo scanning context.'
             ),
         )
         return self

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -144,7 +144,8 @@ class ScanOptions(object):
 
     def add_arguments(self):
         self._add_initialize_baseline_argument()\
-            ._add_adhoc_scanning_argument()
+            ._add_adhoc_scanning_argument()\
+            ._add_output_raw_argument()
 
         PluginOptions(self.parser).add_arguments()
 
@@ -209,6 +210,19 @@ class ScanOptions(object):
                 'plugins\' verdict.'
             ),
         )
+        return self
+
+    def _add_output_raw_argument(self):
+        self.parser.add_argument(
+            '--output-raw',
+            action='store_true',
+            help=(
+                'Outputs the raw secret in the baseline file.'
+                'For development/extension purposes.'
+                'Do not use this option in a repo monitoring context.'
+            ),
+        )
+        return self
 
 
 class AuditOptions(object):

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -178,7 +178,7 @@ def _perform_scan(args, plugins, automaton, word_list_hash):
         word_list_hash=word_list_hash,
         path=args.path,
         should_scan_all_files=args.all_files,
-        output_raw=args.output_raw,
+        debug_output_raw=args.debug_output_raw,
     ).format_for_baseline_output()
 
     if old_baseline:

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -178,6 +178,7 @@ def _perform_scan(args, plugins, automaton, word_list_hash):
         word_list_hash=word_list_hash,
         path=args.path,
         should_scan_all_files=args.all_files,
+        output_raw=args.output_raw,
     ).format_for_baseline_output()
 
     if old_baseline:

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -85,11 +85,12 @@ class BasePlugin(object):
     def default_options(cls):
         return {}
 
-    def analyze(self, file, filename):
+    def analyze(self, file, filename, output_raw=False):
         """
         :param file:     The File object itself.
         :param filename: string; filename of File object, used for creating
                          PotentialSecret objects
+        :param output_raw: whether or not to output the raw, unhashed secret
         :returns         dictionary representation of set (for random access by hash)
                          { detect_secrets.core.potential_secret.__hash__:
                                detect_secrets.core.potential_secret         }
@@ -97,7 +98,7 @@ class BasePlugin(object):
         potential_secrets = {}
         file_lines = tuple(file.readlines())
         for line_num, line in enumerate(file_lines, start=1):
-            results = self.analyze_string(line, line_num, filename)
+            results = self.analyze_string(line, line_num, filename, output_raw)
             if not self.should_verify:
                 potential_secrets.update(results)
                 continue
@@ -121,11 +122,12 @@ class BasePlugin(object):
 
         return potential_secrets
 
-    def analyze_string(self, string, line_num, filename):
+    def analyze_string(self, string, line_num, filename, output_raw=False):
         """
         :param string:    string; the line to analyze
         :param line_num:  integer; line number that is currently being analyzed
         :param filename:  string; name of file being analyzed
+        :param output_raw: whether or not to output the raw, unhashed secret
         :returns:         dictionary
 
         NOTE: line_num and filename are used for PotentialSecret creation only.
@@ -146,14 +148,16 @@ class BasePlugin(object):
             string,
             line_num,
             filename,
+            output_raw,
         )
 
     @abstractmethod
-    def analyze_string_content(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename, output_raw=False):
         """
         :param string:    string; the line to analyze
         :param line_num:  integer; line number that is currently being analyzed
         :param filename:  string; name of file being analyzed
+        :param output_raw: whether or not to output the raw, unhashed secret
         :returns:         dictionary
 
         NOTE: line_num and filename are used for PotentialSecret creation only.
@@ -260,7 +264,7 @@ class RegexBasedDetector(BasePlugin):
     def denylist(self):
         raise NotImplementedError
 
-    def analyze_string_content(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename, output_raw=False):
         output = {}
 
         for identifier in self.secret_generator(string):
@@ -269,6 +273,7 @@ class RegexBasedDetector(BasePlugin):
                 filename,
                 identifier,
                 line_num,
+                output_raw=output_raw,
             )
             output[secret] = secret
 

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -85,12 +85,12 @@ class BasePlugin(object):
     def default_options(cls):
         return {}
 
-    def analyze(self, file, filename, output_raw=False):
+    def analyze(self, file, filename, debug_output_raw=False):
         """
         :param file:     The File object itself.
         :param filename: string; filename of File object, used for creating
                          PotentialSecret objects
-        :param output_raw: whether or not to output the raw, unhashed secret
+        :param debug_output_raw: whether or not to output the raw, unhashed secret
         :returns         dictionary representation of set (for random access by hash)
                          { detect_secrets.core.potential_secret.__hash__:
                                detect_secrets.core.potential_secret         }
@@ -98,7 +98,7 @@ class BasePlugin(object):
         potential_secrets = {}
         file_lines = tuple(file.readlines())
         for line_num, line in enumerate(file_lines, start=1):
-            results = self.analyze_string(line, line_num, filename, output_raw)
+            results = self.analyze_string(line, line_num, filename, debug_output_raw)
             if not self.should_verify:
                 potential_secrets.update(results)
                 continue
@@ -122,12 +122,12 @@ class BasePlugin(object):
 
         return potential_secrets
 
-    def analyze_string(self, string, line_num, filename, output_raw=False):
+    def analyze_string(self, string, line_num, filename, debug_output_raw=False):
         """
         :param string:    string; the line to analyze
         :param line_num:  integer; line number that is currently being analyzed
         :param filename:  string; name of file being analyzed
-        :param output_raw: whether or not to output the raw, unhashed secret
+        :param debug_output_raw: whether or not to output the raw, unhashed secret
         :returns:         dictionary
 
         NOTE: line_num and filename are used for PotentialSecret creation only.
@@ -148,16 +148,16 @@ class BasePlugin(object):
             string,
             line_num,
             filename,
-            output_raw,
+            debug_output_raw,
         )
 
     @abstractmethod
-    def analyze_string_content(self, string, line_num, filename, output_raw=False):
+    def analyze_string_content(self, string, line_num, filename, debug_output_raw=False):
         """
         :param string:    string; the line to analyze
         :param line_num:  integer; line number that is currently being analyzed
         :param filename:  string; name of file being analyzed
-        :param output_raw: whether or not to output the raw, unhashed secret
+        :param debug_output_raw: whether or not to output the raw, unhashed secret
         :returns:         dictionary
 
         NOTE: line_num and filename are used for PotentialSecret creation only.
@@ -264,7 +264,7 @@ class RegexBasedDetector(BasePlugin):
     def denylist(self):
         raise NotImplementedError
 
-    def analyze_string_content(self, string, line_num, filename, output_raw=False):
+    def analyze_string_content(self, string, line_num, filename, debug_output_raw=False):
         output = {}
 
         for identifier in self.secret_generator(string):
@@ -273,7 +273,7 @@ class RegexBasedDetector(BasePlugin):
                 filename,
                 identifier,
                 line_num,
-                output_raw=output_raw,
+                debug_output_raw=debug_output_raw,
             )
             output[secret] = secret
 

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -44,7 +44,7 @@ class HighEntropyStringsPlugin(BasePlugin):
             exclude_lines_regex=exclude_lines_regex,
         )
 
-    def analyze(self, file, filename, output_raw=False):
+    def analyze(self, file, filename, debug_output_raw=False):
         file_type_analyzers = (
             (self._analyze_ini_file(), configparser.Error),
             (self._analyze_yaml_file, yaml.YAMLError),
@@ -83,7 +83,7 @@ class HighEntropyStringsPlugin(BasePlugin):
 
         return entropy
 
-    def analyze_string_content(self, string, line_num, filename, output_raw=False):
+    def analyze_string_content(self, string, line_num, filename, debug_output_raw=False):
         """Searches string for custom pattern, and captures all high entropy strings that
         match self.regex, with a limit defined as self.entropy_limit.
         """
@@ -99,7 +99,7 @@ class HighEntropyStringsPlugin(BasePlugin):
                 filename,
                 result,
                 line_num,
-                output_raw=output_raw,
+                debug_output_raw=debug_output_raw,
             )
             output[secret] = secret
 

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -44,7 +44,7 @@ class HighEntropyStringsPlugin(BasePlugin):
             exclude_lines_regex=exclude_lines_regex,
         )
 
-    def analyze(self, file, filename):
+    def analyze(self, file, filename, output_raw=False):
         file_type_analyzers = (
             (self._analyze_ini_file(), configparser.Error),
             (self._analyze_yaml_file, yaml.YAMLError),
@@ -83,7 +83,7 @@ class HighEntropyStringsPlugin(BasePlugin):
 
         return entropy
 
-    def analyze_string_content(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename, output_raw=False):
         """Searches string for custom pattern, and captures all high entropy strings that
         match self.regex, with a limit defined as self.entropy_limit.
         """
@@ -94,6 +94,13 @@ class HighEntropyStringsPlugin(BasePlugin):
                 continue
 
             secret = PotentialSecret(self.secret_type, filename, result, line_num)
+            secret = PotentialSecret(
+                self.secret_type,
+                filename,
+                result,
+                line_num,
+                output_raw=output_raw,
+            )
             output[secret] = secret
 
         return output

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -287,7 +287,7 @@ class KeywordDetector(BasePlugin):
 
         self.automaton = automaton
 
-    def analyze_string_content(self, string, line_num, filename, output_raw=False):
+    def analyze_string_content(self, string, line_num, filename, debug_output_raw=False):
         output = {}
         if (
             self.keyword_exclude
@@ -305,7 +305,7 @@ class KeywordDetector(BasePlugin):
                 filename,
                 identifier,
                 line_num,
-                output_raw=output_raw,
+                debug_output_raw=debug_output_raw,
             )
             output[secret] = secret
 

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -287,7 +287,7 @@ class KeywordDetector(BasePlugin):
 
         self.automaton = automaton
 
-    def analyze_string_content(self, string, line_num, filename):
+    def analyze_string_content(self, string, line_num, filename, output_raw=False):
         output = {}
         if (
             self.keyword_exclude
@@ -305,6 +305,7 @@ class KeywordDetector(BasePlugin):
                 filename,
                 identifier,
                 line_num,
+                output_raw=output_raw,
             )
             output[secret] = secret
 

--- a/detect_secrets/util.py
+++ b/detect_secrets/util.py
@@ -29,7 +29,7 @@ def build_automaton(word_list):
     word_list_hash = hashlib.sha1()
 
     with open(word_list) as f:
-        for line in f:
+        for line in f.readlines():
             # .lower() to make everything case-insensitive
             line = line.lower().strip()
             if len(line) > 3:

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -465,7 +465,7 @@ class MockPluginFixedValue(MockBasePlugin):
 
     secret_type = 'mock_plugin_fixed_value'
 
-    def analyze(self, f, filename):
+    def analyze(self, f, filename, output_raw=False):
         # We're not testing the plugin's ability to analyze secrets, so
         # it doesn't matter what we return
         secret = PotentialSecret('mock fixed value type', filename, 'asdf', 1)
@@ -476,7 +476,7 @@ class MockPluginFileValue(MockBasePlugin):
 
     secret_type = 'mock_plugin_file_value'
 
-    def analyze(self, f, filename):
+    def analyze(self, f, filename, output_raw=False):
         # We're not testing the plugin's ability to analyze secrets, so
         # it doesn't matter what we return
         secret = PotentialSecret('mock file value type', filename, f.read().strip(), 2)
@@ -487,7 +487,7 @@ class MockPasswordPluginValue(MockBasePlugin):
 
     secret_type = 'mock_plugin_file_value'
 
-    def analyze(self, f, filename):
+    def analyze(self, f, filename, output_raw=False):
         password_secret = PotentialSecret('Password', filename, f.read().strip(), 2)
         return {
             password_secret: password_secret,

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -465,7 +465,7 @@ class MockPluginFixedValue(MockBasePlugin):
 
     secret_type = 'mock_plugin_fixed_value'
 
-    def analyze(self, f, filename, output_raw=False):
+    def analyze(self, f, filename, debug_output_raw=False):
         # We're not testing the plugin's ability to analyze secrets, so
         # it doesn't matter what we return
         secret = PotentialSecret('mock fixed value type', filename, 'asdf', 1)
@@ -476,7 +476,7 @@ class MockPluginFileValue(MockBasePlugin):
 
     secret_type = 'mock_plugin_file_value'
 
-    def analyze(self, f, filename, output_raw=False):
+    def analyze(self, f, filename, debug_output_raw=False):
         # We're not testing the plugin's ability to analyze secrets, so
         # it doesn't matter what we return
         secret = PotentialSecret('mock file value type', filename, f.read().strip(), 2)
@@ -487,7 +487,7 @@ class MockPasswordPluginValue(MockBasePlugin):
 
     secret_type = 'mock_plugin_file_value'
 
-    def analyze(self, f, filename, output_raw=False):
+    def analyze(self, f, filename, debug_output_raw=False):
         password_secret = PotentialSecret('Password', filename, f.read().strip(), 2)
         return {
             password_secret: password_secret,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -138,6 +138,8 @@ class TestMain(object):
             exclude_lines_regex=None,
             path='.',
             should_scan_all_files=False,
+            word_list_file=None,
+            word_list_hash=None,
             output_raw=True,
         )
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -91,7 +91,7 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
-            output_raw=False,
+            debug_output_raw=False,
         )
 
     def test_scan_with_rootdir(self, mock_baseline_initialize):
@@ -106,7 +106,7 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
-            output_raw=False,
+            debug_output_raw=False,
         )
 
     def test_scan_with_exclude_args(self, mock_baseline_initialize):
@@ -123,13 +123,13 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
-            output_raw=False,
+            debug_output_raw=False,
         )
 
-    def test_scan_with_output_raw(self, mock_baseline_initialize):
+    def test_scan_with_debug_output_raw(self, mock_baseline_initialize):
         with mock_stdin():
             assert main(
-                'scan --output-raw'.split(),
+                'scan --debug-output-raw'.split(),
             ) == 0
 
         mock_baseline_initialize.assert_called_once_with(
@@ -140,7 +140,7 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
-            output_raw=True,
+            debug_output_raw=True,
         )
 
     @pytest.mark.parametrize(
@@ -202,7 +202,7 @@ class TestMain(object):
             should_scan_all_files=True,
             word_list_file=None,
             word_list_hash=None,
-            output_raw=False,
+            debug_output_raw=False,
         )
 
     def test_reads_from_stdin(self, mock_merge_baseline):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -91,6 +91,7 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
+            output_raw=False,
         )
 
     def test_scan_with_rootdir(self, mock_baseline_initialize):
@@ -105,6 +106,7 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
+            output_raw=False,
         )
 
     def test_scan_with_exclude_args(self, mock_baseline_initialize):
@@ -121,6 +123,22 @@ class TestMain(object):
             should_scan_all_files=False,
             word_list_file=None,
             word_list_hash=None,
+            output_raw=False,
+        )
+
+    def test_scan_with_output_raw(self, mock_baseline_initialize):
+        with mock_stdin():
+            assert main(
+                'scan --output-raw'.split(),
+            ) == 0
+
+        mock_baseline_initialize.assert_called_once_with(
+            plugins=Any(tuple),
+            exclude_files_regex=None,
+            exclude_lines_regex=None,
+            path='.',
+            should_scan_all_files=False,
+            output_raw=True,
         )
 
     @pytest.mark.parametrize(
@@ -182,6 +200,7 @@ class TestMain(object):
             should_scan_all_files=True,
             word_list_file=None,
             word_list_hash=None,
+            output_raw=False,
         )
 
     def test_reads_from_stdin(self, mock_merge_baseline):


### PR DESCRIPTION
Added one debug option flag to output the raw secret in the output. This feature is disabled by default, and it's intended to help troubleshooting.