### PR TITLE
Modify regex patterns for keyword detector to identify patterns with keyword and appended string

### DIFF
--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -107,14 +107,16 @@ FALSE_POSITIVES = {
     'null;',
     'pass',
     'pass)',
-    'password',
+    # Secrets with this value not detected (Could be and actual password)
+    #'password',
     'password)',
     'password))',
     'password,',
     'password},',
     'prompt',
     'redacted',
-    'secret',
+    # Secrets with this value not detected (Could be and actual password)
+    #'secret',
     'some_key',
     'str',
     'str_to_sign',
@@ -151,7 +153,8 @@ SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password := "bar" or my_password := bar
-    r'({denylist})({closing})?{whitespace}:=?{whitespace}({quote}?)({secret})(\3)'.format(
+    # (Bug fix) Strings with pattern: password_foo/api_key_xyz not detected, hence added a regex pattern to detect such strings
+    r'({denylist})[^.]*({closing})?{whitespace}:=?{whitespace}({quote}?)({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -161,7 +164,8 @@ FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
 )
 FOLLOWED_BY_COLON_REGEX = re.compile(
     # e.g. api_key: foo
-    r'({denylist})({closing})?:{whitespace}({quote}?)({secret})(\3)'.format(
+    # (Bug fix) Strings with pattern: password_foo/api_key_xyz not detected, hence added a regex pattern to detect such strings
+    r'({denylist})[^.]*({closing})?:{whitespace}({quote}?)({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -171,7 +175,8 @@ FOLLOWED_BY_COLON_REGEX = re.compile(
 )
 FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. api_key: "foo"
-    r'({denylist})({closing})?:({whitespace})({quote})({secret})(\4)'.format(
+    # (Bug fix) Strings with pattern: password_foo/api_key_xyz not detected, hence added a regex pattern to detect such strings
+    r'({denylist})[^.]*({closing})?:({whitespace})({quote})({secret})(\4)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -183,7 +188,8 @@ FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX
     # e.g. my_password = "bar"
     # e.g. my_password = @"bar"
     # e.g. my_password[] = "bar";
-    r'({denylist})({square_brackets})?{optional_whitespace}={optional_whitespace}(@)?(")({secret})(\5)'.format(  # noqa: E501
+    # (Bug fix) Strings with pattern: password_foo/api_key_xyz not detected, hence added a regex pattern to detect such strings
+    r'({denylist})[^.]*({square_brackets})?{optional_whitespace}={optional_whitespace}(@)?(")({secret})(\5)'.format(  # noqa: E501
         denylist=DENYLIST_REGEX,
         square_brackets=SQUARE_BRACKETS,
         optional_whitespace=OPTIONAL_WHITESPACE,
@@ -192,7 +198,8 @@ FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX
 )
 FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password = bar
-    r'({denylist})({closing})?{whitespace}={whitespace}({quote}?)({secret})(\3)'.format(
+    # (Bug fix) Strings with pattern: password_foo/api_key_xyz not detected, hence added a regex pattern to detect such strings
+    r'({denylist})[^.]*({closing})?{whitespace}={whitespace}({quote}?)({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -202,7 +209,8 @@ FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
 )
 FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. my_password = "bar"
-    r'({denylist})({closing})?{whitespace}={whitespace}({quote})({secret})(\3)'.format(
+    # (Bug fix) Strings with pattern: password_foo/api_key_xyz not detected, hence added a regex pattern to detect such strings
+    r'({denylist})[^.]*({closing})?{whitespace}={whitespace}({quote})({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -13,7 +13,7 @@ FOLLOWED_BY_COLON_EQUAL_SIGNS_RE = {
             'theapikey := "somefakekey"',  # 'fake' in the secret
         ],
         'quotes_not_required': [
-            'theapikeyforfoo := hopenobodyfindsthisone',  # Characters between apikey and :=
+            # 'theapikeyforfoo := hopenobodyfindsthisone',  # Characters between apikey and :=
         ],
     },
     'positives': {
@@ -28,12 +28,28 @@ FOLLOWED_BY_COLON_EQUAL_SIGNS_RE = {
             "apikey:= 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
             "apikey:='m{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
             "apikey:=  'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            #Digja - regex changes
+            'api_keyforfoo := "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'apikey_foo :="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'apikey_foo  :=   "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            "apikeyforfoo := 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            "apikeyfor_foo :='m{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            'apikeyfoo:= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'apikeyfoo:="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            "apikeyfoo:= 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            "apikey_for_foo:='m{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            "apikeyforfoo:=  'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
         ],
         'quotes_not_required': [
             'apikey := m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'apikey :=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'apikey:= m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'apikey:=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            #Digja - regex changes
+            'apikeyforfoo := m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'apikeyforfoo :=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'apikeyforfoo:= m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'apikeyforfoo:=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
         ],
     },
 }
@@ -44,7 +60,7 @@ FOLLOWED_BY_COLON_RE = {
             'theapikey: "somefakekey"',  # 'fake' in the secret
         ],
         'quotes_not_required': [
-            'theapikeyforfoo:hopenobodyfindsthisone',  # Characters between apikey and :
+            # 'theapikeyforfoo:hopenobodyfindsthisone',  # Characters between apikey and :
             'password: ${link}',  # Has a ${ followed by a }
         ],
     },
@@ -54,11 +70,21 @@ FOLLOWED_BY_COLON_RE = {
             '"theapikey": "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
             'apikey: "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
             "apikey:  'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            #Digja - regex changes
+            'apikeyforxyz: "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            "apikeyforxyz:  'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            "'theapikeyforzyx': 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
+            '"theapikeyforxyz": "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+
         ],
         'quotes_not_required': [
             'apikey: m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'apikey:m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'theapikey:m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            #Digja - regex changes
+            'apikeyforxyz: m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'apikeyforxyz:m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'theapikeyforxyz:m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
         ],
     },
 }
@@ -79,6 +105,11 @@ FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX
             'apikey  =   @"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
             'apikey[]= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
             'apikey[]="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            #Digja - regex changes
+            'apikeyforfoo[]= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'apikeyforfoo="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'apikeyforfoo  =   @"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+
         ],
     },
 }
@@ -104,6 +135,9 @@ FOLLOWED_BY_EQUAL_SIGNS_RE = {
             'some_dict["secret"] = "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
             'the_password= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
             'the_password=\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
+            #Digja - regex changes
+            'the_password_foo= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
+            'the_passwordfoo=\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
         ],
         'quotes_not_required': [
             "some_dict['secret'] = m{{h}o)p${e]nob(ody[finds>-_$#thisone}}",
@@ -113,6 +147,12 @@ FOLLOWED_BY_EQUAL_SIGNS_RE = {
             'my_password = m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'my_password =m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
             'the_password=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\n',
+            #Digja - regex changes
+            'the_password_foo=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\n',
+            'my_passwordfoo= m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'my_passwordfoo =m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'my_password_foo = m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
+            'my_password_foo =m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
         ],
     },
 }
@@ -136,6 +176,7 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE = {
             'private_key \'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\';',  # Single-quotes
             'fooprivate_keyfoo\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\';',  # Single-quotes
             'fooprivate_key\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\';',  # Single-quotes
+
         ],
     },
 }
@@ -292,7 +333,6 @@ class TestKeywordDetector:
     )
     def test_analyze_standard_negatives(self, file_content):
         logic = KeywordDetector()
-
         f = mock_file_object(file_content)
         output = logic.analyze(f, 'mock_filename.foo')
         assert len(output) == 0


### PR DESCRIPTION
1. This change is mainly to identify keywords with variable names like -
PASSWORD**_FOO**
API_KEY**_XYZ**

Keyword detector doesn't consider variable names with above pattern as a secret, but detects variable names with pattern as a secret- 
XYZ_PASSWORD
FOO_API_KEY 

Variable names can have strings appended before/after the keyword.

2. Removed password, secret from the false positives list in keyword.py as these can be the passwords and it isn't a good idea to filter them out.

