### PR TITLE
Adds --slim flag for baseline merge conflict reduction

### DIFF
--- a/detect_secrets/audit/audit.py
+++ b/detect_secrets/audit/audit.py
@@ -4,6 +4,7 @@ the secrets flagged are actually secrets.
 """
 from . import io
 from ..core import baseline
+from ..exceptions import NoLineNumberError
 from ..exceptions import SecretNotFoundOnSpecifiedLineError
 from ..types import SecretContext
 from ..util.code_snippet import get_code_snippet
@@ -35,9 +36,9 @@ def _classify_secrets(iterator: BidirectionalIterator) -> bool:
     has_changes = False
 
     for secret in iterator:
-        io.clear_screen()
         try:
             secret.secret_value = get_raw_secret_from_file(secret)
+            io.clear_screen()
             io.print_context(
                 SecretContext(
                     current_index=iterator.index + 1,
@@ -52,6 +53,7 @@ def _classify_secrets(iterator: BidirectionalIterator) -> bool:
 
             decision = io.get_user_decision(can_step_back=iterator.can_step_back())
         except SecretNotFoundOnSpecifiedLineError as e:
+            io.clear_screen()
             io.print_secret_not_found(
                 SecretContext(
                     current_index=iterator.index + 1,
@@ -65,6 +67,9 @@ def _classify_secrets(iterator: BidirectionalIterator) -> bool:
                 prompt_secret_decision=False,
                 can_step_back=iterator.can_step_back(),
             )
+        except NoLineNumberError as e:
+            io.print_error(str(e))
+            break
 
         if decision == io.InputOptions.QUIT:
             io.print_message('Quitting...')

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -52,9 +52,8 @@ def load_from_file(filename: str) -> Dict[str, Any]:
         raise UnableToReadBaselineError from e
 
 
-def format_for_output(secrets: SecretsCollection) -> Dict[str, Any]:
-    return {
-        'generated_at': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+def format_for_output(secrets: SecretsCollection, is_slim_mode: bool = False) -> Dict[str, Any]:
+    output = {
         'version': VERSION,
 
         # This will populate settings of filters and plugins,
@@ -62,6 +61,17 @@ def format_for_output(secrets: SecretsCollection) -> Dict[str, Any]:
 
         'results': secrets.json(),
     }
+
+    if not is_slim_mode:
+        output['generated_at'] = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+    else:
+        # NOTE: This has a nice little side effect of keeping it ordered by line number,
+        # even though we don't output it.
+        for filename, secrets in output['results'].items():
+            for secret_dict in secrets:
+                secret_dict.pop('line_number')
+
+    return output
 
 
 def save_to_file(

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -27,7 +27,7 @@ def create(*paths: str, should_scan_all_files: bool = False) -> SecretsCollectio
     return secrets
 
 
-def load(baseline: Dict[str, Any], filename: str) -> SecretsCollection:
+def load(baseline: Dict[str, Any], filename: str = '') -> SecretsCollection:
     """
     With a given baseline file, load all settings and discovered secrets from it.
 

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -188,7 +188,7 @@ class SecretsCollection:
         for filename in sorted(self.files):
             secrets = self[filename]
 
-            # TODO: Handle cases when line numbers are not supplied
+            # NOTE: If line numbers aren't supplied, they will default to 0.
             for secret in sorted(secrets, key=lambda x: (x.line_number, x.secret_hash, x.type)):
                 yield filename, secret
 

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -227,6 +227,12 @@ class SecretsCollection:
                 valuesB = vars(secretB)
                 valuesB.pop('secret_value')
 
+                if valuesA['line_number'] == 0 or valuesB['line_number'] == 0:
+                    # If line numbers are not provided (for either one), then don't compare
+                    # line numbers.
+                    valuesA.pop('line_number')
+                    valuesB.pop('line_number')
+
                 if valuesA != valuesB:
                     return False
 

--- a/detect_secrets/core/usage/filters.py
+++ b/detect_secrets/core/usage/filters.py
@@ -1,8 +1,14 @@
 import argparse
+import inspect
+import os
+from importlib import import_module
+from urllib.parse import urlparse
 
 from ... import filters
 from ...constants import VerifiedResult
+from ...exceptions import InvalidFile
 from ...settings import get_settings
+from ...util.importlib import import_file_as_module
 from .common import valid_path
 
 
@@ -50,6 +56,52 @@ def add_filter_options(parent: argparse.ArgumentParser) -> None:
             dest='word_list_file',
         )
 
+    _add_custom_filters(parser)
+
+
+def _add_custom_filters(parser: argparse._ArgumentGroup) -> None:
+    def valid_looking_paths(path: str) -> str:
+        # Expected path format:
+        #   - detect_secrets.filters.common.is_invalid_file (python import path)
+        #   - testing/custom_filters.py::is_invalid_secret (local file)
+        #   - file://testing/custom_filters.py::is_invalid_secret (local file)
+        parts = urlparse(path)
+        if not parts.scheme and '::' in path:
+            # This could be a local file, without the file schema.
+            path = 'file://' + path
+            parts = urlparse(path)
+
+        if parts.scheme == 'file':
+            # May be local file.
+            # We do some initial pre-processing, but perform the file validation during the
+            # post-processing step.
+            components = parts.path.split('::')
+            if len(components) != 2:
+                raise argparse.ArgumentTypeError(
+                    'Did not specify function name for imported file.',
+                )
+
+            file_path = path[len('file://'):].split('::')[0]
+            if not os.path.isfile(file_path):
+                raise argparse.ArgumentTypeError(f'{file_path} is not a valid file.')
+        elif parts.scheme:
+            raise argparse.ArgumentTypeError(f'{path} is not a valid filter path.')
+
+        return path
+
+    parser.add_argument(
+        '-f',
+        '--filter',
+        type=valid_looking_paths,
+        nargs=1,
+        action='append',        # so we can support multiple flags with same value
+        help=(
+            'Specify path to custom filter. '
+            'May be a python module path (e.g. detect_secrets.filters.common.is_invalid_file) or '
+            'a local file path (e.g. file://path/to/file.py::function_name).'
+        ),
+    )
+
 
 def parse_args(args: argparse.Namespace) -> None:
     if args.exclude_lines:
@@ -82,3 +134,56 @@ def parse_args(args: argparse.Namespace) -> None:
         get_settings().disable_filters(
             'detect_secrets.filters.common.is_ignored_due_to_verification_policies',
         )
+
+    if args.filter:
+        # Flatten entry for easier parsing.
+        args.filter = [entry for item in args.filter for entry in item]
+
+        # Post-processing validation
+        for item in args.filter:
+            _raise_if_custom_filter_path_is_invalid(item)
+            get_settings().filters[item] = {}
+
+
+def _raise_if_custom_filter_path_is_invalid(path: str) -> None:
+    """Performs post-validation for custom filters."""
+    parts = urlparse(path)
+    if not parts.scheme:
+        try:
+            module_path, function_name = path.rsplit('.', 1)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                'Invalid Python module path for custom filter.',
+            )
+
+        try:
+            module = import_module(module_path)
+        except ModuleNotFoundError:
+            raise argparse.ArgumentTypeError(f'Cannot import "{path}" as custom filter.')
+
+        try:
+            function = getattr(module, function_name)
+        except AttributeError:
+            raise argparse.ArgumentTypeError(
+                f'No filter function named `{function_name}` found in "{module_path}".',
+            )
+
+        if not inspect.isfunction(function):
+            raise argparse.ArgumentTypeError(f'{path} is not a filter function.')
+
+    elif parts.scheme == 'file':
+        file_path, function_name = path[len('file://'):].split('::')
+
+        try:
+            module = import_file_as_module(file_path)
+        except (FileNotFoundError, InvalidFile):
+            raise argparse.ArgumentTypeError(
+                f'Cannot import {file_path} as custom filter.',
+            )
+
+        try:
+            getattr(module, function_name)
+        except AttributeError:
+            raise argparse.ArgumentTypeError(
+                f'No filter function named `{function_name}` found in "{file_path}".',
+            )

--- a/detect_secrets/core/usage/scan.py
+++ b/detect_secrets/core/usage/scan.py
@@ -76,6 +76,15 @@ def _add_initialize_baseline_options(parser: argparse.ArgumentParser) -> None:
             'latest plugins'
         ),
     )
+    group.add_argument(
+        '--slim',
+        action='store_true',
+        help=(
+            'Slim baselines are created with the intention of minimizing differences between '
+            'commits. However, they are not compatible with the `audit` functionality, and '
+            'slim baselines will need to be remade to be audited.'
+        ),
+    )
 
 
 def parse_args(args: argparse.Namespace) -> None:

--- a/detect_secrets/exceptions.py
+++ b/detect_secrets/exceptions.py
@@ -14,8 +14,17 @@ class InvalidFile(ValueError):
 
 
 class SecretNotFoundOnSpecifiedLineError(Exception):
-    def __init__(self, line: int):
+    def __init__(self, line: int) -> None:
         super().__init__(
             'ERROR: Secret not found on line {}!\n'.format(line)
             + 'Try recreating your baseline to fix this issue.',
+        )
+
+
+class NoLineNumberError(Exception):
+    def __init__(self) -> None:
+        super().__init__(
+            'ERROR: No line numbers found in baseline! Line numbers are needed '
+            'for auditing secret occurrences. Try recreating your baseline to fix '
+            'this issue.',
         )

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -77,7 +77,7 @@ def handle_scan_action(args: argparse.Namespace) -> None:
 
         baseline.save_to_file(secrets, args.baseline_filename)
     else:
-        print(json.dumps(baseline.format_for_output(secrets), indent=2))
+        print(json.dumps(baseline.format_for_output(secrets, is_slim_mode=args.slim), indent=2))
 
 
 def scan_adhoc_string(line: str) -> str:

--- a/testing/custom_filters.py
+++ b/testing/custom_filters.py
@@ -1,0 +1,2 @@
+def is_invalid_secret(secret: str) -> bool:
+    return secret == 'gX69YO4CvBsVjzAwYxdGyDd30t5+9ez31gKATtj4'

--- a/tests/audit/audit_test.py
+++ b/tests/audit/audit_test.py
@@ -139,6 +139,25 @@ def test_ensure_file_transformers_are_used(printer):
     assert lines[line_number - 1] in printer.message
 
 
+def test_fails_if_no_line_numbers_found(printer):
+    with transient_settings({
+        'plugins_used': [
+            {'name': 'Base64HighEntropyString'},
+        ],
+    }):
+        secrets = SecretsCollection()
+        secrets.scan_file('test_data/config.env')
+
+    # Remove line numbers
+    secrets = baseline.load(baseline.format_for_output(secrets, is_slim_mode=True))
+
+    with mock.patch('detect_secrets.audit.io.clear_screen') as m:
+        run_logic(secrets)
+        assert not m.called
+
+    assert 'No line numbers found in baseline' in printer.message
+
+
 def run_logic(
     secrets: SecretsCollection,
     input: Optional[str] = None,

--- a/tests/audit/compare_test.py
+++ b/tests/audit/compare_test.py
@@ -128,6 +128,16 @@ def test_file_no_longer_exists(printer, mock_user_decision):
     assert not mock_user_decision.called
 
 
+def test_fails_when_no_line_number(printer):
+    secretsA = get_secrets(potential_secret_factory('a', line_number=0))
+    secretsB = get_secrets(potential_secret_factory('b'))
+
+    with allow_fake_files():
+        run_logic(secretsA, secretsB)
+
+    assert 'ERROR: No line numbers found' in printer.message
+
+
 def run_logic(secretsA: SecretsCollection, secretsB: SecretsCollection):
     with tempfile.NamedTemporaryFile() as f, tempfile.NamedTemporaryFile() as g:
         baseline.save_to_file(secretsA, f.name)

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -287,6 +287,21 @@ class TestTrim:
 
         assert not bool(secrets)
 
+    @staticmethod
+    def test_maintains_labels():
+        labelled_secrets = SecretsCollection()
+        labelled_secrets.scan_file('test_data/each_secret.py')
+        for _, secret in labelled_secrets:
+            secret.is_secret = True
+            break
+
+        secrets = SecretsCollection()
+        secrets.scan_file('test_data/each_secret.py')
+
+        labelled_secrets.trim(scanned_results=secrets)
+
+        assert any([secret.is_secret for _, secret in labelled_secrets])
+
 
 def test_bool():
     secrets = SecretsCollection()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -54,6 +54,14 @@ class TestScan:
             assert not printer.message
 
 
+def test_slim_scan():
+    with mock_printer(main_module) as printer:
+        main_module.main(['scan', '--slim', 'test_data'])
+
+        assert 'generated_at' not in printer.message
+        assert 'line_number' not in printer.message
+
+
 class TestScanString:
     @staticmethod
     def test_basic():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 from contextlib import contextmanager
+from contextlib import redirect_stdout
 from unittest import mock
 
 from detect_secrets import main as main_module
@@ -54,12 +55,37 @@ class TestScan:
             assert not printer.message
 
 
-def test_slim_scan():
-    with mock_printer(main_module) as printer:
-        main_module.main(['scan', '--slim', 'test_data'])
+class TestSlimScan:
+    @staticmethod
+    def test_basic():
+        with mock_printer(main_module) as printer:
+            main_module.main(['scan', '--slim', 'test_data'])
 
-        assert 'generated_at' not in printer.message
-        assert 'line_number' not in printer.message
+            assert 'generated_at' not in printer.message
+            assert 'line_number' not in printer.message
+
+    @staticmethod
+    def test_restores_line_numbers():
+        with tempfile.NamedTemporaryFile('w+') as f:
+            with redirect_stdout(f):
+                main_module.main(['scan', '--slim', 'test_data/config.env'])
+
+            f.seek(0)
+            main_module.main([
+                'scan',
+                '--slim', 'test_data/config.md', 'test_data/config.env',
+                '--baseline', f.name,
+            ])
+
+            f.seek(0)
+            secrets = baseline.load(baseline.load_from_file(f.name))
+
+        # Make sure both old and new files exist
+        assert secrets.files == {'test_data/config.env', 'test_data/config.md'}
+
+        # Make sure they both have line numbers
+        assert list(secrets['test_data/config.env'])[0].line_number
+        assert list(secrets['test_data/config.md'])[0].line_number
 
 
 class TestScanString:

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -1,4 +1,7 @@
+import json
 import tempfile
+from contextlib import contextmanager
+from functools import partial
 from typing import List
 from unittest import mock
 
@@ -74,39 +77,99 @@ def test_baseline_filters_out_known_secrets():
         ])
 
 
-def test_modifies_baseline_from_version_change():
-    secrets = SecretsCollection()
-    secrets.scan_file('test_data/files/file_with_secrets.py')
+class TestModifiesBaselineFromVersionChange:
+    FILENAME = 'test_data/files/file_with_secrets.py'
 
-    with tempfile.NamedTemporaryFile() as f:
-        with mock.patch('detect_secrets.core.baseline.VERSION', '0.0.1'):
-            data = baseline.format_for_output(secrets)
+    def test_success(self):
+        with self.get_baseline_file() as f:
+            assert_commit_blocked_with_diff_exit_code([
+                # We use file_with_no_secrets so that we can be certain that the commit is blocked
+                # due to the version change only.
+                'test_data/files/file_with_no_secrets.py',
+                '--baseline',
+                f.name,
+            ])
 
-        # Simulating old version
-        data['plugins_used'][0]['base64_limit'] = data['plugins_used'][0].pop('limit')
-        baseline.save_to_file(data, f.name)
+    def test_maintains_labelled_data(self):
+        def label_secret(secrets):
+            list(secrets[self.FILENAME])[0].is_secret = True
+            return baseline.format_for_output(secrets)
 
-        assert_commit_blocked_with_diff_exit_code([
-            'test_data/files/file_with_no_secrets.py',
-            '--baseline',
-            f.name,
-        ])
+        with self.get_baseline_file(formatter=label_secret) as f:
+            assert_commit_blocked_with_diff_exit_code([
+                'test_data/files/file_with_no_secrets.py',
+                '--baseline',
+                f.name,
+            ])
+
+            f.seek(0)
+            data = json.loads(f.read())
+
+            assert data['results'][self.FILENAME][0]['is_secret']
+
+    def test_maintains_slim_mode(self):
+        with self.get_baseline_file(
+            formatter=partial(baseline.format_for_output, is_slim_mode=True),
+        ) as f:
+            assert_commit_blocked_with_diff_exit_code([
+                'test_data/files/file_with_no_secrets.py',
+                '--baseline',
+                f.name,
+            ])
+
+            f.seek(0)
+            assert b'line_number' not in f.read()
+
+    @contextmanager
+    def get_baseline_file(self, formatter=baseline.format_for_output):
+        secrets = SecretsCollection()
+        secrets.scan_file(self.FILENAME)
+
+        with tempfile.NamedTemporaryFile() as f:
+            with mock.patch('detect_secrets.core.baseline.VERSION', '0.0.1'):
+                data = formatter(secrets)
+
+            # Simulating old version
+            data['plugins_used'][0]['base64_limit'] = data['plugins_used'][0].pop('limit')
+            baseline.save_to_file(data, f.name)
+
+            yield f
 
 
-def test_modifies_baseline_from_line_number_change():
-    secrets = SecretsCollection()
-    secrets.scan_file('test_data/files/file_with_secrets.py')
-    for _, secret in secrets:
-        secret.line_number += 1
+class TestLineNumberChanges:
+    FILENAME = 'test_data/files/file_with_secrets.py'
 
-    with tempfile.NamedTemporaryFile() as f:
-        baseline.save_to_file(secrets, f.name)
+    def test_modifies_baseline(self, modified_baseline):
+        with tempfile.NamedTemporaryFile() as f:
+            baseline.save_to_file(modified_baseline, f.name)
 
-        assert_commit_blocked_with_diff_exit_code([
-            'test_data/files/file_with_secrets.py',
-            '--baseline',
-            f.name,
-        ])
+            assert_commit_blocked_with_diff_exit_code([
+                self.FILENAME,
+                '--baseline',
+                f.name,
+            ])
+
+    def test_does_not_modify_slim_baseline(self, modified_baseline):
+        with tempfile.NamedTemporaryFile() as f:
+            baseline.save_to_file(
+                baseline.format_for_output(modified_baseline, is_slim_mode=True),
+                f.name,
+            )
+
+            assert_commit_succeeds([
+                self.FILENAME,
+                '--baseline',
+                f.name,
+            ])
+
+    @pytest.fixture
+    def modified_baseline(self):
+        secrets = SecretsCollection()
+        secrets.scan_file(self.FILENAME)
+        for _, secret in secrets:
+            secret.line_number += 1
+
+        yield secrets
 
 
 def assert_commit_succeeds(command: List[str]):


### PR DESCRIPTION
## Summary

Adds `--slim` flag during `scan` to create a baseline that reduces merge conflicts. Specifically, it removes line numbers and the `generated_at` field, as these are the main causes of observed merge conflicts.

A few additional points:
- When the pre-commit hook is used with a slimmed baseline, and it makes changes, it will also maintain the slimmed nature of the baseline.
- Since `audit` requires line numbers (to find the secret, without scanning the whole file), we raise an error if there's no line numbers to be found. While technically we can (automatically) re-scan the baseline upon auditing, I decided to leave that up to the user to update their baseline with line numbers (explicit local caching is a good thing).

Also, this PR also includes a fix for a pretty bad bug where the pre-commit hook would remove labels on secrets (e.g. `is_secret`). Good thing we found it before we released the new version!

## Reviewer's Note

It looks like this commit history includes one from https://github.com/Yelp/detect-secrets/pull/393, so I'll merge that first, then merge this one.