### PR TITLE
Not every company has a #security channel in slack/irc

### DIFF
--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -206,14 +206,17 @@ def _print_secrets_found(secrets):
 
 
 def _print_mitigation_suggestions():
-    security_team = os.environ.get("DETECT_SECRETS_SECURITY_TEAM", "in #security")
+    security_team = os.environ.get(
+        "DETECT_SECRETS_SECURITY_TEAM",
+        "in #security"
+    )
     suggestions = [
-        "For information about putting your secrets in a safer place, please ask "
-        + security_team,
-        "Mark false positives with an inline `pragma: allowlist secret` comment",
+        "For information about putting your secrets in a safer place, "
+        "please ask " + security_team,
+        "Mark false positives with an inline"
+        "`pragma: allowlist secret` comment",
         "Commit with `--no-verify` if this is a one-time false positive",
     ]
-
 
     wrapper = textwrap.TextWrapper(
         initial_indent='  - ',

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -207,15 +207,15 @@ def _print_secrets_found(secrets):
 
 def _print_mitigation_suggestions():
     security_team = os.environ.get(
-        "DETECT_SECRETS_SECURITY_TEAM",
-        "in #security"
+        'DETECT_SECRETS_SECURITY_TEAM',
+        'in #security'
     )
     suggestions = [
-        "For information about putting your secrets in a safer place, "
-        "please ask " + security_team,
-        "Mark false positives with an inline"
-        "`pragma: allowlist secret` comment",
-        "Commit with `--no-verify` if this is a one-time false positive",
+        'For information about putting your secrets in a safer place, ' +
+        'please ask ' + security_team,
+        'Mark false positives with an inline ' +
+        '`pragma: allowlist secret` comment',
+        'Commit with `--no-verify` if this is a one-time false positive',
     ]
 
     wrapper = textwrap.TextWrapper(

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
 import subprocess
 import sys
 import textwrap
@@ -205,11 +206,14 @@ def _print_secrets_found(secrets):
 
 
 def _print_mitigation_suggestions():
+    security_team = os.environ.get("DETECT_SECRETS_SECURITY_TEAM", "in #security")
     suggestions = [
-        'For information about putting your secrets in a safer place, please ask in #security',
-        'Mark false positives with an inline `pragma: allowlist secret` comment',
-        'Commit with `--no-verify` if this is a one-time false positive',
+        "For information about putting your secrets in a safer place, please ask "
+        + security_team,
+        "Mark false positives with an inline `pragma: allowlist secret` comment",
+        "Commit with `--no-verify` if this is a one-time false positive",
     ]
+
 
     wrapper = textwrap.TextWrapper(
         initial_indent='  - ',


### PR DESCRIPTION
> For information about putting your secrets in a safer place, please ask in #security

For us, in @alphagov, our **#security** channel is for physical security questions and our cyber security team hang out in **#cybersecurity**.

This seems like the simplest way to get the message changed, working even for people who don't - or can't - use a config.

My edits formatted with [black](https://github.com/psf/black)
EDIT: They're now linted by flake8, in accordance with the CI.