### PR TITLE
Create plugin to detect Twilio API keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The current heuristic searches we implement out of the box include:
 
 * **KeywordDetector**: checks to see if certain keywords are being used e.g. `password` or `secret`
 
-* **RegexBasedDetector**: checks for any keys matching certain regular expressions (Artifactory, AWS, Slack, Stripe, Mailchimp).
+* **RegexBasedDetector**: checks for any keys matching certain regular expressions (Artifactory, AWS, Slack, Stripe, Mailchimp, Twilio).
 
 * **JwtTokenDetector**: checks for formally correct JWTs.
 

--- a/detect_secrets/plugins/twilio.py
+++ b/detect_secrets/plugins/twilio.py
@@ -5,10 +5,7 @@ from __future__ import absolute_import
 
 import re
 
-import requests
-
 from .base import RegexBasedDetector
-from detect_secrets.core.constants import VerifiedResult
 
 
 class TwilioKeyDetector(RegexBasedDetector):

--- a/detect_secrets/plugins/twilio.py
+++ b/detect_secrets/plugins/twilio.py
@@ -1,0 +1,24 @@
+"""
+This plugin searches for Twilio API keys
+"""
+from __future__ import absolute_import
+
+import re
+
+import requests
+
+from .base import RegexBasedDetector
+from detect_secrets.core.constants import VerifiedResult
+
+
+class TwilioKeyDetector(RegexBasedDetector):
+    """Scans for Twilio API keys."""
+    secret_type = 'Twilio API Key'
+
+    denylist = [
+        # Account SID (ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+        re.compile(r'AC[a-z0-9]{32}'),
+
+        # Auth token (SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+        re.compile(r'SK[a-z0-9]{32}'),
+    ]

--- a/tests/plugins/twilio_test.py
+++ b/tests/plugins/twilio_test.py
@@ -23,4 +23,4 @@ class TestTwilioKeyDetector(object):
     def test_analyze(self, payload, should_flag):
         logic = TwilioKeyDetector()
         output = logic.analyze_line(payload, 1, 'mock_filename')
-        assert len(output) == int(should_flag)
+        assert output

--- a/tests/plugins/twilio_test.py
+++ b/tests/plugins/twilio_test.py
@@ -12,17 +12,15 @@ class TestTwilioKeyDetector(object):
         [
             (
                 'SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-                True
+                True,
             ),
             (
                 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-                True
-            ), 
+                True,
+            ),
         ],
     )
-    
     def test_analyze(self, payload, should_flag):
         logic = TwilioKeyDetector()
-        
         output = logic.analyze_line(payload, 1, 'mock_filename')
         assert len(output) == int(should_flag)

--- a/tests/plugins/twilio_test.py
+++ b/tests/plugins/twilio_test.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+import pytest
+
+from detect_secrets.plugins.twilio import TwilioKeyDetector
+
+
+class TestTwilioKeyDetector(object):
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            (
+                'SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                True
+            ),
+            (
+                'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                True
+            ), 
+        ],
+    )
+    
+    def test_analyze(self, payload, should_flag):
+        logic = TwilioKeyDetector()
+        
+        output = logic.analyze_line(payload, 1, 'mock_filename')
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
This commit contains a `RegexBasedDetector` plugin for Twilio API keys. Twilio's API requires an "account SID" and "auth token" which can be detected by this plugin using two regular expressions.

```
Example account SID: ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Regex: AC[a-z0-9]{32}

Example auth token: SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Regex: SK[a-z0-9]{32}
```

It might be worth further expanding this plugin to include a verify function that sends a GET request to `{}:{}@api.twilio.com/2010-04-01/Accounts.json`.