### PR TITLE
Ensuring consistent serialized baselines

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,90 +1,250 @@
 {
-  "exclude_regex": "test_data/.*|tests/.*|^.secrets.baseline$",
-  "generated_at": "2018-12-21T22:29:02Z",
+  "generated_at": "2020-12-12T01:34:30Z",
+  "version": "0.14.3",
   "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
     {
       "name": "AWSKeyDetector"
     },
     {
-      "base64_limit": 4.5,
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "limit": 4.5,
       "name": "Base64HighEntropyString"
     },
     {
       "name": "BasicAuthDetector"
     },
     {
-      "hex_limit": 3,
+      "name": "CloudantDetector"
+    },
+    {
+      "limit": 3.0,
       "name": "HexHighEntropyString"
     },
     {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": "",
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": "test*"
     }
   ],
   "results": {
     "README.md": [
       {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "line_number": 153,
-        "type": "Basic Auth Credentials"
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "21aec83d523e5dcc7daa669d1d7de6cebe242426",
+        "is_verified": false,
+        "line_number": 371
       }
     ],
-    "detect_secrets/plugins/high_entropy_strings.py": [
+    "detect_secrets/plugins/keyword.py": [
       {
-        "hashed_secret": "88a7b59d2e9172960b72b65f7839b9da2453f3e9",
-        "is_secret": false,
-        "line_number": 261,
-        "type": "Hex High Entropy String"
+        "type": "Secret Keyword",
+        "filename": "detect_secrets/plugins/keyword.py",
+        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "is_verified": false,
+        "line_number": 176
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "detect_secrets/plugins/keyword.py",
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "detect_secrets/plugins/keyword.py",
+        "hashed_secret": "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "detect_secrets/plugins/keyword.py",
+        "hashed_secret": "2a8951fc713e17840a8fe7e60050f66c66f58083",
+        "is_verified": false,
+        "line_number": 344
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "detect_secrets/plugins/keyword.py",
+        "hashed_secret": "6346ef778712eda3bf9b52b3e57d79946bf2a6c9",
+        "is_verified": false,
+        "line_number": 346
       }
     ],
     "detect_secrets/plugins/private_key.py": [
       {
-        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
-        "is_secret": false,
-        "line_number": 43,
-        "type": "Private Key"
-      },
-      {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
         "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
-        "is_secret": false,
-        "line_number": 44,
-        "type": "Private Key"
+        "is_verified": false,
+        "line_number": 45
       },
       {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
-        "is_secret": false,
-        "line_number": 45,
-        "type": "Private Key"
+        "is_verified": false,
+        "line_number": 46
       },
       {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
-        "is_secret": false,
-        "line_number": 46,
-        "type": "Private Key"
+        "is_verified": false,
+        "line_number": 47
       },
       {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "line_number": 47,
-        "type": "Private Key"
-      },
-      {
-        "hashed_secret": "11200d1bf5e1eb358b5d823c443347d97e982a85",
-        "is_secret": false,
-        "line_number": 48,
-        "type": "Private Key"
-      },
-      {
-        "hashed_secret": "9279619d0c9a9529b0b223e3b809f4df24b8ba8b",
-        "is_secret": false,
-        "line_number": 49,
-        "type": "Private Key"
-      },
-      {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
         "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
-        "line_number": 50,
-        "type": "Private Key"
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
+        "hashed_secret": "9279619d0c9a9529b0b223e3b809f4df24b8ba8b",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Private Key",
+        "filename": "detect_secrets/plugins/private_key.py",
+        "hashed_secret": "11200d1bf5e1eb358b5d823c443347d97e982a85",
+        "is_verified": false,
+        "line_number": 52
+      }
+    ],
+    "detect_secrets/plugins/twilio.py": [
+      {
+        "type": "Twilio API Key",
+        "filename": "detect_secrets/plugins/twilio.py",
+        "hashed_secret": "34c2246140bc39b1fce81d9be2124f713a06bdaf",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "docs/audit.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/audit.md",
+        "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audit.md",
+        "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "docs/design.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/design.md",
+        "hashed_secret": "2785b2a1c217669b3bd8fbcb4516006e61181237",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/design.md",
+        "hashed_secret": "2785b2a1c217669b3bd8fbcb4516006e61181237",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/design.md",
+        "hashed_secret": "fc782b0875be9e076d80f5da1430d6ea501c87e5",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/design.md",
+        "hashed_secret": "513e0a36963ae1e8431c041b744679ee578b7c44",
+        "is_verified": false,
+        "line_number": 200
       }
     ]
-  },
-  "version": "0.11.0"
+  }
 }

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -161,6 +161,13 @@ class SecretsCollection:
         for filename, secret in self:
             output[filename].append(secret.json())
 
+        # Ensure stable sort
+        for key, value in output.items():
+            output[key] = sorted(
+                value,
+                key=lambda x: (x['line_number'], x['hashed_secret'], x['type']),
+            )
+
         return dict(output)
 
     def exactly_equals(self, other: Any) -> bool:

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -161,13 +161,6 @@ class SecretsCollection:
         for filename, secret in self:
             output[filename].append(secret.json())
 
-        # Ensure stable sort
-        for key, value in output.items():
-            output[key] = sorted(
-                value,
-                key=lambda x: (x['line_number'], x['hashed_secret'], x['type']),
-            )
-
         return dict(output)
 
     def exactly_equals(self, other: Any) -> bool:
@@ -184,7 +177,7 @@ class SecretsCollection:
             secrets = self[filename]
 
             # TODO: Handle cases when line numbers are not supplied
-            for secret in sorted(secrets, key=lambda x: (x.line_number, x.secret_hash)):
+            for secret in sorted(secrets, key=lambda x: (x.line_number, x.secret_hash, x.type)):
                 yield filename, secret
 
     def __bool__(self) -> bool:

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -9,12 +9,12 @@ from .core import baseline
 from .core import plugins
 from .core.log import log
 from .core.scan import get_files_to_scan
-from .core.scan import get_plugins
 from .core.scan import scan_for_allowlisted_secrets_in_file
 from .core.scan import scan_line
 from .core.secrets_collection import SecretsCollection
 from .core.usage import ParserBuilder
 from .exceptions import InvalidBaselineError
+from .settings import get_plugins
 from .settings import get_settings
 
 
@@ -104,7 +104,7 @@ def scan_adhoc_string(line: str) -> str:
             plugin.__class__.__name__,
             results[plugin.secret_type],
         )
-        for plugin in sorted(registered_plugins, key=lambda x: x.__class__.__name__)
+        for plugin in sorted(registered_plugins, key=lambda x: str(x.__class__.__name__))
     ])
 
 

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -324,7 +324,7 @@ class KeywordDetector(BasePlugin):
             'keyword_exclude': (
                 self.keyword_exclude.pattern
                 if self.keyword_exclude
-                else '',
+                else ''
             ),
             **super().json(),
         }

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from copy import deepcopy
 from functools import lru_cache
+from importlib import import_module
 from typing import Any
 from typing import Dict
 from typing import Generator
@@ -50,9 +51,6 @@ def transient_settings(config: Dict[str, Any]) -> Generator['Settings', None, No
 
 
 def cache_bust() -> None:
-    from detect_secrets.core.scan import get_filters
-    from detect_secrets.core.scan import get_plugins
-
     get_settings.cache_clear()
     get_filters.cache_clear()
     get_plugins.cache_clear()
@@ -138,20 +136,72 @@ class Settings:
         return self
 
     def json(self) -> Dict[str, Any]:
+        plugins_used = []
+        for plugin in get_plugins():
+            # NOTE: We use the initialized plugin's JSON representation (rather than using
+            # the configured settings) to deal with cases where plugins define their own
+            # default variables, that is not necessarily carried through through the
+            # settings object.
+            serialized_plugin = plugin.json()
+
+            plugins_used.append({
+                # NOTE: We still need to use the saved settings configuration though, since
+                # there are keys specifically in the settings object that we need to carry over
+                # (e.g. `path` for custom plugins).
+                **self.plugins[serialized_plugin['name']],
+                **serialized_plugin,
+            })
+
         return {
-            'plugins_used': [
-                {
-                    'name': name,
-                    **config,
-                }
-                for name, config in self.plugins.items()
-            ],
-            'filters_used': [
-                {
-                    'path': path,
-                    **config,
-                }
-                for path, config in self.filters.items()
-                if path not in self.DEFAULT_FILTERS
-            ],
+            'plugins_used': sorted(
+                plugins_used,
+                key=lambda x: str(x['name'].lower()),
+            ),
+            'filters_used': sorted(
+                [
+                    {
+                        'path': path,
+                        **config,
+                    }
+                    for path, config in self.filters.items()
+                    if path not in self.DEFAULT_FILTERS
+                ],
+                key=lambda x: str(x['path'].lower()),
+            ),
         }
+
+
+@lru_cache(maxsize=1)
+def get_plugins() -> List:
+    # We need to import this here, otherwise it will result in a circular dependency.
+    from .core import plugins
+
+    return [
+        plugins.initialize.from_plugin_classname(classname)
+        for classname in get_settings().plugins
+    ]
+
+
+@lru_cache(maxsize=1)
+def get_filters() -> List:
+    from .core.log import log
+    from .util.inject import get_injectable_variables
+
+    output = []
+    for path, config in get_settings().filters.items():
+        module_path, function_name = path.rsplit('.', 1)
+        try:
+            function = getattr(import_module(module_path), function_name)
+        except (ModuleNotFoundError, AttributeError):
+            log.warning(f'Invalid filter: {path}')
+            continue
+
+        # We attach this metadata to the function itself, so that we don't need to
+        # compute it everytime. This will allow for dependency injection for filters.
+        function.injectable_variables = set(get_injectable_variables(function))
+        output.append(function)
+
+        # This is for better logging.
+        function.path = path
+
+    return output

--- a/docs/design.md
+++ b/docs/design.md
@@ -147,7 +147,7 @@ Filters operate through a system of
 that they need to come to a decision. For more information on how to configure filters, or write
 your own, check out the [filters documentation](filters.md).
 
-All filters are dynamically initialized through `detect_secrets.core.scan.get_filters`, which
+All filters are dynamically initialized through `detect_secrets.settings.get_filters`, which
 is responsible for importing all registered filters (as specified in the `Settings` object).
 Additionally, if you want to learn more about the dependency injection framework we use, check out
 `detect_secrets.util.inject`.

--- a/testing/plugins.py
+++ b/testing/plugins.py
@@ -15,6 +15,10 @@ def register_plugin(plugin: Plugin) -> Generator[None, None, None]:
         # to the classname. However, we already have an instance, so it doesn't matter.
         return plugin
 
+    # NOTE: This hack is needed so that when we dynamically populate the default settings with
+    # registered plugins, this shimmed function will be known as the underlying plugin class.
+    get_instance.__name__ = plugin.__class__.__name__
+
     try:
         get_mapping_from_secret_type_to_class()[plugin.secret_type] = get_instance  # type: ignore
         yield

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -31,7 +31,6 @@ def test_quit_early_if_bad_baseline():
         main(['test_data/files/file_with_secrets.py', '--baseline', 'does-not-exist'])
 
 
-@pytest.mark.xfail(reason='TODO: We need to recreate our baseline once it\'s all over.')
 def test_quit_if_baseline_is_changed_but_not_staged():
     with mock.patch(
         'detect_secrets.pre_commit_hook.raise_exception_if_baseline_file_is_unstaged',


### PR DESCRIPTION
### Summary

Consistent, serialized baselines are important. Otherwise, when the pre-commit hook updates the baselines, irrelevant changes (caused by unstable sorts) may unnecessarily cause the commit to fail. We now test this programmatically by performing a round trip serialization to ensure baselines are identical.

In other news, this PR means that we finally have a stable baseline format for v1!

### Details

Within this PR, I also included bug fixes for:

- Missing default limit for `HighEntropyString` plugin serialization.

  Previously, when `HighEntropyString` plugins were serialized, it would look something like this:

  ```json
  {
    "name": "Base64HighEntropyString"
  }
  ```

  While this works, it is somewhat fragile since this would cause different scan results if the engine changed its default value. As such, we now explicitly include the limit for initialization, so results are more sturdy to version changes.

- `KeywordDetector` `keyword_exclude` now serializes to a string, not a list

  Ah, the magic hanging comma, that accidentally transformed a multi-line string into a tuple. This fixes it so that `KeywordDetector` can be initialized properly from the baseline.