### PR TITLE
:bug: Fix AttributeError on Windows

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -104,14 +104,14 @@ def get_parser_to_add_opt_out_options_to(parser):
     :rtype: argparse.ArgumentParser
     :returns: argparse.ArgumentParser to pass into PluginOptions
     """
-    if parser.prog == 'detect-secrets-hook':
-        return parser
-
     for action in parser._actions:  # pragma: no cover (Always returns)
         if isinstance(action, argparse._SubParsersAction):
             for subparser in action.choices.values():
                 if subparser.prog.endswith('scan'):
                     return subparser
+    # Assume it is the 'detect-secrets-hook' console script
+    # Relying on parser.prog is too brittle
+    return parser
 
 
 class ParserBuilder:


### PR DESCRIPTION
For some reason the pre-commit hook did not have a parser.prog == 'detect-secrets-hook'.
Fixes #320.