### PR TITLE
Slack Plugin bug fixes

### DIFF
--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -58,6 +58,7 @@ class PotentialSecret:
 
     def set_secret(self, secret):
         self.secret_hash = self.hash_secret(secret)
+        self.secret_len = len(secret)
 
         # Note: Originally, we never wanted to keep the secret value in memory,
         #       after finding it in the codebase. However, to support verifiable
@@ -86,6 +87,7 @@ class PotentialSecret:
             'filename': self.filename,
             'line_number': self.lineno,
             'hashed_secret': self.secret_hash,
+            'secret_len': self.secret_len,
             'is_verified': self.is_verified,
         }
 

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -58,7 +58,6 @@ class PotentialSecret:
 
     def set_secret(self, secret):
         self.secret_hash = self.hash_secret(secret)
-        self.secret_len = len(secret)
 
         # Note: Originally, we never wanted to keep the secret value in memory,
         #       after finding it in the codebase. However, to support verifiable
@@ -87,7 +86,6 @@ class PotentialSecret:
             'filename': self.filename,
             'line_number': self.lineno,
             'hashed_secret': self.secret_hash,
-            'secret_len': self.secret_len,
             'is_verified': self.is_verified,
         }
 

--- a/detect_secrets/plugins/slack.py
+++ b/detect_secrets/plugins/slack.py
@@ -18,9 +18,7 @@ class SlackDetector(RegexBasedDetector):
         re.compile(r'xox(?:a|b|p|o|s|r)-(?:\d+-)+[a-z0-9]+', flags=re.IGNORECASE),
         # Slack Webhooks
         re.compile(
-            r"""
-            https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}
-            """,
+            r'https://hooks.slack.com/services/T[a-zA-Z0-9_]+/B[a-zA-Z0-9_]+/[a-zA-Z0-9_]+',
             flags=re.IGNORECASE | re.VERBOSE,
         ),
     )
@@ -33,7 +31,7 @@ class SlackDetector(RegexBasedDetector):
                     'text': '',
                 },
             )
-            valid = response.text == 'missing_text_or_fallback_or_attachments'
+            valid = response.text in ['missing_text_or_fallback_or_attachments', 'no_text']
         else:
             response = requests.post(
                 'https://slack.com/api/auth.test',


### PR DESCRIPTION
Fixed the slack webhooks regex to support longer urls which didn't match the existing one.
Also, added 'no_text' as a valid response.text. Without it some valid urls hasn't been marked as verified and didn't appear in the baseline at all