### PR TITLE
Adding --list-all-plugins

### DIFF
--- a/detect_secrets/core/usage/plugins.py
+++ b/detect_secrets/core/usage/plugins.py
@@ -15,6 +15,12 @@ def add_plugin_options(parent: argparse.ArgumentParser) -> None:
         ),
     )
 
+    parser.add_argument(
+        '--list-all-plugins',
+        action='store_true',
+        help='Lists all plugins that will be used for the scan.',
+    )
+
     _add_custom_limits(parser)
     _add_disable_flag(parser)
     # TODO: custom plugins?

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -12,6 +12,7 @@ from .core.scan import get_plugins
 from .core.scan import scan_line
 from .core.usage import ParserBuilder
 from .exceptions import InvalidBaselineError
+from .settings import get_settings
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -35,6 +36,12 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
 
 
 def handle_scan_action(args: argparse.Namespace) -> None:
+    if args.list_all_plugins:
+        # NOTE: If there was a baseline provided, it would already have been parsed and
+        # settings populated by the time it reaches here.
+        print('\n'.join(get_settings().plugins))
+        return
+
     if args.string:
         line = args.string
         if isinstance(args.string, bool):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -120,6 +120,13 @@ class TestScanString:
             assert printer.message.strip() == 'AWSKeyDetector: False'
 
 
+def test_list_all_plugins():
+    with mock_printer(main_module) as printer:
+        assert main_module.main(['scan', '--list-all-plugins']) == 0
+
+    assert printer.message
+
+
 @contextmanager
 def mock_stdin(response=None):
     if not response:


### PR DESCRIPTION
## Summary

Adds `--list-all-plugins` argument to list all plugins used.

```
$ detect-secrets scan --list-all-plugins
ArtifactoryDetector
AWSKeyDetector
AzureStorageKeyDetector
BasicAuthDetector
CloudantDetector
Base64HighEntropyString
HexHighEntropyString
IbmCloudIamDetector
IbmCosHmacDetector
JwtTokenDetector
KeywordDetector
MailchimpDetector
NpmDetector
PrivateKeyDetector
SlackDetector
SoftlayerDetector
StripeDetector
TwilioKeyDetector
```

or with baseline support:

```
$ detect-secrets scan --disabled-plugins KeywordDetector test_data > test.baseline
$ detect-secrets scan --list-all-plugins --baseline test.baseline | grep 'KeywordDetector'
```

This opens the path for CLI usage as such:

```
$ detect-secrets scan --list-all-plugins | \
    grep -v 'BasicAuthDetector' | \
    sed "s#^#--disable-plugin #g | \
    xargs detect-secrets scan test_data
```

so you can run a specific plugin, without needing to disable everything manually (or writing some funky logic to resolve enablement / disablement of plugins).