### PR TITLE
making KeywordDetector case-insensitive

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,21 +115,21 @@
         "filename": "detect_secrets/plugins/keyword.py",
         "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
         "is_verified": false,
-        "line_number": 176
+        "line_number": 178
       },
       {
         "type": "Secret Keyword",
         "filename": "detect_secrets/plugins/keyword.py",
         "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 189
       },
       {
         "type": "Secret Keyword",
         "filename": "detect_secrets/plugins/keyword.py",
         "hashed_secret": "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29",
         "is_verified": false,
-        "line_number": 217
+        "line_number": 223
       }
     ],
     "detect_secrets/plugins/private_key.py": [
@@ -255,5 +255,5 @@
       }
     ]
   },
-  "generated_at": "2021-02-25T15:16:48Z"
+  "generated_at": "2021-02-25T19:11:59Z"
 }

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -161,6 +161,7 @@ FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 FOLLOWED_BY_COLON_REGEX = re.compile(
     # e.g. api_key: foo
@@ -171,6 +172,7 @@ FOLLOWED_BY_COLON_REGEX = re.compile(
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. api_key: "foo"
@@ -181,6 +183,7 @@ FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX = re.compile(
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. my_password = "bar"
@@ -192,6 +195,7 @@ FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX
         optional_whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password = bar
@@ -202,6 +206,7 @@ FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. my_password = "bar"
@@ -212,6 +217,7 @@ FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
     # e.g. private_key "something";
@@ -222,6 +228,7 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,
     ),
+    flags=re.IGNORECASE,
 )
 DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_REGEX: 4,

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -232,10 +232,19 @@ class TestKeywordDetector:
                 'name': 'KeywordDetector',
             }],
         }):
-            assert not list(scan_line(line))
+            assert list(scan_line(line))
 
             with tempfile.NamedTemporaryFile(suffix='.js') as f:
                 f.write(line.encode('utf-8'))
                 f.seek(0)
 
                 assert not list(scan_file(f.name))
+
+    @staticmethod
+    def test_ignore_case():
+        with transient_settings({
+            'plugins_used': [{
+                'name': 'KeywordDetector',
+            }],
+        }):
+            assert list(scan_line('os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"'))


### PR DESCRIPTION
## Summary

It looks like `KeywordDetector` became case-sensitive during the v1 migration. Let's change this back.

## Testing Done

Automated.

I also fixed a previous test case -- I'm pretty sure that it was incorrectly passing all along last time.