### PR TITLE
Added support for JUnit XML format

### DIFF
--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -269,6 +269,13 @@ class ScanOptions:
             help='Scan all files recursively (as compared to only scanning git tracked files).',
         )
 
+        self.parser.add_argument(
+            '--junit-xml',
+            action='store_true',
+            dest='junit_xml',
+            help='Returns output in JUnit XML format.',
+        )
+
         return self
 
     def _add_adhoc_scanning_argument(self):

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -61,6 +61,12 @@ def main(argv=sys.argv[1:]):
                     filename=args.import_filename[0],
                     data=baseline_dict,
                 )
+            elif args.junit_xml:
+                print(
+                    baseline.format_baseline_for_junit_xml(
+                        baseline_dict,
+                    ),
+                )
             else:
                 print(
                     baseline.format_baseline_for_output(

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         'pyyaml',
         'requests',
+        'junit-xml'
     ],
     extras_require={
         'word_list': [


### PR DESCRIPTION
JUnit XML format has become standard format for storage of test case results. When running detect-secrets on CI platforms like Jenkins and Bitbucket pipelines it becomes easier to read results if they are available in JUnit XML format. This PR adds a --junit-xml arg which can be used to print the result in the said format.

```
<?xml version="1.0" ?>
<testsuites disabled="0" errors="0" failures="150" tests="150" time="0.0">
	<testsuite disabled="0" errors="0" failures="53" name="Secret Keyword" skipped="0" tests="53" time="0">
		<testcase name=".secrets.baseline:26">
			<failure message="Found secret of type Secret Keyword on line 26 in file .secrets.baseline" type="Secret Keyword"/>
		</testcase>
		<testcase name=".secrets.baseline:33">
			<failure message="Found secret of type Secret Keyword on line 33 in file .secrets.baseline" type="Secret Keyword"/>
		</testcase>
```