### PR TITLE
Faster raw secret fetch during audit

### DIFF
--- a/detect_secrets/core/audit.py
+++ b/detect_secrets/core/audit.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from copy import deepcopy
 from functools import lru_cache
 
+from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.core.baseline import merge_results
 from detect_secrets.core.bidirectional_iterator import BidirectionalIterator
 from detect_secrets.core.code_snippet import CodeSnippetHighlighter
@@ -275,10 +276,7 @@ def determine_audit_results(baseline, baseline_path):
         try:
             secret_info['plaintext'] = get_raw_secret_value(
                 secret=secret,
-                plugins_used=baseline['plugins_used'],
-                custom_plugin_paths=baseline['custom_plugin_paths'],
-                file_handle=io.StringIO(file_contents),
-                filename=filename,
+                file_handle=io.StringIO(file_contents)
             )
         except SecretNotFoundOnSpecifiedLineError:
             secret_info['plaintext'] = None
@@ -683,10 +681,7 @@ def _get_secret_with_context(
 
         raw_secret_value = get_raw_secret_value(
             secret=secret,
-            plugins_used=plugins_used,
-            custom_plugin_paths=custom_plugin_paths,
-            file_handle=io.StringIO(file_content),
-            filename=filename,
+            file_handle=io.StringIO(file_content)
         )
 
         try:
@@ -707,45 +702,28 @@ def _get_secret_with_context(
 
 def get_raw_secret_value(
     secret,
-    plugins_used,
-    custom_plugin_paths,
-    file_handle,
-    filename,
+    file_handle
 ):
     """
     :type secret: dict
     :param secret: see caller's docstring
 
-    :type plugins_used: list
-    :param plugins_used: output of "plugins_used" in baseline. e.g.
-        >>> [
-        ...     {
-        ...         'name': 'Base64HighEntropyString',
-        ...         'base64_limit': 4.5,
-        ...     },
-        ... ]
-
-    :type custom_plugin_paths: Tuple[str]
-    :param custom_plugin_paths: possibly empty tuple of paths that have custom plugins.
-
     :type file_handle: file object
     :param file_handle: Open handle to file where the secret is
 
-    :type filename: str
-    :param filename: this is needed, because PotentialSecret uses this
-        as a means of comparing whether two secrets are equal.
     """
-    plugin = initialize.from_secret_type(
-        secret_type=secret['type'],
-        plugins_used=plugins_used,
-        custom_plugin_paths=custom_plugin_paths,
-    )
+    secret_length = secret['secret_length']
+    secret_position = secret['position']
+    line_number = secret['line_number']
 
-    plugin_secrets = plugin.analyze(file_handle, filename)
+    file_lines = file_handle.readlines()
+    if len(file_lines) >= line_number:
+        line = file_lines[line_number - 1]
+        possible_secret = line[secret_position:secret_position + secret_length]
+        possible_secret_hash = PotentialSecret.hash_secret(possible_secret)
+        lowered_possible_secret_hash = PotentialSecret.hash_secret(possible_secret.lower())
 
-    # Return value of matching secret
-    for plugin_secret in plugin_secrets:
-        if plugin_secret.secret_hash == secret['hashed_secret']:
-            return plugin_secret.secret_value
+        if secret['hashed_secret'] in [possible_secret_hash, lowered_possible_secret_hash]:
+            return possible_secret
 
-    raise SecretNotFoundOnSpecifiedLineError(secret['line_number'])
+    raise SecretNotFoundOnSpecifiedLineError(line_number)

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -84,8 +84,8 @@ def initialize(
 
     for file in sorted(files_to_scan):
         output.scan_file(file)
-        with open(file) as temp_file:
-            file_lines = temp_file.readlines()
+        with open(file) as f:
+            file_lines = f.readlines()
             
         if file in output.data:
             for secret in output.data[file]:

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -84,6 +84,16 @@ def initialize(
 
     for file in sorted(files_to_scan):
         output.scan_file(file)
+        with open(file) as temp_file:
+            file_lines = temp_file.readlines()
+            
+        if file in output.data:
+            for secret in output.data[file]:
+                line_number = secret.lineno
+                if len(file_lines) >= line_number:
+                    line = file_lines[line_number - 1]
+                    if secret.secret_value.lower() in line.lower():
+                        secret.position = line.lower().index(secret.secret_value.lower())
 
     return output
 

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -50,6 +50,8 @@ class PotentialSecret:
         self.set_secret(secret)
         self.is_secret = is_secret
         self.is_verified = False
+        self.secret_length = len(secret)
+        self.position = -1
 
         # If two PotentialSecrets have the same values for these fields,
         # they are considered equal. Note that line numbers aren't included
@@ -87,6 +89,8 @@ class PotentialSecret:
             'line_number': self.lineno,
             'hashed_secret': self.secret_hash,
             'is_verified': self.is_verified,
+            'secret_length': self.secret_length,
+            'position': self.position
         }
 
         if self.is_secret is not None:


### PR DESCRIPTION
During audit, each file is re-scanned using every plugin, generating a list of secret hashes which are then compared to the 'hashed_secret' value of the secret (this is done by the get_raw_secret_value function).
Although this process should allow detecting secrets which are not in the correct line - this is not currently not supported while auditing and for good reason. If the code was changed you'll want to create a new baseline.
To speed up this process, I've added the secret length and position in line into each PotentialSecret object, which then makes the get_raw_secret_value function go super fast and removes dependancy on plugins.