### PR TITLE
Change exclude *test* example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ cat .pre-commit-config.yaml
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude: .*/tests/.*
+        exclude: package.lock.json
 ```
 
 


### PR DESCRIPTION
For our usage, we've found the biggest potential leaker of secrets is using un-redacted customer data in tests.

The example config should **not** have `tests/` excluded.