### PR TITLE
Adding support for custom filters and disabling filters through CLI

### DIFF
--- a/detect_secrets/core/usage/filters.py
+++ b/detect_secrets/core/usage/filters.py
@@ -1,8 +1,14 @@
 import argparse
+import inspect
+import os
+from importlib import import_module
+from urllib.parse import urlparse
 
 from ... import filters
 from ...constants import VerifiedResult
+from ...exceptions import InvalidFile
 from ...settings import get_settings
+from ...util.importlib import import_file_as_module
 from .common import valid_path
 
 
@@ -50,6 +56,52 @@ def add_filter_options(parent: argparse.ArgumentParser) -> None:
             dest='word_list_file',
         )
 
+    _add_custom_filters(parser)
+
+
+def _add_custom_filters(parser: argparse._ArgumentGroup) -> None:
+    def valid_looking_paths(path: str) -> str:
+        # Expected path format:
+        #   - detect_secrets.filters.common.is_invalid_file (python import path)
+        #   - testing/custom_filters.py::is_invalid_secret (local file)
+        #   - file://testing/custom_filters.py::is_invalid_secret (local file)
+        parts = urlparse(path)
+        if not parts.scheme and '::' in path:
+            # This could be a local file, without the file schema.
+            path = 'file://' + path
+            parts = urlparse(path)
+
+        if parts.scheme == 'file':
+            # May be local file.
+            # We do some initial pre-processing, but perform the file validation during the
+            # post-processing step.
+            components = parts.path.split('::')
+            if len(components) != 2:
+                raise argparse.ArgumentTypeError(
+                    'Did not specify function name for imported file.',
+                )
+
+            file_path = path[len('file://'):].split('::')[0]
+            if not os.path.isfile(file_path):
+                raise argparse.ArgumentTypeError(f'{file_path} is not a valid file.')
+        elif parts.scheme:
+            raise argparse.ArgumentTypeError(f'{path} is not a valid filter path.')
+
+        return path
+
+    parser.add_argument(
+        '-f',
+        '--filter',
+        type=valid_looking_paths,
+        nargs=1,
+        action='append',        # so we can support multiple flags with same value
+        help=(
+            'Specify path to custom filter. '
+            'May be a python module path (e.g. detect_secrets.filters.common.is_invalid_file) or '
+            'a local file path (e.g. file://path/to/file.py::function_name).'
+        ),
+    )
+
 
 def parse_args(args: argparse.Namespace) -> None:
     if args.exclude_lines:
@@ -82,3 +134,56 @@ def parse_args(args: argparse.Namespace) -> None:
         get_settings().disable_filters(
             'detect_secrets.filters.common.is_ignored_due_to_verification_policies',
         )
+
+    if args.filter:
+        # Flatten entry for easier parsing.
+        args.filter = [entry for item in args.filter for entry in item]
+
+        # Post-processing validation
+        for item in args.filter:
+            _raise_if_custom_filter_path_is_invalid(item)
+            get_settings().filters[item] = {}
+
+
+def _raise_if_custom_filter_path_is_invalid(path: str) -> None:
+    """Performs post-validation for custom filters."""
+    parts = urlparse(path)
+    if not parts.scheme:
+        try:
+            module_path, function_name = path.rsplit('.', 1)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                'Invalid Python module path for custom filter.',
+            )
+
+        try:
+            module = import_module(module_path)
+        except ModuleNotFoundError:
+            raise argparse.ArgumentTypeError(f'Cannot import "{path}" as custom filter.')
+
+        try:
+            function = getattr(module, function_name)
+        except AttributeError:
+            raise argparse.ArgumentTypeError(
+                f'No filter function named `{function_name}` found in "{module_path}".',
+            )
+
+        if not inspect.isfunction(function):
+            raise argparse.ArgumentTypeError(f'{path} is not a filter function.')
+
+    elif parts.scheme == 'file':
+        file_path, function_name = path[len('file://'):].split('::')
+
+        try:
+            module = import_file_as_module(file_path)
+        except (FileNotFoundError, InvalidFile):
+            raise argparse.ArgumentTypeError(
+                f'Cannot import {file_path} as custom filter.',
+            )
+
+        try:
+            getattr(module, function_name)
+        except AttributeError:
+            raise argparse.ArgumentTypeError(
+                f'No filter function named `{function_name}` found in "{file_path}".',
+            )

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -6,6 +6,10 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 from typing import List
+from urllib.parse import urlparse
+
+from .exceptions import InvalidFile
+from .util.importlib import import_file_as_module
 
 
 @lru_cache(maxsize=1)
@@ -217,10 +221,25 @@ def get_filters() -> List:
 
     output = []
     for path, config in get_settings().filters.items():
-        module_path, function_name = path.rsplit('.', 1)
-        try:
-            function = getattr(import_module(module_path), function_name)
-        except (ModuleNotFoundError, AttributeError):
+        parts = urlparse(path)
+        if not parts.scheme:
+            module_path, function_name = path.rsplit('.', 1)
+            try:
+                function = getattr(import_module(module_path), function_name)
+            except (ModuleNotFoundError, AttributeError):
+                log.warning(f'Invalid filter: {path}')
+                continue
+
+        elif parts.scheme == 'file':
+            file_path, function_name = path[len('file://'):].split('::')
+
+            try:
+                function = getattr(import_file_as_module(file_path), function_name)
+            except (FileNotFoundError, InvalidFile, AttributeError):
+                log.warning(f'Invalid filter: {path}')
+                continue
+
+        else:
             log.warning(f'Invalid filter: {path}')
             continue
 

--- a/testing/custom_filters.py
+++ b/testing/custom_filters.py
@@ -1,0 +1,2 @@
+def is_invalid_secret(secret: str) -> bool:
+    return secret == 'gX69YO4CvBsVjzAwYxdGyDd30t5+9ez31gKATtj4'

--- a/tests/core/usage/filters_usage_test.py
+++ b/tests/core/usage/filters_usage_test.py
@@ -96,6 +96,22 @@ class TestCustomFilters:
         assert not secrets
 
     @staticmethod
+    def test_module_success(parser):
+        config = {
+            # Remove all filters, so we can test adding things back in.
+            'filters_used': [],
+        }
+
+        with transient_settings(config):
+            default_filters = set(get_settings().filters.keys())
+
+        module_path = 'detect_secrets.filters.heuristic.is_sequential_string'
+        assert module_path not in default_filters
+        with transient_settings(config):
+            parser.parse_args(['scan', '--filter', module_path])
+            assert module_path in get_settings().filters
+
+    @staticmethod
     @pytest.mark.parametrize(
         'filepath',
         (

--- a/tests/core/usage/plugins_usage_test.py
+++ b/tests/core/usage/plugins_usage_test.py
@@ -92,9 +92,12 @@ class TestAddCustomLimits:
 class TestAddDisableFlag:
     @staticmethod
     def test_success(parser):
-        args = parser.parse_args(['--disabled-plugins', 'Base64HighEntropyString,AWSKeyDetector'])
+        args = parser.parse_args([
+            '--disable-plugin', 'Base64HighEntropyString',
+            '--disable-plugin', 'AWSKeyDetector',
+        ])
 
-        assert args.disabled_plugins == {'AWSKeyDetector', 'Base64HighEntropyString'}
+        assert args.disable_plugin == {'AWSKeyDetector', 'Base64HighEntropyString'}
         assert 'AWSKeyDetector' not in get_settings().plugins
         assert 'Base64HighEntropyString' not in get_settings().plugins
         assert get_settings().plugins
@@ -103,12 +106,12 @@ class TestAddDisableFlag:
     def test_not_supplied(parser):
         args = parser.parse_args([])
 
-        assert args.disabled_plugins == set([])
+        assert not args.disable_plugin
 
     @staticmethod
     def test_invalid_classname(parser):
         with pytest.raises(SystemExit):
-            parser.parse_args(['--disabled-plugins', 'InvalidClassName'])
+            parser.parse_args(['--disable-plugin', 'InvalidClassName'])
 
     @staticmethod
     def test_precedence_with_baseline(parser):
@@ -132,7 +135,7 @@ class TestAddDisableFlag:
 
             parser.parse_args([
                 '--baseline', f.name,
-                '--disabled-plugins', 'Base64HighEntropyString',
+                '--disable-plugin', 'Base64HighEntropyString',
             ])
 
         assert len(get_settings().plugins) == 1

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -149,7 +149,7 @@ class TestScanOnlyAllowlisted:
             main_module.main([
                 'scan',
                 '--only-allowlisted',
-                '--disabled-plugins', 'KeywordDetector',
+                '--disable-plugin', 'KeywordDetector',
                 'test_data/config.ini',
             ])
 


### PR DESCRIPTION
## Summary

This introduces two new flags:

- `--filter`: allows the use of custom filters with the `detect-secrets` engine
- `--disable-filter`: allows users to disable built-in filters, if necessary

There's quite a bit of parsing logic to grok, but essentially, it allows for both custom modules to be used as custom filters, as well as local files. For example:

```
detect-secrets scan --filter detect_secrets_internal_filters.ml_model.is_secret
```

Might be YAGNI for now, but the intention is to accommodate new filters that may not be auto added to the default set (aka any new filters created after v1)