### PR TITLE
Windows support for clear command in audit

### DIFF
--- a/detect_secrets/audit/io.py
+++ b/detect_secrets/audit/io.py
@@ -1,7 +1,8 @@
 """
 Responsible for input/output for audit related functions.
 """
-import subprocess
+import os
+import platform
 import sys
 from enum import Enum
 
@@ -19,7 +20,10 @@ def print_error(message: str) -> None:
 
 
 def clear_screen() -> None:     # pragma: no cover
-    subprocess.call(['clear'])
+    command = 'clear'
+    if platform.system() == 'Windows':
+        command = 'cls'
+    os.system(command)
 
 
 def print_context(context: SecretContext) -> None:


### PR DESCRIPTION
Closes #333 

Operative System checking before running `clear` or `cls` command. The `subprocess.call` method has been replaced by `os.system` to avoid unexpected errors in Microsoft Windows environments. This method has been tested in Windows, Linux and MacOS.