### PR TITLE
Fix adhoc scan verify

### DIFF
--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -27,8 +27,8 @@ class AWSKeyDetector(RegexBasedDetector):
     def disable_flag_text(cls):
         return 'no-aws-key-scan'
 
-    def verify(self, token, content):
-        secret_access_key_candidates = get_secret_access_keys(content)
+    def verify(self, token, context):
+        secret_access_key_candidates = get_secret_access_keys(context)
         if not secret_access_key_candidates:
             return VerifiedResult.UNVERIFIED
 

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -144,7 +144,7 @@ class BasePlugin:
                     lines_of_context=LINES_OF_CONTEXT,
                 )
 
-                is_verified = self.verify(result.secret_value, content=str(snippet))
+                is_verified = self.verify(result.secret_value, context=str(snippet))
                 if is_verified == VerifiedResult.VERIFIED_TRUE:
                     result.is_verified = True
 
@@ -239,7 +239,7 @@ class BasePlugin:
 
         return output[verified_result]
 
-    def verify(self, token, content=''):
+    def verify(self, token, context=''):
         """
         To increase accuracy and reduce false positives, plugins can also
         optionally declare a method to verify their status.

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -226,7 +226,7 @@ class BasePlugin:
 
         verified_result = VerifiedResult.UNVERIFIED
         for result in results:
-            is_verified = self.verify(result.secret_value)
+            is_verified = self.verify(result.secret_value, string)
             if is_verified != VerifiedResult.UNVERIFIED:
                 verified_result = is_verified
                 break

--- a/detect_secrets/plugins/cloudant.py
+++ b/detect_secrets/plugins/cloudant.py
@@ -60,9 +60,9 @@ class CloudantDetector(RegexBasedDetector):
         ),
     ]
 
-    def verify(self, token, content):
+    def verify(self, token, context):
 
-        hosts = find_account(content)
+        hosts = find_account(context)
         if not hosts:
             return VerifiedResult.UNVERIFIED
 
@@ -72,7 +72,7 @@ class CloudantDetector(RegexBasedDetector):
         return VerifiedResult.VERIFIED_FALSE
 
 
-def find_account(content):
+def find_account(context):
     opt_hostname_keyword = r'(?:hostname|host|username|id|user|userid|user-id|user-name|' \
         'name|user_id|user_name|uname|account)'
     account = r'(\w[\w\-]*)'
@@ -98,7 +98,7 @@ def find_account(content):
 
     return [
         match
-        for line in content.splitlines()
+        for line in context.splitlines()
         for regex in regexes
         for match in regex.findall(line)
     ]

--- a/detect_secrets/plugins/ibm_cos_hmac.py
+++ b/detect_secrets/plugins/ibm_cos_hmac.py
@@ -29,8 +29,8 @@ class IbmCosHmacDetector(RegexBasedDetector):
         ),
     )
 
-    def verify(self, token, content):
-        key_id_matches = find_access_key_id(content)
+    def verify(self, token, context):
+        key_id_matches = find_access_key_id(context)
 
         if not key_id_matches:
             return VerifiedResult.UNVERIFIED
@@ -48,7 +48,7 @@ class IbmCosHmacDetector(RegexBasedDetector):
         return VerifiedResult.VERIFIED_FALSE
 
 
-def find_access_key_id(content):
+def find_access_key_id(context):
     key_id_keyword_regex = r'(?:access[-_]?(?:key)?[-_]?(?:id)?|key[-_]?id)'
     key_id_regex = r'([a-f0-9]{32})'
 
@@ -60,7 +60,7 @@ def find_access_key_id(content):
 
     return [
         match
-        for line in content.splitlines()
+        for line in context.splitlines()
         for match in regex.findall(line)
     ]
 

--- a/detect_secrets/plugins/softlayer.py
+++ b/detect_secrets/plugins/softlayer.py
@@ -28,8 +28,8 @@ class SoftlayerDetector(RegexBasedDetector):
         ),
     ]
 
-    def verify(self, token, content):
-        usernames = find_username(content)
+    def verify(self, token, context):
+        usernames = find_username(context)
         if not usernames:
             return VerifiedResult.UNVERIFIED
 
@@ -39,7 +39,7 @@ class SoftlayerDetector(RegexBasedDetector):
         return VerifiedResult.VERIFIED_FALSE
 
 
-def find_username(content):
+def find_username(context):
     # opt means optional
     username_keyword = (
         r'(?:'
@@ -58,7 +58,7 @@ def find_username(content):
 
     return [
         match
-        for line in content.splitlines()
+        for line in context.splitlines()
         for match in regex.findall(line)
     ]
 


### PR DESCRIPTION
The `self.verify` call was missing a parameter in the adhoc string scanning function. This PR adds the missing parameter.

Also, I noticed that a parameter name for `verify` was misnamed. I fixed that in this PR too.