### PR TITLE
Adding more default filters

### DIFF
--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -106,6 +106,9 @@ class Settings:
                 'detect_secrets.filters.heuristic.is_sequential_string',
                 'detect_secrets.filters.heuristic.is_potential_uuid',
                 'detect_secrets.filters.heuristic.is_likely_id_string',
+                'detect_secrets.filters.heuristic.is_templated_secret',
+                'detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign',
+                'detect_secrets.filters.heuristic.is_indirect_reference',
             }
         }
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -46,10 +46,13 @@ the `detect_secrets.filters` namespace.
 | `common.is_invalid_file`                         | Ignores files that are not files (e.g. links).                                      |
 | `common.is_baseline_file`                        | Ignores the baseline file itself.                                                   |
 | `common.is_ignored_due_to_verification_policies` | Powers secret verification functionality.                                           |
-| `heuristic.is_sequential_string`                 | Ignores secrets like `abcdefg`.                                                     |
-| `heuristic.is_potential_uuid`                    | Ignores uuid looking secret values.                                                 |
+| `heuristic.is_indirect_reference`                | Primarily for `KeywordDetector`, filters secrets like `secret = get_secret_key()`.  |
 | `heuristic.is_likely_id_string`                  | Ignores secret values prefixed with `id`.                                           |
 | `heuristic.is_non_text_file`                     | Ignores non-text files (e.g. archives, images).                                     |
+| `heuristic.is_potential_uuid`                    | Ignores uuid looking secret values.                                                 |
+| `heuristic.is_prefixed_with_dollar_sign`         | Primarily for `KeywordDetector`, filters secrets like `secret = $variableName;`.    |
+| `heuristic.is_sequential_string`                 | Ignores secrets like `abcdefg`.                                                     |
+| `heuristic.is_templated_secret`                  | Ignores secrets like `secret = <key>`, `secret = {{key}}` and `secret = ${key}`.    |
 | `regex.should_exclude_line`                      | Powers the [`--exclude-lines` functionality](../README.md#--exclude-lines).         |
 | `regex.should_exclude_file`                      | Powers the [`--exclude-files` functionality](../README.md#--exclude-files).         |
 | `wordlist.should_exclude_secret`                 | Powers the [`--word-list` functionality](../README.md#--word-list).                 |


### PR DESCRIPTION
## Summary

This adds the following filters as default (though able to be disabled) filters:

- `detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign`
- `detect_secrets.filters.heuristic.is_indirect_reference`
- `detect_secrets.filters.heuristic.is_templated_secret`

This also adds documentation for them.

## Reviewers Notes

In https://github.com/Yelp/detect-secrets/pull/377, I made it such that upgraded clients would get these new filters (due to `KeywordDetector`'s migration), however, new users wouldn't. However, I also realized that without these filters, `KeywordDetector` will be REALLY noisy, which is the main cause of noise currently.

As such, I decided to add these as default filters as well -- given that it's relatively simple to disable them if needed.