### PR TITLE
Improve wording of user prompt

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -579,7 +579,7 @@ def _get_user_decision(prompt_secret_decision=True, can_step_back=False):
             print('Invalid input.')
 
         if 'y' in allowable_user_input:
-            user_input_string = 'Is this a valid secret? i.e. not a false-positive (y)es, (n)o, '
+            user_input_string = 'Prevent this secret from being committed? (y)es, (n)o, '
         else:
             user_input_string = 'What would you like to do? '
         if 'b' in allowable_user_input:


### PR DESCRIPTION
On the first use, we are prompted:

```
Secret:      1 of 1
Filename:    dev.yml
Secret Type: Secret Keyword
----------
1:memory: 500M
2:db_password: mysecretpassword
3:db_user: ledger
4:db_name: ledger
5:db_ssl_option: ssl=none
6:disk_quota: 500M
7:disable_internal_https: 'true'
----------
Is this a valid secret? i.e. not a false-positive (y)es, (n)o, (s)kip, (q)uit: 
```

The wording of this prompt contains a double-negative which is hard to comprehend for a new user. To avoid the double negative, I propose an alternative clearer wording:

```
Secret:      1 of 1
Filename:    dev.yml
Secret Type: Secret Keyword
----------
1:memory: 500M
2:db_password: mysecretpassword
3:db_user: ledger
4:db_name: ledger
5:db_ssl_option: ssl=none
6:disk_quota: 500M
7:disable_internal_https: 'true'
----------
Prevent this secret from being committed? (y)es, (n)o, (s)kip, (q)uit: 
```