### PR TITLE
adding is_lock_file filter

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -251,9 +251,9 @@
         "filename": "docs/filters.md",
         "hashed_secret": "4566d0493d8a9b7a811728e852ed5df95fa70dd2",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 56
       }
     ]
   },
-  "generated_at": "2021-02-25T19:11:59Z"
+  "generated_at": "2021-03-04T16:27:24Z"
 }

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -165,3 +165,12 @@ def is_indirect_reference(secret: str) -> bool:
             continue
 
     return output
+
+
+def is_lock_file(filename: str) -> bool:
+    return os.path.basename(filename) in {
+        'Brewfile.lock.json',
+        'composer.lock',
+        'package.lock',
+        'yarn.lock',
+    }

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -170,7 +170,11 @@ def is_indirect_reference(secret: str) -> bool:
 def is_lock_file(filename: str) -> bool:
     return os.path.basename(filename) in {
         'Brewfile.lock.json',
+        'Cartfile.resolved',
         'composer.lock',
-        'package.lock',
+        'Gemfile.lock',
+        'Package.resolved',
+        'package-lock.json',
+        'Podfile.lock',
         'yarn.lock',
     }

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -109,6 +109,7 @@ class Settings:
                 'detect_secrets.filters.heuristic.is_templated_secret',
                 'detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign',
                 'detect_secrets.filters.heuristic.is_indirect_reference',
+                'detect_secrets.filters.heuristic.is_lock_file',
             }
         }
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -48,6 +48,7 @@ the `detect_secrets.filters` namespace.
 | `common.is_ignored_due_to_verification_policies` | Powers secret verification functionality.                                           |
 | `heuristic.is_indirect_reference`                | Primarily for `KeywordDetector`, filters secrets like `secret = get_secret_key()`.  |
 | `heuristic.is_likely_id_string`                  | Ignores secret values prefixed with `id`.                                           |
+| `heuristic.is_lock_file`                         | Ignores common lock files.                                                          |
 | `heuristic.is_non_text_file`                     | Ignores non-text files (e.g. archives, images).                                     |
 | `heuristic.is_potential_uuid`                    | Ignores uuid looking secret values.                                                 |
 | `heuristic.is_prefixed_with_dollar_sign`         | Primarily for `KeywordDetector`, filters secrets like `secret = $variableName;`.    |

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -127,3 +127,14 @@ def test_is_indirect_reference(line, result):
         }],
     }):
         assert bool(list(scan_line(line))) is result
+
+
+def test_is_lock_file():
+    # Basic test
+    assert filters.heuristic.is_lock_file('composer.lock')
+
+    # file path
+    assert filters.heuristic.is_lock_file('path/yarn.lock')
+
+    # assert non-regex
+    assert not filters.heuristic.is_lock_file('Gemfilealock')


### PR DESCRIPTION
## Summary

Lock files typically have hashes in them, and this triggers a lot of false positives for our high entropy string plugins. We've seen success in just ignoring them, so let's formalize it.