### PR TITLE
Pinning coverage version due to magical reasons.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
-coverage
+# coveragepy==5.0 fails with `Safety level may not be changed inside a transaction
+# on python 3.6.0 (xenial)
+coverage<5
 flake8==3.5.0
 mock
 monotonic


### PR DESCRIPTION
For more information, see https://github.com/Yelp/py_zipkin/pull/139.