### PR TITLE
Deprecate whitelist pragma and hyphen in pragma

### DIFF
--- a/detect_secrets/filters/allowlist.py
+++ b/detect_secrets/filters/allowlist.py
@@ -35,8 +35,7 @@ def _get_allowlist_regexes() -> List[Pattern]:
     return [
         re.compile(r)
         for r in [
-            # Note: Always use allowlist, whitelist will be deprecated in the future
-            r'[ \t]+{} *pragma: ?(allow|white)list[ -]secret.*?{}[ \t]*$'.format(start, end)
+            r'[ \t]+{} *pragma: allowlist secret.*?{}[ \t]*$'.format(start, end)
             for start, end in (
                 ('#', ''),                    # e.g. python or yaml
                 ('//', ''),                   # e.g. golang

--- a/tests/filters/allowlist_filter_test.py
+++ b/tests/filters/allowlist_filter_test.py
@@ -28,13 +28,6 @@ def test_basic(prefix, suffix):
     )
 
 
-def test_backwards_compatibility():
-    assert is_line_allowlisted(
-        'filename',
-        'AKIAEXAMPLE  # pragma: whitelist secret',
-    )
-
-
 @pytest.mark.parametrize(
     'line, expected_result',
     (


### PR DESCRIPTION
This removes support for whitelisting lines using
the "whitelist" pragma. Users should switch to "allowlist".

This also removes support for the hyphen in the
allowlist pragma (e.g. "# allowlist-secret") which apparently
we supported, but wasn't documented anywhere.

Closes #375

Tested with `tox -e py38`.