### PR TITLE
Better scanning UX

### DIFF
--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -53,10 +53,13 @@ def get_files_to_scan(
 
     See test cases for more details.
     """
+    # First, we determine the appropriate filtering mode to be used.
     # If this is True, then it will consider everything to be valid.
     # Otherwise, it will only list the files that are valid.
     valid_paths: Union[bool, Set[str]] = True
     for path in paths:
+        # Since this is not a directory, we assume that it is a file proper, and automatically
+        # consider it valid.
         if not os.path.isdir(path):
             continue
 
@@ -67,6 +70,8 @@ def get_files_to_scan(
                 log.warning('Did not detect git repository. Try scanning all files instead.')
                 valid_paths = False
 
+        # Since valid_paths attempts to get *all* tracked files in the repository, we just need
+        # to initialize it once.
         break
 
     if not valid_paths:

--- a/tests/core/scan_test.py
+++ b/tests/core/scan_test.py
@@ -38,6 +38,28 @@ class TestGetFilesToScan:
         )
 
     @staticmethod
+    def test_handles_each_path_separately(non_tracked_file):
+        results = list(
+            scan.get_files_to_scan(
+                non_tracked_file.name,
+                'test_data/short_files',
+            ),
+        )
+
+        # This implies that the test_data/short_files directory is scanned, because otherwise,
+        # it would only be one file. However, at the same time, this test case isn't fragile to
+        # additions to this directory.
+        assert len(results) > 2
+
+    @staticmethod
+    def test_handles_multiple_directories():
+        directories = ['test_data/short_files', 'test_data/files']
+        results = list(scan.get_files_to_scan(*directories))
+
+        for prefix in directories:
+            assert len(list(filter(lambda x: x.startswith(prefix), results))) > 1
+
+    @staticmethod
     @pytest.fixture(autouse=True, scope='class')
     def non_tracked_file():
         with tempfile.NamedTemporaryFile(

--- a/tests/core/scan_test.py
+++ b/tests/core/scan_test.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import textwrap
 
@@ -5,29 +6,72 @@ import pytest
 
 from detect_secrets.core import scan
 from detect_secrets.settings import transient_settings
+from detect_secrets.util import git
+from detect_secrets.util.path import get_relative_path_if_in_cwd
 
 
-def test_handles_broken_yaml_gracefully():
-    with tempfile.NamedTemporaryFile(suffix='.yaml') as f:
-        f.write(
-            textwrap.dedent("""
-            metadata:
-                name: {{ .values.name }}
-            """)[1:].encode(),
+class TestGetFilesToScan:
+    @staticmethod
+    def test_should_scan_specific_non_tracked_file(non_tracked_file):
+        assert list(scan.get_files_to_scan(non_tracked_file.name, should_scan_all_files=False))
+
+    @staticmethod
+    def test_should_scan_tracked_files_in_directory(non_tracked_file):
+        assert (
+            get_relative_path_if_in_cwd(non_tracked_file.name) not in set(
+                scan.get_files_to_scan(
+                    os.path.dirname(non_tracked_file.name),
+                    should_scan_all_files=False,
+                ),
+            )
         )
-        f.seek(0)
 
-        assert not list(scan.scan_file(f.name))
+    @staticmethod
+    def test_should_scan_all_files_in_directory_if_flag_is_provided(non_tracked_file):
+        assert (
+            get_relative_path_if_in_cwd(non_tracked_file.name) in set(
+                scan.get_files_to_scan(
+                    os.path.dirname(non_tracked_file.name),
+                    should_scan_all_files=True,
+                ),
+            )
+        )
+
+    @staticmethod
+    @pytest.fixture(autouse=True, scope='class')
+    def non_tracked_file():
+        with tempfile.NamedTemporaryFile(
+            prefix=os.path.join(git.get_root_directory(), 'test_data/'),
+        ) as f:
+            f.write(b'content does not matter')
+            f.seek(0)
+
+            yield f
 
 
-def test_handles_binary_files_gracefully():
-    # NOTE: This suffix needs to be something that isn't in the known file types, as determined
-    # by `detect_secrets.util.filetype.determine_file_type`.
-    with tempfile.NamedTemporaryFile(suffix='.woff2') as f:
-        f.write(b'\x86')
-        f.seek(0)
+class TestScanFile:
+    @staticmethod
+    def test_handles_broken_yaml_gracefully():
+        with tempfile.NamedTemporaryFile(suffix='.yaml') as f:
+            f.write(
+                textwrap.dedent("""
+                metadata:
+                    name: {{ .values.name }}
+                """)[1:].encode(),
+            )
+            f.seek(0)
 
-        assert not list(scan.scan_file(f.name))
+            assert not list(scan.scan_file(f.name))
+
+    @staticmethod
+    def test_handles_binary_files_gracefully():
+        # NOTE: This suffix needs to be something that isn't in the known file types, as determined
+        # by `detect_secrets.util.filetype.determine_file_type`.
+        with tempfile.NamedTemporaryFile(suffix='.woff2') as f:
+            f.write(b'\x86')
+            f.seek(0)
+
+            assert not list(scan.scan_file(f.name))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This improves the scanning usability of this tool by allowing scans for non-tracked git files, without passing a flag.

e.g.

```bash
$ echo "secret = 'blah'" > blah.py
$ detect-secrets scan blah.py
...
  "results": {
    "blah.py": [
      {
        "type": "Secret Keyword",
        "filename": "blah.py",
        "hashed_secret": "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
        "is_verified": false,
        "line_number": 1
      }
    ]
  }
}
```

This still does not address the ability to scan files outside the current git repository, because I haven't figured what to do with the baseline files. That is, the implicit assumption for the baseline is that it is run at git root, so that all the files can be found and navigated to with the audit / pre-commit tool. It's really unclear what it would mean if this is run from a non-git repository.