### PR TITLE
improved adhoc string scanning

### DIFF
--- a/detect_secrets/audit/common.py
+++ b/detect_secrets/audit/common.py
@@ -11,8 +11,6 @@ from ..core.secrets_collection import SecretsCollection
 from ..exceptions import InvalidBaselineError
 from ..exceptions import SecretNotFoundOnSpecifiedLineError
 from ..plugins.base import BasePlugin
-from ..types import SelfAwareCallable
-from ..util.inject import get_injectable_variables
 from ..util.inject import inject_variables_into_function
 
 
@@ -46,16 +44,8 @@ def get_raw_secret_from_file(secret: PotentialSecret) -> str:
     except IndexError:
         raise SecretNotFoundOnSpecifiedLineError(secret.line_number)
 
-    function = plugin.__class__.analyze_line
-    if not hasattr(function, 'injectable_variables'):
-        function.injectable_variables = set(        # type: ignore
-            get_injectable_variables(plugin.analyze_line),
-        )
-        function.path = f'{plugin.__class__.__name__}.analyze_line'  # type: ignore
-
     identified_secrets = inject_variables_into_function(
-        cast(SelfAwareCallable, function),
-        self=plugin,
+        plugin.analyze_line,
         filename=secret.filename,
         line=target_line,
         line_number=secret.line_number,     # TODO: this will be optional

--- a/detect_secrets/audit/common.py
+++ b/detect_secrets/audit/common.py
@@ -11,7 +11,7 @@ from ..core.secrets_collection import SecretsCollection
 from ..exceptions import InvalidBaselineError
 from ..exceptions import SecretNotFoundOnSpecifiedLineError
 from ..plugins.base import BasePlugin
-from ..util.inject import inject_variables_into_function
+from ..util.inject import call_function_with_arguments
 
 
 def get_baseline_from_file(filename: str) -> SecretsCollection:
@@ -44,7 +44,7 @@ def get_raw_secret_from_file(secret: PotentialSecret) -> str:
     except IndexError:
         raise SecretNotFoundOnSpecifiedLineError(secret.line_number)
 
-    identified_secrets = inject_variables_into_function(
+    identified_secrets = call_function_with_arguments(
         plugin.analyze_line,
         filename=secret.filename,
         line=target_line,

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -332,19 +332,8 @@ def _scan_line(
 ) -> Generator[PotentialSecret, None, None]:
     # NOTE: We don't apply filter functions here yet, because we don't have any filters
     # that operate on (filename, line, plugin) without `secret`
-    try:
-        analyze_line = plugin.__class__.analyze_line
-        if not hasattr(analyze_line, 'injectable_variables'):
-            analyze_line.injectable_variables = set(        # type: ignore
-                get_injectable_variables(plugin.analyze_line),
-            )
-            analyze_line.path = f'{plugin.__class__.__name__}.analyze_line'     # type: ignore
-    except AttributeError:
-        return
-
     secrets = inject_variables_into_function(
-        cast(SelfAwareCallable, analyze_line),
-        self=plugin,
+        plugin.analyze_line,
         filename=filename,
         line=line,
         line_number=line_number,

--- a/detect_secrets/filters/common.py
+++ b/detect_secrets/filters/common.py
@@ -7,9 +7,7 @@ import requests
 from ..constants import VerifiedResult
 from ..core.plugins import Plugin
 from ..settings import get_settings
-from ..types import SelfAwareCallable
 from ..util.code_snippet import CodeSnippet
-from ..util.inject import get_injectable_variables
 from ..util.inject import inject_variables_into_function
 from .util import get_caller_path
 
@@ -42,15 +40,9 @@ def is_ignored_due_to_verification_policies(
     There's no such thing as "only verified false", because if you're going to verify
     something, and it's verified false, why are you still including it as a valid secret?
     """
-    function = plugin.__class__.verify
-    if not hasattr(function, 'injectable_variables'):
-        function.injectable_variables = set(get_injectable_variables(plugin.verify))  # type: ignore
-        function.path = f'{plugin.__class__.__name__}.verify'   # type: ignore
-
     try:
         verify_result = inject_variables_into_function(
-            cast(SelfAwareCallable, function),
-            self=plugin,
+            plugin.verify,
             secret=secret,
             context=context,
         )

--- a/detect_secrets/filters/common.py
+++ b/detect_secrets/filters/common.py
@@ -8,7 +8,7 @@ from ..constants import VerifiedResult
 from ..core.plugins import Plugin
 from ..settings import get_settings
 from ..util.code_snippet import CodeSnippet
-from ..util.inject import inject_variables_into_function
+from ..util.inject import call_function_with_arguments
 from .util import get_caller_path
 
 
@@ -41,7 +41,7 @@ def is_ignored_due_to_verification_policies(
     something, and it's verified false, why are you still including it as a valid secret?
     """
     try:
-        verify_result = inject_variables_into_function(
+        verify_result = call_function_with_arguments(
             plugin.verify,
             secret=secret,
             context=context,

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -13,7 +13,6 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 from typing import Iterable
-from typing import Optional
 from typing import Pattern
 from typing import Set
 
@@ -71,10 +70,7 @@ class BasePlugin(metaclass=ABCMeta):
             'name': self.__class__.__name__,
         }
 
-    def format_scan_result(self, secret: Optional[PotentialSecret]) -> str:
-        if not secret:
-            return 'False'
-
+    def format_scan_result(self, secret: PotentialSecret) -> str:
         try:
             verification_level = VerifiedResult(
                 get_settings().filters[

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -35,6 +35,9 @@ class HighEntropyStringsPlugin(BasePlugin, metaclass=ABCMeta):
                 # This occurs on the default regex, but not on the eager regex.
                 result = result[1]
 
+            # We perform the shannon entropy check in `analyze_line` instead, so that we have
+            # more control over **when** we display the results of this plugin. Specifically,
+            # this allows us to show the computed entropy values during adhoc string scans.
             yield result
 
     def analyze_line(
@@ -52,7 +55,7 @@ class HighEntropyStringsPlugin(BasePlugin, metaclass=ABCMeta):
             # enable_eager_search=True.
             return {
                 secret
-                for secret in (output or set([]))
+                for secret in (output or set())
                 if (
                     self.calculate_shannon_entropy(cast(str, secret.secret_value)) >
                     self.entropy_limit

--- a/detect_secrets/util/inject.py
+++ b/detect_secrets/util/inject.py
@@ -9,7 +9,7 @@ from typing import Union
 from ..types import SelfAwareCallable
 
 
-def inject_variables_into_function(
+def call_function_with_arguments(
     func: Union[Callable, SelfAwareCallable],
     **kwargs: Any,
 ) -> Optional[Any]:

--- a/detect_secrets/util/inject.py
+++ b/detect_secrets/util/inject.py
@@ -13,10 +13,11 @@ def inject_variables_into_function(func: SelfAwareCallable, **kwargs: Any) -> Op
         for key in (variables_to_inject & func.injectable_variables)
     }
 
-    if set(values.keys()) != func.injectable_variables:
+    try:
+        return func(**values)
+    except TypeError:
+        # When parameters are required (and not supplied), it raises a TypeError.
         return None
-
-    return func(**values)
 
 
 def get_injectable_variables(func: Callable) -> Tuple[str, ...]:

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -31,8 +31,8 @@ class TestScanFile:
         SecretsCollection().scan_file('test_data')
 
         assert (
-            'Skipping "test_data" due to "detect_secrets.filters.common.is_invalid_file"'
-            in mock_log.info_messages
+            'Skipping "test_data" due to `detect_secrets.filters.common.is_invalid_file`'
+            in mock_log.debug_messages
         )
 
     @staticmethod

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -3,8 +3,6 @@ import tempfile
 from contextlib import contextmanager
 from unittest import mock
 
-import pytest
-
 from detect_secrets import main as main_module
 from detect_secrets.core import baseline
 from detect_secrets.core.secrets_collection import SecretsCollection
@@ -75,7 +73,6 @@ class TestScanString:
             ]
 
     @staticmethod
-    @pytest.mark.xfail(reason='TODO')
     def test_failed_high_entropy_string():
         with transient_settings({
             'plugins_used': [

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -38,7 +38,15 @@ class TestHighEntropyString:
         ),
     )
     def test_basic(plugin, non_secret, secret, format, should_be_caught):
-        results = list(plugin().analyze_string(format.format(non_secret=non_secret, secret=secret)))
+        # NOTE: We need to use analyze_line (rather than analyze_string) since the entropy
+        # limit check lives in this function.
+        results = list(
+            plugin().analyze_line(
+                filename='does not matter',
+                line=format.format(non_secret=non_secret, secret=secret),
+                line_number=0,
+            ),
+        )
         assert bool(results) == should_be_caught
 
     @staticmethod
@@ -58,7 +66,13 @@ class TestHighEntropyString:
         ),
     )
     def test_multiple_strings_same_line(plugin, non_secret, secret, format, num_results):
-        results = list(plugin().analyze_string(format.format(non_secret=non_secret, secret=secret)))
+        results = list(
+            plugin().analyze_line(
+                filename='does not matter',
+                line=format.format(non_secret=non_secret, secret=secret),
+                line_number=0,
+            ),
+        )
         assert len(results) == num_results
 
     @staticmethod


### PR DESCRIPTION
## Summary

Adhoc string scanning is hella useful. e.g.

```bash
$ detect-secrets scan --string 'butactuallynotasecret'
...
Base64HighEntropyString: False
```

However, sometimes (especially for the HighEntropyString plugins), we want to see *why* it failed. This is existing behavior in 0.14.3; this PR carries this functionality forward. With this change, it will be:

```bash
$ detect-secrets scan --string 'butactuallynotasecret'
...
Base64HighEntropyString: False (3.404)
```

## Reviewer Notes

It was somewhat difficult to surface the non-secret to the scan layer in a generic manner (i.e. without using `if plugin in {Base64HighEntropyString}`), so I had to be creative with the `analyze_line` and `analyze_string` functionality. As a result, for people using the `analyze_string` function directly (like the test case), they would need to be responsible for filtering out the secret themselves.

Not ideal, but it's the best way I could find.

This PR also introduces another gotcha -- for our DI system, we now leverage the pythonic fashion of duck-typing to determine whether there are enough required parameters to inject into the function. This needed to be done to support cases where the underlying function had default values for their parameters (e.g. `HighEntropyStringsPlugin.analyze_line`), and as such, we don't need to supply **all** the parameters that a function needs. However, this also means that if the underlying function raises an uncaught `TypeError`, it will be silenced by the DI system.

I guess future improvements could be done to distinguish default parameters from non-default parameters in a function declaration, but I didn't want to dive too deep into Python magic internals for this PR.