### PR TITLE
Adding convenience function to get default settings

### DIFF
--- a/detect_secrets/__init__.py
+++ b/detect_secrets/__init__.py
@@ -1,0 +1,1 @@
+from .core.secrets_collection import SecretsCollection  # noqa: F401

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -130,7 +130,7 @@ def scan_line(line: str) -> Generator[PotentialSecret, None, None]:
 
 def scan_file(filename: str) -> Generator[PotentialSecret, None, None]:
     if not get_plugins():   # pragma: no cover
-        log.warning('No plugins to scan with!')
+        log.error('No plugins to scan with!')
         return
 
     if _is_filtered_out(required_filter_parameters=['filename'], filename=filename):
@@ -158,7 +158,7 @@ def scan_diff(diff: str) -> Generator[PotentialSecret, None, None]:
     :raises: ImportError
     """
     if not get_plugins():   # pragma: no cover
-        log.warning('No plugins to scan with!')
+        log.error('No plugins to scan with!')
         return
 
     for filename, lines in _get_lines_from_diff(diff):
@@ -175,7 +175,7 @@ def scan_for_allowlisted_secrets_in_file(filename: str) -> Generator[PotentialSe
     This scans specifically for these lines, and ignores everything else.
     """
     if not get_plugins():   # pragma: no cover
-        log.warning('No plugins to scan with!')
+        log.error('No plugins to scan with!')
         return
 
     if _is_filtered_out(
@@ -197,7 +197,7 @@ def scan_for_allowlisted_secrets_in_file(filename: str) -> Generator[PotentialSe
 
 def scan_for_allowlisted_secrets_in_diff(diff: str) -> Generator[PotentialSecret, None, None]:
     if not get_plugins():   # pragma: no cover
-        log.warning('No plugins to scan with!')
+        log.error('No plugins to scan with!')
         return
 
     for filename, lines in _get_lines_from_diff(diff):

--- a/detect_secrets/core/usage/common.py
+++ b/detect_secrets/core/usage/common.py
@@ -1,8 +1,8 @@
 import argparse
 import os
 
+from ...settings import default_settings
 from ...settings import get_settings
-from ..plugins.util import get_mapping_from_secret_type_to_class
 
 
 def valid_path(path: str) -> str:
@@ -24,9 +24,10 @@ def initialize_plugin_settings(args: argparse.Namespace) -> None:
     if get_settings().plugins:
         return
 
-    # TODO: This should take cli args (e.g. --base64-limit)
+    # We initialize the `settings` variable here, but we can't save it to the global object
+    # yet, since the contextmanager will revert those changes. As such, we quit the context
+    # first, then set it to the global namespace.
+    with default_settings() as settings:
+        pass
 
-    get_settings().configure_plugins([
-        {'name': plugin_type.__name__}
-        for plugin_type in get_mapping_from_secret_type_to_class().values()
-    ])
+    get_settings().set(settings)

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -48,6 +48,20 @@ def configure_settings_from_baseline(baseline: Dict[str, Any], filename: str = '
 
 
 @contextmanager
+def default_settings() -> Generator['Settings', None, None]:
+    """Convenience function to enable all plugins and default filters."""
+    from .core.plugins.util import get_mapping_from_secret_type_to_class
+
+    with transient_settings({
+        'plugins_used': [
+            {'name': plugin_type.__name__}
+            for plugin_type in get_mapping_from_secret_type_to_class().values()
+        ],
+    }) as settings:
+        yield settings
+
+
+@contextmanager
 def transient_settings(config: Dict[str, Any]) -> Generator['Settings', None, None]:
     """Allows the customizability of non-global settings per invocation."""
     original_settings = get_settings().json()
@@ -90,6 +104,10 @@ class Settings:
                 'detect_secrets.filters.heuristic.is_likely_id_string',
             }
         }
+
+    def set(self, other: 'Settings') -> None:
+        self.plugins = other.plugins
+        self.filters = other.filters
 
     def configure_plugins(self, config: List[Dict[str, Any]]) -> 'Settings':
         """

--- a/tests/core/usage/scan_usage_test.py
+++ b/tests/core/usage/scan_usage_test.py
@@ -3,6 +3,7 @@ import tempfile
 
 import pytest
 
+from detect_secrets.core import plugins
 from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
 from detect_secrets.core.usage import ParserBuilder
 from detect_secrets.settings import get_settings
@@ -31,3 +32,11 @@ def test_force_use_all_plugins(parser):
         parser.parse_args(['scan', '--force-use-all-plugins', '--baseline', f.name])
 
     assert len(get_settings().plugins) == len(get_mapping_from_secret_type_to_class())
+
+
+def test_default_plugins_initialized(parser):
+    parser.parse_args(['scan', '--hex-limit', '2'])
+
+    assert len(get_settings().plugins) == len(get_mapping_from_secret_type_to_class())
+    assert plugins.initialize.from_plugin_classname('HexHighEntropyString').entropy_limit == 2
+    assert plugins.initialize.from_plugin_classname('Base64HighEntropyString').entropy_limit == 4.5


### PR DESCRIPTION
## Summary

One of the primary motivations of the v1 redesign is to enable developers to more easily extend and integrate this tool into their ecosystem. However, the new `Settings` object lends itself to a gotcha: by default, it starts off uninitialized and as such, it's easy to fall into the trap of scanning without any plugins enabled.

This PR attempts to make this easier. I've added instructions in the README, but now, developers can just do:

```python
from detect_secrets import SecretsCollection
from detect_secrets.settings import default_settings

secrets = SecretsCollection()
with default_settings():
    results = secrets.scan_file(...)
```

This abstracts away the pain of figuring out which plugins they want to initialize themselves.

## Testing

Automated.