### PR TITLE
:bug: Fix missing tuple() conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ If you love `detect-secrets`, please star our project on GitHub to show your sup
 ### Unreleased
 -->
 
+### Unreleased
+
+#### :bug: Bugfixes
+
+- Add missing `tuple()` conversion that raised a `TypeError` when using `scan --update` ([#317], thanks [@shaikmanu797])
+
+[#317]: https://github.com/Yelp/detect-secrets/pull/317
+[@shaikmanu797]: https://github.com/shaikmanu797
+
 # v0.14.0
 ##### July 9th, 2020
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ detect-secrets scan > .secrets.baseline
 ```
 $ cat .pre-commit-config.yaml
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: v0.13.1
+    rev: v0.14.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -115,8 +115,8 @@ class SecretsCollection:
                 # The difference will show whenever the word list changes
                 automaton, result.word_list_hash = build_automaton(result.word_list_file)
 
-        # In v0.13.2 the `--custom-plugins` option got added
-        result.custom_plugin_paths = data.get('custom_plugin_paths', ())
+        # In v0.14.0 the `--custom-plugins` option got added
+        result.custom_plugin_paths = tuple(data.get('custom_plugin_paths', ()))
 
         plugins = []
         for plugin in data['plugins_used']:

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -118,20 +118,16 @@ class SecretsCollection:
         # In v0.14.0 the `--custom-plugins` option got added
         result.custom_plugin_paths = tuple(data.get('custom_plugin_paths', ()))
 
-        plugins = []
-        for plugin in data['plugins_used']:
-            plugin_classname = plugin.pop('name')
-            plugins.append(
-                initialize.from_plugin_classname(
-                    plugin_classname,
-                    custom_plugin_paths=result.custom_plugin_paths,
-                    exclude_lines_regex=result.exclude_lines,
-                    automaton=automaton,
-                    should_verify_secrets=False,
-                    **plugin
-                ),
-            )
-        result.plugins = tuple(plugins)
+        result.plugins = tuple(
+            initialize.from_plugin_classname(
+                plugin_classname=plugin.pop('name'),
+                custom_plugin_paths=result.custom_plugin_paths,
+                exclude_lines_regex=result.exclude_lines,
+                automaton=automaton,
+                should_verify_secrets=False,
+                **plugin
+            ) for plugin in data['plugins_used']
+        )
 
         for filename in data['results']:
             result.data[filename] = {}

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -293,7 +293,7 @@ class TestBaselineInputOutput:
     def test_output(self, mock_gmtime):
         assert (
             self.logic.format_for_baseline_output()
-            == self.get_point_thirteen_point_two_and_later_baseline_dict(mock_gmtime)
+            == self.get_point_fourteen_point_zero_and_later_baseline_dict(mock_gmtime)
         )
 
     def test_load_baseline_from_string_with_pre_point_twelve_string(self, mock_gmtime):
@@ -348,7 +348,7 @@ class TestBaselineInputOutput:
                 json.dumps(original),
             ).format_for_baseline_output()
 
-        # v0.13.2+ assertions
+        # v0.14.0+ assertions
         assert 'custom_plugin_paths' not in original
         assert secrets['custom_plugin_paths'] == ()
 
@@ -387,8 +387,8 @@ class TestBaselineInputOutput:
             )
         assert mock_log.error_messages == 'Incorrectly formatted baseline!\n'
 
-    def get_point_thirteen_point_two_and_later_baseline_dict(self, gmtime):
-        # In v0.13.2 --custom-plugins got added
+    def get_point_fourteen_point_zero_and_later_baseline_dict(self, gmtime):
+        # In v0.14.0 --custom-plugins got added
         baseline = self.get_point_twelve_point_seven_and_later_baseline_dict(gmtime)
         baseline['custom_plugin_paths'] = ()
         return baseline


### PR DESCRIPTION
Also correct mentions of v0.13.2, which was the wrongly anticipated version, to v0.14.0.

Note: We have had bugs in the past with --update, a few mentioned in the CHANGELOG and a couple not. We should have a test that would of caught this. I'll think about adding one but for now given the priority that can come in a follow-up PR.