### PR TITLE
Terminate token matching

### DIFF
--- a/detect_secrets/plugins/ibm_cloud_iam.py
+++ b/detect_secrets/plugins/ibm_cloud_iam.py
@@ -17,7 +17,7 @@ class IbmCloudIamDetector(RegexBasedDetector):
     opt_dash_undrscr = r'(?:_|-|)'
     opt_api = r'(?:api|)'
     key_or_pass = r'(?:key|pwd|password|pass|token)'
-    secret = r'([a-zA-Z0-9_\-]{44})'
+    secret = r'([a-zA-Z0-9_\-]{44}(?![a-zA-Z0-9_\-]))'
     denylist = [
         RegexBasedDetector.assign_regex_generator(
             prefix_regex=opt_ibm_cloud_iam + opt_dash_undrscr + opt_api,

--- a/detect_secrets/plugins/ibm_cos_hmac.py
+++ b/detect_secrets/plugins/ibm_cos_hmac.py
@@ -22,7 +22,7 @@ class IbmCosHmacDetector(RegexBasedDetector):
 
     token_prefix = r'(?:(?:ibm)?[-_]?cos[-_]?(?:hmac)?|)'
     password_keyword = r'(?:secret[-_]?(?:access)?[-_]?key)'
-    password = r'([a-f0-9]{48})'
+    password = r'([a-f0-9]{48}(?![a-f0-9]))'
     denylist = (
         RegexBasedDetector.assign_regex_generator(
             prefix_regex=token_prefix,

--- a/tests/plugins/ibm_cloud_iam_test.py
+++ b/tests/plugins/ibm_cloud_iam_test.py
@@ -44,9 +44,12 @@ class TestIBMCloudIamDetector(object):
             ('ibm-cloud_api_key:={cloud_iam_key}'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
             ('"cloud_iam_api_key":="{cloud_iam_key}"'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
             ('ibm_iam_key:= "{cloud_iam_key}"'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
+            ('ibm_iam_key:= "{cloud_iam_key}extra"'.format(cloud_iam_key=CLOUD_IAM_KEY), False),
             ('ibm_api_key:="{cloud_iam_key}"'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
             ('ibm_password = "{cloud_iam_key}"'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
             ('ibm-cloud-pwd = {cloud_iam_key}'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
+            ('ibm-cloud-pwd = {cloud_iam_key}extra'.format(cloud_iam_key=CLOUD_IAM_KEY), False),
+            ('ibm-cloud-pwd = shorter-version', False),
             ('apikey:{cloud_iam_key}'.format(cloud_iam_key=CLOUD_IAM_KEY), True),
             ('iam_api_key="%s" % IBM_IAM_API_KEY_ENV', False),
             ('CLOUD_APIKEY: "insert_key_here"', False),
@@ -59,6 +62,8 @@ class TestIBMCloudIamDetector(object):
 
         output = logic.analyze_string_content(payload, 1, 'mock_filename')
         assert len(output) == (1 if should_flag else 0)
+        if should_flag:
+            assert list(output.values())[0].secret_value == CLOUD_IAM_KEY
 
     @responses.activate
     def test_verify_invalid_secret(self):

--- a/tests/plugins/ibm_cos_hmac_test.py
+++ b/tests/plugins/ibm_cos_hmac_test.py
@@ -22,30 +22,74 @@ class TestIbmCosHmacDetector(object):
     @pytest.mark.parametrize(
         'payload, should_flag',
         [
-            ('"secret_access_key": "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('secret_access_key=1234567890abcdef1234567890abcdef1234567890abcdef', True),
-            ('secret_access_key="1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('secret_access_key=\'1234567890abcdef1234567890abcdef1234567890abcdef\'', True),
-            ('secret_access_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
             (
-                'COS_HMAC_SECRET_ACCESS_KEY = "1234567890abcdef1234567890abcdef1234567890abcdef"',
+                '"secret_access_key": "{secret}"'.format(secret=SECRET_ACCESS_KEY),
                 True,
             ),
             (
-                'ibm_cos_SECRET_ACCESS_KEY = "1234567890abcdef1234567890abcdef1234567890abcdef"',
+                '"secret_access_key": "{secret}extra"'.format(secret=SECRET_ACCESS_KEY),
+                False,
+            ),
+            (
+                'secret_access_key={secret}'.format(secret=SECRET_ACCESS_KEY),
                 True,
             ),
             (
-                'ibm_cos_secret_access_key = "1234567890abcdef1234567890abcdef1234567890abcdef"',
+                'secret_access_key={secret}extra'.format(secret=SECRET_ACCESS_KEY),
+                False,
+            ),
+            (
+                'secret_access_key="{secret}"'.format(secret=SECRET_ACCESS_KEY),
                 True,
             ),
-            ('ibm_cos_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('cos_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('ibm-cos_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('cos-hmac_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('coshmac_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('ibmcoshmac_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
-            ('ibmcos_secret_key = "1234567890abcdef1234567890abcdef1234567890abcdef"', True),
+            (
+                'secret_access_key=\'{secret}\''.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'secret_access_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'COS_HMAC_SECRET_ACCESS_KEY = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'ibm_cos_SECRET_ACCESS_KEY = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'ibm_cos_secret_access_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'ibm_cos_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'cos_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'ibm-cos_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'cos-hmac_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'coshmac_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'ibmcoshmac_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
+            (
+                'ibmcos_secret_key = "{secret}"'.format(secret=SECRET_ACCESS_KEY),
+                True,
+            ),
             ('not_secret = notapassword', False),
             ('someotherpassword = "doesnt start right"', False),
         ],
@@ -55,6 +99,8 @@ class TestIbmCosHmacDetector(object):
 
         output = logic.analyze_line(payload, 1, 'mock_filename')
         assert len(output) == int(should_flag)
+        if should_flag:
+            assert list(output.values())[0].secret_value == SECRET_ACCESS_KEY
 
     @patch('detect_secrets.plugins.ibm_cos_hmac.verify_ibm_cos_hmac_credentials')
     def test_verify_invalid_secret(self, mock_hmac_verify):


### PR DESCRIPTION
Fixes https://github.com/Yelp/detect-secrets/issues/288

Terminate the string matching after required number of characters.