### PR TITLE
bug fix: initializing wordlist from baseline

### DIFF
--- a/detect_secrets/filters/wordlist.py
+++ b/detect_secrets/filters/wordlist.py
@@ -22,11 +22,18 @@ def is_feature_enabled() -> bool:
         return False
 
 
-def initialize(wordlist_filename: str, min_length: int = 3) -> Automaton:
+def initialize(wordlist_filename: str, min_length: int = 3, file_hash: str = '') -> Automaton:
     """
     :param min_length: if words are too small, the automaton will flag too many
         words. As a result, our recall will decrease without a precision boost.
         Tweak this value to customize it based on your own findings.
+
+    :param file_hash: this is currently used for baseline reporting purposes only, rather than
+        engine's functionality. One can imagine a future where this automaton model is
+        cached and keyed off the hash, and thus, this file_hash can be used to see if the
+        cache needs to be invalidated.
+
+        But alas, this functionality has yet to be implemented.
     """
     # See https://pyahocorasick.readthedocs.io/en/latest/ for more information.
     automaton = get_automaton()
@@ -66,6 +73,13 @@ def get_automaton() -> Automaton:
 
 
 def _compute_wordlist_hash(filename: str, buffer_size: int = 64 * 1024) -> str:
+    """
+    We compute the hash based on the file contents, rather than the filename itself, since we
+    want to know if the underlying contents of the file changes.
+
+    This is akin to:
+        $ sha1sum <filename>
+    """
     sha1 = hashlib.sha1()
     with open(filename, 'rb') as f:
         data = f.read(buffer_size)

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -28,6 +28,16 @@ def configure_settings_from_baseline(baseline: Dict[str, Any], filename: str = '
     if 'filters_used' in baseline:
         settings.configure_filters(baseline['filters_used'])
 
+        if 'detect_secrets.filters.wordlist.should_exclude_secret' in settings.filters:
+            config = settings.filters['detect_secrets.filters.wordlist.should_exclude_secret']
+
+            from detect_secrets import filters
+            filters.wordlist.initialize(
+                wordlist_filename=config['file_name'],
+                min_length=config['min_length'],
+                file_hash=config['file_hash'],
+            )
+
     if filename:
         settings.filters['detect_secrets.filters.common.is_baseline_file'] = {
             'filename': filename,

--- a/tests/filters/wordlist_filter_test.py
+++ b/tests/filters/wordlist_filter_test.py
@@ -2,33 +2,48 @@ import pytest
 
 from detect_secrets import filters
 from detect_secrets.settings import get_settings
+from detect_secrets.settings import transient_settings
 
 
-@pytest.fixture(autouse=True)
-def initialize_automaton():
-    filters.wordlist.initialize('test_data/word_list.txt', min_length=8)
+class TestShouldExcludeSecret:
+    @staticmethod
+    @pytest.fixture(autouse=True)
+    def initialize_automaton():
+        filters.wordlist.initialize('test_data/word_list.txt', min_length=8)
 
-    yield
+        yield
 
-    filters.wordlist.get_automaton.cache_clear()
+        filters.wordlist.get_automaton.cache_clear()
+
+    @staticmethod
+    def test_success():
+        # case-insensitivity
+        assert filters.wordlist.should_exclude_secret('testPass') is True
+
+        # min_length requirement
+        assert filters.wordlist.should_exclude_secret('2short') is False
+
+        assert get_settings().filters['detect_secrets.filters.wordlist.should_exclude_secret'] == {
+            'min_length': 8,
+
+            # Manually computed with `sha1sum test_data/word_list.txt`
+            'file_hash': '116598304e5b33667e651025bcfed6b9a99484c7',
+            'file_name': 'test_data/word_list.txt',
+        }
+
+    @staticmethod
+    def test_failure():
+        # prefix match is not sufficient
+        assert filters.wordlist.should_exclude_secret('AKIAnotr') is False
 
 
-def test_success():
-    # case-insensitivity
-    assert filters.wordlist.should_exclude_secret('testPass') is True
-
-    # min_length requirement
-    assert filters.wordlist.should_exclude_secret('2short') is False
-
-    assert get_settings().filters['detect_secrets.filters.wordlist.should_exclude_secret'] == {
-        'min_length': 8,
-
-        # Manually computed with `sha1sum test_data/word_list.txt`
-        'file_hash': '116598304e5b33667e651025bcfed6b9a99484c7',
-        'file_name': 'test_data/word_list.txt',
-    }
-
-
-def test_failure():
-    # prefix match is not sufficient
-    assert filters.wordlist.should_exclude_secret('AKIAnotr') is False
+def test_load_from_baseline():
+    with transient_settings({
+        'filters_used': [{
+            'path': 'detect_secrets.filters.wordlist.should_exclude_secret',
+            'min_length': 8,
+            'file_name': 'test_data/word_list.txt',
+            'file_hash': '116598304e5b33667e651025bcfed6b9a99484c7',
+        }],
+    }):
+        assert filters.wordlist.should_exclude_secret('testPass') is True


### PR DESCRIPTION
## Issue

When using the `--word-list` filter to create a baseline, subsequent baseline updates fail to properly initialize the wordlist filter. e.g.

```bash
$ cat test_data/word_list.txt
TESTPASS
2short
AKIANOTREAL
$ echo "secret: 'testPass'" > blah.py
$ detect-secrets scan --word-list test_data/word_list.txt blah.py > secrets.baseline
$ cat secrets.baseline | jq .results
{}
$ detect-secrets scan --baseline secrets.baseline
Traceback (most recent call last):
  File "/Users/aaronloo/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/aaronloo/.pyenv/versions/3.6.8/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/__main__.py", line 7, in <module>
    sys.exit(main())
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/main.py", line 30, in main
    handle_scan_action(args)
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/main.py", line 66, in handle_scan_action
    secrets = baseline.create(*args.path, should_scan_all_files=args.all_files)
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/core/baseline.py", line 25, in create
    secrets.scan_file(filename)
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/core/secrets_collection.py", line 42, in scan_file
    for secret in scan.scan_file(filename):
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/core/scan.py", line 107, in scan_file
    filename=filename,
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/core/scan.py", line 308, in _process_line_based_plugins
    for secret in _scan_line(plugin, filename, line, line_number):
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/core/scan.py", line 347, in _scan_line
    line=line,
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/util/inject.py", line 19, in inject_variables_into_function
    return func(**values)
  File "/Users/aaronloo/Documents/github/detect-secrets/detect_secrets/filters/wordlist.py", line 63, in should_exclude_secret
    next(get_automaton().iter(string=secret.lower()))
AttributeError: Not an Aho-Corasick automaton yet: call add_word to add some keys and call make_automaton to convert the trie to an automaton.
```

## Description

This PR fixes this issue.

```
$ detect-secrets scan --baseline secrets.baseline
```

now works.