### PR TITLE
bug fix: audit now uses file transformers

### DIFF
--- a/detect_secrets/audit/audit.py
+++ b/detect_secrets/audit/audit.py
@@ -44,7 +44,7 @@ def _classify_secrets(iterator: BidirectionalIterator) -> bool:
                     num_total_secrets=len(iterator.collection),
                     secret=secret,
                     snippet=get_code_snippet(
-                        lines=open_file(secret.filename),
+                        lines=open_file(secret.filename).raw_lines,
                         line_number=secret.line_number,
                     ),
                 ),

--- a/detect_secrets/audit/compare.py
+++ b/detect_secrets/audit/compare.py
@@ -188,7 +188,7 @@ def _display_difference_to_user(
                     ),
                 ),
                 snippet=get_code_snippet(
-                    lines=open_file(secret.filename),
+                    lines=open_file(secret.filename).raw_lines,
                     line_number=secret.line_number,
                 ),
             )

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -12,6 +12,7 @@ from . import plugins
 from ..filters.allowlist import is_line_allowlisted
 from ..settings import get_settings
 from ..transformers import get_transformed_file
+from ..types import NamedIO
 from ..types import SelfAwareCallable
 from ..util import git
 from ..util.code_snippet import get_code_snippet
@@ -202,7 +203,7 @@ def _get_lines_from_file(filename: str) -> Generator[List[str], None, None]:
         log.info(f'Checking file: {filename}')
 
         try:
-            lines = get_transformed_file(f)
+            lines = get_transformed_file(cast(NamedIO, f))
             if not lines:
                 lines = f.readlines()
         except UnicodeDecodeError:
@@ -213,7 +214,7 @@ def _get_lines_from_file(filename: str) -> Generator[List[str], None, None]:
 
         # If the above lines don't prove to be useful to the caller, try using eager transformers.
         f.seek(0)
-        lines = get_transformed_file(f, use_eager_transformers=True)
+        lines = get_transformed_file(cast(NamedIO, f), use_eager_transformers=True)
         if not lines:
             return
 

--- a/detect_secrets/transformers/__init__.py
+++ b/detect_secrets/transformers/__init__.py
@@ -2,12 +2,12 @@ import inspect
 import sys
 from functools import lru_cache
 from typing import Any
-from typing import IO
 from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import TypeVar
 
+from ..types import NamedIO
 from ..util.importlib import import_types_from_package
 from .base import BaseTransformer
 from .exceptions import ParsingError
@@ -16,7 +16,10 @@ from .exceptions import ParsingError
 Transformer = TypeVar('Transformer', bound=BaseTransformer)
 
 
-def get_transformed_file(file: IO, use_eager_transformers: bool = False) -> Optional[List[str]]:
+def get_transformed_file(
+    file: NamedIO,
+    use_eager_transformers: bool = False,
+) -> Optional[List[str]]:
     for transformer in get_transformers():
         if not transformer.should_parse_file(file.name):
             continue

--- a/detect_secrets/transformers/base.py
+++ b/detect_secrets/transformers/base.py
@@ -1,7 +1,8 @@
 from abc import ABCMeta
 from abc import abstractmethod
-from typing import IO
 from typing import List
+
+from ..types import NamedIO
 
 
 class BaseTransformer(metaclass=ABCMeta):
@@ -31,7 +32,7 @@ class BaseTransformer(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def parse_file(self, file: IO) -> List[str]:
+    def parse_file(self, file: NamedIO) -> List[str]:
         """
         :raises: ParsingError
         """

--- a/detect_secrets/transformers/config.py
+++ b/detect_secrets/transformers/config.py
@@ -3,11 +3,11 @@ This handles `.ini` files, or more generally known as `config` files.
 """
 import configparser
 import re
-from typing import Generator
-from typing import IO
+from typing import Iterator
 from typing import List
 from typing import Tuple
 
+from ..types import NamedIO
 from ..util.filetype import determine_file_type
 from ..util.filetype import FileType
 from .base import BaseTransformer
@@ -18,7 +18,7 @@ class ConfigFileTransformer(BaseTransformer):
     def should_parse_file(self, filename: str) -> bool:
         return True
 
-    def parse_file(self, file: IO) -> List[str]:
+    def parse_file(self, file: NamedIO) -> List[str]:
         try:
             return _parse_file(file)
         except configparser.Error:
@@ -32,14 +32,14 @@ class EagerConfigFileTransformer(BaseTransformer):
     def should_parse_file(self, filename: str) -> bool:
         return determine_file_type(filename) == FileType.OTHER
 
-    def parse_file(self, file: IO) -> List[str]:
+    def parse_file(self, file: NamedIO) -> List[str]:
         try:
             return _parse_file(file, add_header=True)
         except configparser.Error:
             raise ParsingError
 
 
-def _parse_file(file: IO, add_header: bool = False) -> List[str]:
+def _parse_file(file: NamedIO, add_header: bool = False) -> List[str]:
     """
     :raises: configparser.Error
     :raises: UnicodeDecodeError
@@ -81,7 +81,7 @@ class IniFileParser:
 
     _comment_regex = re.compile(r'\s*[;#]')
 
-    def __init__(self, file: IO, add_header: bool = False) -> None:
+    def __init__(self, file: NamedIO, add_header: bool = False) -> None:
         """
         :param add_header: whether or not to add a top-level [global] header.
         """
@@ -101,7 +101,7 @@ class IniFileParser:
         self.lines = [line.strip() for line in file.readlines()]
         self.line_offset = 0
 
-    def __iter__(self) -> Generator[Tuple[str, str, int], None, None]:
+    def __iter__(self) -> Iterator[Tuple[str, str, int]]:
         if not self.parser.sections():
             # To prevent cases where it's not an ini file, but the parser
             # helpfully attempts to parse everything to a DEFAULT section,

--- a/detect_secrets/transformers/yaml.py
+++ b/detect_secrets/transformers/yaml.py
@@ -4,8 +4,7 @@ from functools import lru_cache
 from typing import Any
 from typing import cast
 from typing import Dict
-from typing import Generator
-from typing import IO
+from typing import Iterator
 from typing import List
 from typing import NamedTuple
 from typing import Optional
@@ -16,6 +15,7 @@ from typing import Union
 import yaml
 
 from ..core.log import log
+from ..types import NamedIO
 from ..util.filetype import determine_file_type
 from ..util.filetype import FileType
 from .base import BaseTransformer
@@ -26,7 +26,7 @@ class YAMLTransformer(BaseTransformer):
     def should_parse_file(self, filename: str) -> bool:
         return determine_file_type(filename) == FileType.YAML
 
-    def parse_file(self, file: IO) -> List[str]:
+    def parse_file(self, file: NamedIO) -> List[str]:
         """
         :raises: ParsingError
         """
@@ -139,7 +139,7 @@ class YAMLFileParser:
     This parsing method is inspired by https://stackoverflow.com/a/13319530.
     """
 
-    def __init__(self, file: IO):
+    def __init__(self, file: NamedIO):
         self.content = file.read()
 
         self.loader = yaml.SafeLoader(self.content)
@@ -148,7 +148,7 @@ class YAMLFileParser:
     def json(self) -> Dict[str, Any]:
         return cast(Dict[str, Any], self.loader.get_single_data())
 
-    def __iter__(self) -> Generator[YAMLValue, None, None]:
+    def __iter__(self) -> Iterator[YAMLValue]:
         """
         :returns: (value, line_number)
         """

--- a/detect_secrets/types.py
+++ b/detect_secrets/types.py
@@ -1,3 +1,4 @@
+from io import TextIOBase
 from typing import Any
 from typing import NamedTuple
 from typing import NoReturn
@@ -59,3 +60,7 @@ class SecretContext(NamedTuple):
 
     # ...or error information. But it has an XOR relationship.
     error: Optional[SecretNotFoundOnSpecifiedLineError] = None
+
+
+class NamedIO(TextIOBase):
+    name: str


### PR DESCRIPTION
## Issue

In manually testing this, I came across an interesting issue: the auditor was unable to find the secret that the scanner had just picked up.

```bash
$ detect-secrets scan --disabled-plugins PrivateKeyDetector,BasicAuthDetector,AWSKeyDetector,HexHighEntropyString,KeywordDetector test_data/config.env > .secrets.baseline
$ detect-secrets audit .secrets.baseline
Secret:      1 of 1
Filename:    test_data/config.env
Secret Type: Base64 High Entropy String
----------
ERROR: Secret not found on line 1!
Try recreating your baseline to fix this issue.
----------
What would you like to do? (s)kip, (q)uit: q
$ cat test_data/config.env
mimi=gX69YO4CvBsVjzAwYxdGyDd30t5+9ez31gKATtj4
```

In looking at this deeper, it looks like the reason is because audit did not depend on file transformers. If we look at `test_data/config.env`, we see that the line in question meets the `Base64HighEntropyString` regex (no space delimiters). Furthermore, this line does not meet the bar for qualifying as a secret for Base64HighEntropyString (no quotes), so it depends on the `EagerConfigFileTransformer` to convert it into a style that the plugin understands.

As a result, we uncover a peculiar case: the file is transformed during scan (hence, finding the secret), but not during audit (hence, missing it).

This specific case is captured in the automated test included.

## Description

We do some abstraction handling with `LineGetter` to try and cache file results (instead of re-opening and parsing the line every time). Since the `use_eager_transformers` pattern is failure-dependent (we don't know which transformer to use until one fails), I tried to wrap this up this behavior in a nice cache-able fashion so it would make the other code easier to reason about (🤞 )