### PR TITLE
Fix issue with detect-secrets-server and -custom-plugins #343

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ If you love `detect-secrets`, please star our project on GitHub to show your sup
 -->
 
 ### v0.14.3
+
+##### September 16th, 2020
+
+#### :bug: Bugfixes
+
+- Fix compatibility issue with detect-secrets-server after introduction of "---custom-plugins" ([#343], by [@francisluz])
+
 ##### August 27th, 2020
 
 #### :telescope: Accuracy

--- a/detect_secrets/core/usage.py
+++ b/detect_secrets/core/usage.py
@@ -448,15 +448,18 @@ class PluginOptions:
 
         active_plugins = {}
         is_using_default_value = {}
+        # Validate custom_plugin_paths arg as it's optional parameter.
+        custom_plugin_paths = args.custom_plugin_paths if 'custom_plugin_paths' in args else ()
 
-        for plugin in get_all_plugin_descriptors(args.custom_plugin_paths):
+        for plugin in get_all_plugin_descriptors(custom_plugin_paths):
             arg_name = PluginOptions._convert_flag_text_to_argument_name(
                 plugin.disable_flag_text,
             )
 
             # Remove disabled plugins
             is_disabled = getattr(args, arg_name, False)
-            delattr(args, arg_name)
+            if(hasattr(args, arg_name)):
+                delattr(args, arg_name)
             if is_disabled:
                 continue
 

--- a/tests/core/usage_test.py
+++ b/tests/core/usage_test.py
@@ -1,6 +1,8 @@
 import pytest
 
 from detect_secrets.plugins.common.util import import_plugins
+from detect_secrets.core.usage import PluginOptions
+
 from testing.util import parse_pre_commit_args_with_correct_prog
 
 
@@ -84,3 +86,13 @@ class TestPluginOptions:
         else:
             with pytest.raises(SystemExit):
                 parse_pre_commit_args_with_correct_prog(argument_string)
+
+    def test_consolidate_args_without_custom_plugins(self):
+        args = parse_pre_commit_args_with_correct_prog()
+        setattr(args, 'hex_limit', None)
+        setattr(args, 'keyword_exclude', None)
+        setattr(args, 'base64_limit', None)
+        delattr(args, 'custom_plugin_paths')
+        PluginOptions.consolidate_args(args)
+
+        assert( hasattr(args, 'custom_plugin_paths')  == False)


### PR DESCRIPTION
#### 🐛 Bug Report
This bug has been reported at [#343]

#### 💡 Solution

Implemented double check code when using `custom_plugin_paths` and verify if the attribute is on the collection before delete it.