### PR TITLE
Bug fix: handling file paths with spaces

### DIFF
--- a/detect_secrets/util/git.py
+++ b/detect_secrets/util/git.py
@@ -25,11 +25,6 @@ def get_tracked_files(root: str) -> Set[str]:
 
     :raises: CalledProcessError
     """
-    files = subprocess.check_output(
-        ['git', '-C', root, 'ls-files'],
-        stderr=subprocess.DEVNULL,
-    )
-
     output = set([])
     try:
         files = subprocess.check_output(
@@ -37,7 +32,7 @@ def get_tracked_files(root: str) -> Set[str]:
             stderr=subprocess.DEVNULL,
         )
 
-        for filename in files.decode('utf-8').split():
+        for filename in files.decode('utf-8').splitlines():
             path = get_relative_path_if_in_cwd(os.path.join(root, filename))
             if path:
                 output.add(path)
@@ -52,7 +47,7 @@ def get_tracked_files(root: str) -> Set[str]:
 
 def get_changed_but_unstaged_files() -> Set[str]:
     try:
-        files = subprocess.check_output('git diff --name-only'.split()).decode().split()
+        files = subprocess.check_output('git diff --name-only'.split()).decode().splitlines()
     except subprocess.CalledProcessError:   # pragma: no cover
         # Since we don't pipe stderr, we get free logging through git.
         raise ValueError


### PR DESCRIPTION
## Summary

Previously, `detect-secrets scan` would ignore file paths with spaces. This fixes that.

## Reproduction Steps

```bash
$ mkdir 'testing/a b'
$ echo "password = 'hunter2'" > 'testing/a b/blah.py'
$ git add 'testing/a b/test.py'   # needed for testing git tracked files
$ detect-secrets scan testing | jq .results
{}
```

## Testing Done

The same steps above, but it actually came up with a result (as expected) this time.