### PR TITLE
fix hang with very long lines

### DIFF
--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -146,7 +146,7 @@ CLOSING = r'[]\'"]{0,2}'
 DENYLIST_REGEX = r'|'.join(DENYLIST)
 # Non-greedy match
 OPTIONAL_WHITESPACE = r'\s*?'
-OPTIONAL_NON_WHITESPACE = r'[^\s]*?'
+OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"]'
 SECRET = r'[^\s]+'
 SQUARE_BRACKETS = r'(\[\])'


### PR DESCRIPTION
Fixes #372

OPTIONAL_NON_WHITESPACE is used only in [FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX](https://github.com/Yelp/detect-secrets/blob/30ecb2da0b08dca52a32b4028f7b21f92b8e1ff7/detect_secrets/plugins/keyword.py#L215). I'm not completely sure of the intended use of OPTIONAL_NON_WHITESPACE there. The example is:
```python
    # e.g. private_key "something";
```
I'm guessing it is meant to also handle something like this, where "_for_the_server" would be matched by OPTIONAL_NON_WHITESPACE. My change limits matching of that extra text to 50 characters.
```c
private_key_for_the_server "something";
```