### PR TITLE
Bugfix in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_version():
 VERSION = get_version()
 
 
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
The following exception has been raised during the installation of detect-secrets in a Microsoft Windows environment (tested in PowerShell and CMD):

```
Traceback (most recent call last):
  File ".\setup.py", line 17, in <module>
    long_description = f.read()
  File "c:\Users\psantial\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 5964: character maps to <undefined>
```

The command used to the installation was:

```BASH
$ python3 setup.py build install
```

With this Pull Request, the problem is solved (tested in Windows and MacOS).