### PR TITLE
Keyword regexes improvement

### DIFF
--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -153,7 +153,7 @@ OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"]'
 # Includes, at least, 1 alphanumeric character
-SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*'
+SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*[^\r\n,\'"]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -229,7 +229,7 @@ FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # or my_password !== "bar"
     # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
     # or my_password !== 'bar'
-    r'({denylist})({closing})?{whitespace}[!=]{2,3}{whitespace}({quote})({secret})(\3)'.format(  # noqa: E501
+    r'({denylist})({closing})?{whitespace}[!=]{{2,3}}{whitespace}({quote})({secret})(\3)'.format(  # noqa: E501
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -238,7 +238,7 @@ FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     ),
 )
 
-PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = = re.compile(
+PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. "bar" == my_password or "bar" != my_password or "bar" === my_password
     # or "bar" !== my_password
     # e.g. 'bar' == my_password or 'bar' != my_password or 'bar' === my_password

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -154,17 +154,17 @@ OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
 '''
 Secret regex details:
-    [^\r\n]*      -> this section match with every character except line breaks. 
-                     This allows to find secrets that starts with symbols or 
+    [^\r\n]*      -> this section match with every character except line breaks.
+                     This allows to find secrets that starts with symbols or
                      alphanumeric characters.
-    [a-zA-Z0-9]+  -> this section match only with alphanumeric characters, and at 
-                     least one is required. This allows to reduce the false positives 
+    [a-zA-Z0-9]+  -> this section match only with alphanumeric characters, and at
+                     least one is required. This allows to reduce the false positives
                      number.
-    [^\r\n]*      -> this section match with every character except line breaks. 
+    [^\r\n]*      -> this section match with every character except line breaks.
                      This allows to find secrets with symbols at the end.
-    [^\r\n,\'"`]  -> this section match with the last secret character that can be 
-                     everything except line breaks, comma, backticks or quotes. This 
-                     allows to reduce the false positives number and to prevent 
+    [^\r\n,\'"`]  -> this section match with the last secret character that can be
+                     everything except line breaks, comma, backticks or quotes. This
+                     allows to reduce the false positives number and to prevent
                      errors in the code snippet highlighting.
 '''
 SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*[^\r\n,\'"`]'

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -203,7 +203,11 @@ FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX
 )
 FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password = bar
-    r'({denylist})({closing})?{whitespace}={whitespace}({quote}?)({secret})(\3)'.format(
+    # e.g. my_password == "bar" or my_password != "bar" or my_password === "bar"
+    # or my_password !== "bar"
+    # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
+    # or my_password !== 'bar'
+    r'({denylist})({closing})?{whitespace}(={{1,3}}|!==?){whitespace}({quote}?)({secret})(\4)'.format(  # noqa: E501
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -214,7 +218,11 @@ FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
 )
 FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. my_password = "bar"
-    r'({denylist})({closing})?{whitespace}={whitespace}({quote})({secret})(\3)'.format(
+    # e.g. my_password == "bar" or my_password != "bar" or my_password === "bar"
+    # or my_password !== "bar"
+    # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
+    # or my_password !== 'bar'
+    r'({denylist})({closing})?{whitespace}(={{1,3}}|!==?){whitespace}({quote})({secret})(\4)'.format(  # noqa: E501
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -222,20 +230,6 @@ FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
         secret=SECRET,
     ),
     flags=re.IGNORECASE,
-)
-
-FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
-    # e.g. my_password == "bar" or my_password != "bar" or my_password === "bar"
-    # or my_password !== "bar"
-    # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
-    # or my_password !== 'bar'
-    r'({denylist})({closing})?{whitespace}[!=]{{2,3}}{whitespace}({quote})({secret})(\3)'.format(  # noqa: E501
-        denylist=DENYLIST_REGEX,
-        closing=CLOSING,
-        quote=QUOTE,
-        whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET,
-    ),
 )
 
 PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
@@ -264,16 +258,14 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
 )
 DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_REGEX: 4,
-    FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 4,
     PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 2,
-    FOLLOWED_BY_EQUAL_SIGNS_REGEX: 4,
+    FOLLOWED_BY_EQUAL_SIGNS_REGEX: 5,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
 }
 GOLANG_DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX: 4,
-    FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 4,
     PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 2,
-    FOLLOWED_BY_EQUAL_SIGNS_REGEX: 4,
+    FOLLOWED_BY_EQUAL_SIGNS_REGEX: 5,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
 }
 OBJECTIVE_C_DENYLIST_REGEX_TO_GROUP = {
@@ -281,9 +273,8 @@ OBJECTIVE_C_DENYLIST_REGEX_TO_GROUP = {
 }
 QUOTES_REQUIRED_DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX: 5,
-    FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 4,
     PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 2,
-    FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX: 4,
+    FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX: 5,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
 }
 QUOTES_REQUIRED_FILETYPES = {

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -152,7 +152,7 @@ DENYLIST_REGEX = r'|'.join(DENYLIST)
 OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"]'
-SECRET = r'[^\r\n]+'
+SECRET = r'[^\r\n\'"]+'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -151,9 +151,23 @@ DENYLIST_REGEX = r'|'.join(DENYLIST)
 # Non-greedy match
 OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
-QUOTE = r'[\'"]'
-# Includes, at least, 1 alphanumeric character
-SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*[^\r\n,\'"]'
+QUOTE = r'[\'"`]'
+'''
+Secret regex details:
+    [^\r\n]*      -> this section match with every character except line breaks. 
+                     This allows to find secrets that starts with symbols or 
+                     alphanumeric characters.
+    [a-zA-Z0-9]+  -> this section match only with alphanumeric characters, and at 
+                     least one is required. This allows to reduce the false positives 
+                     number.
+    [^\r\n]*      -> this section match with every character except line breaks. 
+                     This allows to find secrets with symbols at the end.
+    [^\r\n,\'"`]  -> this section match with the last secret character that can be 
+                     everything except line breaks, comma, backticks or quotes. This 
+                     allows to reduce the false positives number and to prevent 
+                     errors in the code snippet highlighting.
+'''
+SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*[^\r\n,\'"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -152,7 +152,8 @@ DENYLIST_REGEX = r'|'.join(DENYLIST)
 OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"]'
-SECRET = r'[^\r\n\'"]+'
+# Includes, at least, 1 alphanumeric character
+SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
@@ -222,6 +223,34 @@ FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     ),
     flags=re.IGNORECASE,
 )
+
+FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
+    # e.g. my_password == "bar" or my_password != "bar" or my_password === "bar"
+    # or my_password !== "bar"
+    # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
+    # or my_password !== 'bar'
+    r'({denylist})({closing})?{whitespace}[!=]{2,3}{whitespace}({quote})({secret})(\3)'.format(  # noqa: E501
+        denylist=DENYLIST_REGEX,
+        closing=CLOSING,
+        quote=QUOTE,
+        whitespace=OPTIONAL_WHITESPACE,
+        secret=SECRET,
+    ),
+)
+
+PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = = re.compile(
+    # e.g. "bar" == my_password or "bar" != my_password or "bar" === my_password
+    # or "bar" !== my_password
+    # e.g. 'bar' == my_password or 'bar' != my_password or 'bar' === my_password
+    # or 'bar' !== my_password
+    r'({quote})({secret})(\1){whitespace}[!=]{{2,3}}{whitespace}({denylist})'.format(
+        denylist=DENYLIST_REGEX,
+        quote=QUOTE,
+        whitespace=OPTIONAL_WHITESPACE,
+        secret=SECRET,
+    ),
+)
+
 FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
     # e.g. private_key "something";
     r'({denylist}){nonWhitespace}{whitespace}({quote})({secret})(\2);'.format(
@@ -235,11 +264,15 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
 )
 DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_REGEX: 4,
+    FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 4,
+    PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 2,
     FOLLOWED_BY_EQUAL_SIGNS_REGEX: 4,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
 }
 GOLANG_DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX: 4,
+    FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 4,
+    PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 2,
     FOLLOWED_BY_EQUAL_SIGNS_REGEX: 4,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
 }
@@ -248,6 +281,8 @@ OBJECTIVE_C_DENYLIST_REGEX_TO_GROUP = {
 }
 QUOTES_REQUIRED_DENYLIST_REGEX_TO_GROUP = {
     FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX: 5,
+    FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 4,
+    PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX: 2,
     FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX: 4,
     FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX: 3,
 }

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -50,101 +50,99 @@ DENYLIST = (
     'secret',
     'secrete',
 )
-'''
-Deprecated false positives list. This will be migrated soon.
-FALSE_POSITIVES = {
-    '""',
-    '""):',
-    '"\'',
-    '")',
-    '"dummy',
-    '"replace',
-    '"this',
-    '#pass',
-    '#password',
-    '$(shell',
-    "'\"",
-    "''",
-    "''):",
-    "')",
-    "'dummy",
-    "'replace",
-    "'this",
-    '(nsstring',
-    '-default}',
-    '::',
-    '<%=',
-    '<?php',
-    '<a',
-    '<aws_secret_access_key>',
-    '<input',
-    '<password>',
-    '<redacted>',
-    '<secret',
-    '>',
-    '=',
-    '\\"$(shell',
-    '\\k.*"',
-    "\\k.*'",
-    '`cat',
-    '`grep',
-    '`sudo',
-    'account_password',
-    'api_key',
-    'disable',
-    'dummy_secret',
-    'dummy_value',
-    'false',
-    'false):',
-    'false,',
-    'false;',
-    'login_password',
-    'none',
-    'none,',
-    'none}',
-    'nopasswd',
-    'not',
-    'not_real_key',
-    'null',
-    'null,',
-    'null.*"',
-    "null.*'",
-    'null;',
-    'pass',
-    'pass)',
-    'password',
-    'password)',
-    'password))',
-    'password,',
-    'password},',
-    'prompt',
-    'redacted',
-    'secret',
-    'some_key',
-    'str',
-    'str_to_sign',
-    'string',
-    'string)',
-    'string,',
-    'string;',
-    'string?',
-    'string?)',
-    'string}',
-    'string}}',
-    'test',
-    'test-access-key',
-    'thisisnottherealsecret',
-    'todo',
-    'true',
-    'true):',
-    'true,',
-    'true;',
-    'undef',
-    'undef,',
-    '{',
-    '{{',
-}
-'''
+# Deprecated false positives list. This will be migrated soon.
+# FALSE_POSITIVES = {
+#     '""',
+#     '""):',
+#     '"\'',
+#     '")',
+#     '"dummy',
+#     '"replace',
+#     '"this',
+#     '#pass',
+#     '#password',
+#     '$(shell',
+#     "'\"",
+#     "''",
+#     "''):",
+#     "')",
+#     "'dummy",
+#     "'replace",
+#     "'this",
+#     '(nsstring',
+#     '-default}',
+#     '::',
+#     '<%=',
+#     '<?php',
+#     '<a',
+#     '<aws_secret_access_key>',
+#     '<input',
+#     '<password>',
+#     '<redacted>',
+#     '<secret',
+#     '>',
+#     '=',
+#     '\\"$(shell',
+#     '\\k.*"',
+#     "\\k.*'",
+#     '`cat',
+#     '`grep',
+#     '`sudo',
+#     'account_password',
+#     'api_key',
+#     'disable',
+#     'dummy_secret',
+#     'dummy_value',
+#     'false',
+#     'false):',
+#     'false,',
+#     'false;',
+#     'login_password',
+#     'none',
+#     'none,',
+#     'none}',
+#     'nopasswd',
+#     'not',
+#     'not_real_key',
+#     'null',
+#     'null,',
+#     'null.*"',
+#     "null.*'",
+#     'null;',
+#     'pass',
+#     'pass)',
+#     'password',
+#     'password)',
+#     'password))',
+#     'password,',
+#     'password},',
+#     'prompt',
+#     'redacted',
+#     'secret',
+#     'some_key',
+#     'str',
+#     'str_to_sign',
+#     'string',
+#     'string)',
+#     'string,',
+#     'string;',
+#     'string?',
+#     'string?)',
+#     'string}',
+#     'string}}',
+#     'test',
+#     'test-access-key',
+#     'thisisnottherealsecret',
+#     'todo',
+#     'true',
+#     'true):',
+#     'true,',
+#     'true;',
+#     'undef',
+#     'undef,',
+#     '{',
+#     '{{',
+# }
 # Includes ], ', " as closing
 CLOSING = r'[]\'"]{0,2}'
 DENYLIST_REGEX = r'|'.join(DENYLIST)
@@ -152,21 +150,19 @@ DENYLIST_REGEX = r'|'.join(DENYLIST)
 OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
-'''
-Secret regex details:
-    [^\r\n]*      -> this section match with every character except line breaks.
-                     This allows to find secrets that starts with symbols or
-                     alphanumeric characters.
-    [a-zA-Z0-9]+  -> this section match only with alphanumeric characters, and at
-                     least one is required. This allows to reduce the false positives
-                     number.
-    [^\r\n]*      -> this section match with every character except line breaks.
-                     This allows to find secrets with symbols at the end.
-    [^\r\n,\'"`]  -> this section match with the last secret character that can be
-                     everything except line breaks, comma, backticks or quotes. This
-                     allows to reduce the false positives number and to prevent
-                     errors in the code snippet highlighting.
-'''
+# Secret regex details:
+#    [^\r\n]*      -> this section match with every character except line breaks.
+#                     This allows to find secrets that starts with symbols or
+#                     alphanumeric characters.
+#    [a-zA-Z0-9]+  -> this section match only with alphanumeric characters, and at
+#                     least one is required. This allows to reduce the false positives
+#                     number.
+#    [^\r\n]*      -> this section match with every character except line breaks.
+#                     This allows to find secrets with symbols at the end.
+#    [^\r\n,\'"`]  -> this section match with the last secret character that can be
+#                     everything except line breaks, comma, backticks or quotes. This
+#                     allows to reduce the false positives number and to prevent
+#                     errors in the code snippet highlighting.
 SECRET = r'[^\r\n]*[a-zA-Z0-9]+[^\r\n]*[^\r\n,\'"`]'
 SQUARE_BRACKETS = r'(\[\])'
 

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -173,13 +173,11 @@ PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = {
     },
     'positives': {
         'quotes_required': [
-            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" == some_dict["secret"]',
-            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" == the_password\n',
-            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' == the_password\n',
-            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" != some_dict["secret"]',
-            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" != the_password\n',
-            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' === the_password\n',
-            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'!== the_password\n',
+            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" == password\n',
+            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' == password\n',
+            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" != password\n',
+            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' === password\n',
+            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'!== password\n',
         ],
     },
 }
@@ -199,8 +197,8 @@ STANDARD_POSITIVES.extend(
     + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_required')
     + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_not_required')
     + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get('positives').get('quotes_required')
-    + FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required')
-    + PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required'),
+    + FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required')   # noqa: E501
+    + PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required'),  # noqa: E501
 )
 
 

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -1,292 +1,168 @@
-import tempfile
-
 import pytest
 
-from detect_secrets.core.scan import scan_file
 from detect_secrets.core.scan import scan_line
 from detect_secrets.plugins.keyword import KeywordDetector
 from detect_secrets.settings import transient_settings
 
 
-FOLLOWED_BY_COLON_EQUAL_SIGNS_RE = {
-    'negatives': {
-        'quotes_required': [
-            'theapikey := ""',  # Nothing in the quotes
-            'theapikey := "somefakekey"',  # 'fake' in the secret
-        ],
-        'quotes_not_required': [
-            'theapikeyforfoo := hopenobodyfindsthisone',  # Characters between apikey and :=
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            'apikey := "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey :="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey  :=   "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            "apikey := 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-            "apikey :='m{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-            'apikey:= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey:="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            "apikey:= 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-            "apikey:='m{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-            "apikey:=  'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-        ],
-        'quotes_not_required': [
-            'apikey := m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'apikey :=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'apikey:= m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'apikey:=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-        ],
-    },
-}
-FOLLOWED_BY_COLON_RE = {
-    'negatives': {
-        'quotes_required': [
-            'theapikey: ""',  # Nothing in the quotes
-            'theapikey: "somefakekey"',  # 'fake' in the secret
-        ],
-        'quotes_not_required': [
-            'theapikeyforfoo:hopenobodyfindsthisone',  # Characters between apikey and :
-            'password: ${link}',  # Has a ${ followed by a }
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            "'theapikey': 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-            '"theapikey": "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey: "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            "apikey:  'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'",
-        ],
-        'quotes_not_required': [
-            'apikey: m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'apikey:m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'theapikey:m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-        ],
-    },
-}
-FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX = {
-    'negatives': {
-        'quotes_required': [
-            'theapikey[] = ""',  # Nothing in the quotes
-            'theapikey = @"somefakekey"',  # 'fake' in the secret
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            'apikey = "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey ="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey  =   "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey = @"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey =@"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey  =   @"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey[]= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'apikey[]="m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-        ],
-    },
-}
-FOLLOWED_BY_EQUAL_SIGNS_RE = {
-    'negatives': {
-        'quotes_required': [
-            'some_key = "real_secret"',  # We cannot make 'key' a Keyword, too noisy
-            'my_password = ""',  # Nothing in the quotes
-            "my_password = ''",  # Nothing in the quotes
-            'my_password = "fakesecret"',  # 'fake' in the secret
-            'open(self, password = ""):',  # secrets is ""):
-            'open(self, password = ""):',  # secrets is ""):
-        ],
-        'quotes_not_required': [
-            'my_password = foo(hey)you',  # Has a ( followed by a )
-            "my_password = request.json_body['hey']",  # Has a [ followed by a ]
-            'my_password = True',  # 'True' is a known false-positive
-            'login(username=username, password=password)',  # secret is password)
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            'some_dict["secret"] = "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'the_password= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
-            'the_password=\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
-        ],
-        'quotes_not_required': [
-            "some_dict['secret'] = m{{h}o)p${e]nob(ody[finds>-_$#thisone}}",
-            'my_password=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'my_password= m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'my_password =m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'my_password = m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'my_password =m{{h}o)p${e]nob(ody[finds>-_$#thisone}}',
-            'the_password=m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\n',
-        ],
-    },
-}
-FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE = {
-    'negatives': {
-        'quotes_required': [
-            'private_key "";',  # Nothing in the quotes
-            'private_key \'"no spaces\';',  # Has whitespace in the secret
-            'private_key "fake";',  # 'fake' in the secret
-            'private_key "some/dir/aint/a/secret";',  # 3 or more /
-            'private_key "${FOO}";',  # Starts with ${ and ends with }
-            'private_key "hopenobodyfindsthisone\';',  # Double-quote does not match single-quote
-            'private_key \'hopenobodyfindsthisone";',  # Single-quote does not match double-quote
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            'apikey "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}";',  # Double-quotes
-            'fooapikeyfoo "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}";',  # Double-quotes
-            'fooapikeyfoo"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}";',  # Double-quotes
-            'private_key \'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\';',  # Single-quotes
-            'fooprivate_keyfoo\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\';',  # Single-quotes
-            'fooprivate_key\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\';',  # Single-quotes
-        ],
-    },
-}
+COMMON_SECRET = 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
+WHITES_SECRET = 'value with quotes and spaces'
+LETTER_SECRET = 'A,.:-¨Ç*¿?!'
+SYMBOL_SECRET = ',.:-¨Ç*¿?!'
 
-FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = {
-    'negatives': {
-        'quotes_required': [
-            'my_password == ""',  # Nothing in the quotes
-            "my_password == ''",  # Nothing in the quotes
-            'my_password == "fakesecret"',  # 'fake' in the secret
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            'some_dict["secret"] == "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'the_password== "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
-            'the_password==\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
-            'some_dict["secret"] != "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
-            'the_password!= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
-            'the_password===\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
-            'the_password!==\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
-        ],
-    },
-}
+GENERIC_TEST_CASES = [
+    ('password = "{}"'.format(WHITES_SECRET), WHITES_SECRET),
+    ('apikey = {}'.format(COMMON_SECRET), COMMON_SECRET),
+    ("api_key: '{}'".format(WHITES_SECRET), WHITES_SECRET),
+    ('aws_secret_access_key: {}'.format(WHITES_SECRET), WHITES_SECRET),
+    ('db_pass: {},'.format(COMMON_SECRET), COMMON_SECRET),      # Last character is ignored
+    ('passwd: {}`'.format(COMMON_SECRET), COMMON_SECRET),       # Last character is ignored
+    ('private_key: {}"'.format(COMMON_SECRET), COMMON_SECRET),  # Last character is ignored
+    ("secret: {}'".format(COMMON_SECRET), COMMON_SECRET),       # Last character is ignored
+    ('secrete "{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (apikey == "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (api_key != "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (aws_secret_access_key === "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (db_pass !== "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" == password) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" != passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" !== secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('secrete = {}'.format(LETTER_SECRET), LETTER_SECRET),   # All symbols are allowed
+    ('password = {}'.format(SYMBOL_SECRET), None),  # At least 1 alphanumeric character is required
+    ('api_key = ""', None),  # Nothing in the quotes
+    ("secret: ''", None),   # Nothing in the quotes
+    ('secret = "abcdefghi"', None),     # Alphabet sequential string
+    ('password: ${link}', None),        # Has a ${ followed by a }
+    ('some_key = "real_secret"', None),  # We cannot make 'key' a Keyword, too noisy)
+    ('private_key "hopenobodyfindsthisone\';', None),   # Double-quote does not match single-quote)
+]
 
-PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = {
-    'negatives': {
-        'quotes_required': [
-            '"" == my_password',  # Nothing in the quotes
-            "'' == my_password",  # Nothing in the quotes
-            '"fakesecret" == my_password',  # 'fake' in the secret
-        ],
-    },
-    'positives': {
-        'quotes_required': [
-            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" == password\n',
-            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' == password\n',
-            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" != password\n',
-            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' === password\n',
-            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'!== password\n',
-        ],
-    },
-}
+GOLANG_TEST_CASES = [
+    ('apikey := "{}"'.format(COMMON_SECRET), COMMON_SECRET),
+    ("api_key := '{}'".format(COMMON_SECRET), COMMON_SECRET),
+    ('aws_secret_access_key := `{}`'.format(COMMON_SECRET), COMMON_SECRET),
+    ('db_pass := {}'.format(COMMON_SECRET), COMMON_SECRET),
+    ('passwd := {},'.format(COMMON_SECRET), COMMON_SECRET),         # Last character is ignored
+    ("private_key := {}'".format(COMMON_SECRET), COMMON_SECRET),    # Last character is ignored
+    ('secret := {}"'.format(COMMON_SECRET), COMMON_SECRET),         # Last character is ignored
+    ('password := {}`'.format(COMMON_SECRET), COMMON_SECRET),       # Last character is ignored
+    ('if ("{}" == passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" != secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" !== password) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('apikey = "{}"'.format(COMMON_SECRET), COMMON_SECRET),
+    ("api_key = '{}'".format(COMMON_SECRET), COMMON_SECRET),
+    ('aws_secret_access_key = `{}`'.format(COMMON_SECRET), COMMON_SECRET),
+    ('db_pass = {}'.format(COMMON_SECRET), COMMON_SECRET),
+    ('password = {},'.format(COMMON_SECRET), COMMON_SECRET),        # Last character is ignored
+    ("passwd = {}'".format(COMMON_SECRET), COMMON_SECRET),          # Last character is ignored
+    ('private_key = {}"'.format(COMMON_SECRET), COMMON_SECRET),     # Last character is ignored
+    ('secret = {}`'.format(COMMON_SECRET), COMMON_SECRET),          # Last character is ignored
+    ('secrete = "{}"'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (apikey == "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (api_key === "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (aws_secret_access_key != "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (db_pass !== "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('password "{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('secrete := {}'.format(LETTER_SECRET), LETTER_SECRET),   # All symbols are allowed
+    ('password :={}'.format(SYMBOL_SECRET), None),  # At least 1 alphanumeric character is required
+    ('api_key = ""', None),    # Nothing in the quotes
+    ("secret := ''", None),    # Nothing in the quotes
+    ('password := "somefakekey"', None),    # 'fake' in the secret
+    ('some_key = "real_secret"', None),     # We cannot make 'key' a Keyword, too noisy)
+    ('private_key "hopenobodyfindsthisone\';', None),  # Double-quote does not match single-quote)
+]
 
-QUOTES_REQUIRED_FILE_EXTENSIONS = (
-    '.cls',
-    '.java',
-    '.js',
-    '.py',
-    '.swift',
+OBJECTIVE_C_TEST_CASES = [
+    ('apikey = "{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('password = @"{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('secrete[] = "{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('secrete = "{}"'.format(LETTER_SECRET), LETTER_SECRET),    # All symbols are allowed
+    ('password = "{}"'.format(SYMBOL_SECRET), None),  # At least 1 alphanumeric char is required
+    ("api_key = '{}';".format(COMMON_SECRET), None),                 # Double quotes required
+    ("aws_secret_access_key = @'{}';".format(COMMON_SECRET), None),  # Double quotes required
+    ("db_pass[] = '{}';".format(COMMON_SECRET), None),  # Double quotes required
+    ('passwd = {};'.format(COMMON_SECRET), None),       # Double quotes required
+    ('private_key = {};'.format(COMMON_SECRET), None),  # Double quotes required
+    ('secret[] = {};'.format(COMMON_SECRET), None),     # Double quotes required
+    ('api_key = ""', None),                 # Nothing in the quotes
+    ('password = "somefakekey"', None),     # 'fake' in the secret
+    ('password[] = ${link}', None),         # Has a ${ followed by a }
+    ('some_key = "real_secret"', None),     # We cannot make 'key' a Keyword, too noisy)
+]
+
+QUOTES_REQUIRED_TEST_CASES = [
+    ('apikey: "{}"'.format(COMMON_SECRET), COMMON_SECRET),
+    ('api_key: `{}`'.format(COMMON_SECRET), COMMON_SECRET),
+    ("aws_secret_access_key: '{}'".format(COMMON_SECRET), COMMON_SECRET),
+    ("db_pass: '{}'".format(LETTER_SECRET), LETTER_SECRET),  # All symbols are allowed
+    ("password: '{}'".format(SYMBOL_SECRET), None),  # At least 1 alphanumeric character is required
+    ('if ("{}" == passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" != secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" !== password) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('secrete = "{}"'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (apikey == "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (api_key === "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (aws_secret_access_key != "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if (db_pass !== "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('password "{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('password = {}'.format(COMMON_SECRET), None),  # Secret without quotes
+    ('api_key = ""', None),              # Nothing in the quotes
+    ("secret: ''", None),                # Nothing in the quotes
+    ('password = "somefakekey"', None),  # 'fake' in the secret
+    ('password: ${link}', None),         # Has a ${ followed by a }
+    ('some_key = "real_secret"', None),  # We cannot make 'key' a Keyword, too noisy)
+    ('private_key "hopenobodyfindsthisone\';', None),  # Double-quote does not match single-quote)
+]
+
+
+def parse_test_cases(test_cases):
+    for file_extension, test_case in test_cases:
+        for item in test_case:
+            line, expected_secret = item
+            yield file_extension, line, expected_secret
+
+
+@pytest.mark.parametrize(
+    'file_extension, line, expected_secret',
+    (
+        parse_test_cases([
+            (None, GENERIC_TEST_CASES),
+            ('go', GOLANG_TEST_CASES),
+            ('m', OBJECTIVE_C_TEST_CASES),
+            ('cls', QUOTES_REQUIRED_TEST_CASES),
+            ('java', QUOTES_REQUIRED_TEST_CASES),
+            ('py', QUOTES_REQUIRED_TEST_CASES),
+            ('pyi', QUOTES_REQUIRED_TEST_CASES),
+            ('js', QUOTES_REQUIRED_TEST_CASES),
+            ('swift', QUOTES_REQUIRED_TEST_CASES),
+            ('tf', QUOTES_REQUIRED_TEST_CASES),
+        ])
+    ),
 )
-
-STANDARD_POSITIVES = []
-STANDARD_POSITIVES.extend(
-    FOLLOWED_BY_COLON_RE.get('positives').get('quotes_required')
-    + FOLLOWED_BY_COLON_RE.get('positives').get('quotes_not_required')
-    + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_required')
-    + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_not_required')
-    + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get('positives').get('quotes_required')
-    + FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required')   # noqa: E501
-    + PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required'),  # noqa: E501
-)
-
-
-class TestKeywordDetector:
-
-    @pytest.mark.parametrize(
-        'file_content',
-        STANDARD_POSITIVES,
-    )
-    def test_analyze_standard_positives(self, file_content):
-        secrets = list(KeywordDetector().analyze_string(file_content))
-
-        assert len(secrets) == 1
-        assert secrets[0] == 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
-
-    @pytest.mark.parametrize(
-        'file_content, file_extension',
-        (
-            (positive, file_extension)
-            for positive in (
-                FOLLOWED_BY_COLON_RE.get('positives').get('quotes_required')
-                + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_required')
-                + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get('positives').get('quotes_required')
-            ) for file_extension in QUOTES_REQUIRED_FILE_EXTENSIONS
-        ),
-    )
-    def test_analyze_quotes_required_positives(self, file_content, file_extension):
-        secrets = KeywordDetector().analyze_line(
-            filename='mock_filename{}'.format(file_extension),
-            line=file_content,
+def test_keyword(file_extension, line, expected_secret):
+    if not file_extension:
+        secrets = list(scan_line(line))
+    else:
+        secrets = list(
+            KeywordDetector(keyword_exclude='.*fake.*').analyze_line(
+                filename='mock_filename.{}'.format(file_extension),
+                line=line,
+            ),
         )
+    if expected_secret:
+        assert secrets[0].secret_value == expected_secret
+    else:
+        assert not secrets
 
-        assert len(secrets) == 1
-        assert list(secrets)[0].secret_value == 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
 
-    @pytest.mark.parametrize(
-        'file_content',
-        FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_required')
-        + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_not_required')
-        + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get('positives').get('quotes_required')
-        + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get('positives').get('quotes_required')
-        + FOLLOWED_BY_COLON_EQUAL_SIGNS_RE.get('positives').get('quotes_not_required'),
-    )
-    def test_analyze_go_positives(self, file_content):
-        secrets = KeywordDetector().analyze_line(filename='mock_filename.go', line=file_content)
-
-        assert len(secrets) == 1
-        assert list(secrets)[0].secret_value == 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
-
-    @pytest.mark.parametrize(
-        'file_content',
-        FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX.get(
-            'positives',
-        ).get('quotes_required'),
-    )
-    def test_analyze_objective_c_positives(self, file_content):
-        secrets = KeywordDetector().analyze_line(filename='mock_filename.m', line=file_content)
-
-        assert len(secrets) == 1
-        assert list(secrets)[0].secret_value == 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
-
-    @staticmethod
-    @pytest.mark.parametrize(
-        'line',
-        (
-            'apiKey: this.apiKey,',
-            "apiKey: fs.readFileSync('foo',",
-        ),
-    )
-    def test_analyze_javascript_negatives(line):
-        with transient_settings({
-            'plugins_used': [{
-                'name': 'KeywordDetector',
-            }],
-        }):
-            assert list(scan_line(line))
-
-            with tempfile.NamedTemporaryFile(suffix='.js') as f:
-                f.write(line.encode('utf-8'))
-                f.seek(0)
-
-                assert not list(scan_file(f.name))
-
-    @staticmethod
-    def test_ignore_case():
-        with transient_settings({
-            'plugins_used': [{
-                'name': 'KeywordDetector',
-            }],
-        }):
-            assert list(scan_line('os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"'))
+@pytest.fixture(autouse=True)
+def use_keyword_detector():
+    with transient_settings({
+        'plugins_used': [{
+            'name': 'KeywordDetector',
+        }],
+    }):
+        yield

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -142,6 +142,48 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE = {
     },
 }
 
+FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = {
+    'negatives': {
+        'quotes_required': [
+            'my_password == ""',  # Nothing in the quotes
+            "my_password == ''",  # Nothing in the quotes
+            'my_password == "fakesecret"',  # 'fake' in the secret
+        ],
+    },
+    'positives': {
+        'quotes_required': [
+            'some_dict["secret"] == "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'the_password== "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
+            'the_password==\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
+            'some_dict["secret"] != "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"',
+            'the_password!= "m{{h}o)p${e]nob(ody[finds>-_$#thisone}}"\n',
+            'the_password===\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
+            'the_password!==\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'\n',
+        ],
+    },
+}
+
+PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = {
+    'negatives': {
+        'quotes_required': [
+            '"" == my_password',  # Nothing in the quotes
+            "'' == my_password",  # Nothing in the quotes
+            '"fakesecret" == my_password',  # 'fake' in the secret
+        ],
+    },
+    'positives': {
+        'quotes_required': [
+            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" == some_dict["secret"]',
+            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" == the_password\n',
+            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' == the_password\n',
+            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" != some_dict["secret"]',
+            '"m{{h}o)p${e]nob(ody[finds>-_$#thisone}}" != the_password\n',
+            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\' === the_password\n',
+            '\'m{{h}o)p${e]nob(ody[finds>-_$#thisone}}\'!== the_password\n',
+        ],
+    },
+}
+
 QUOTES_REQUIRED_FILE_EXTENSIONS = (
     '.cls',
     '.java',
@@ -156,7 +198,9 @@ STANDARD_POSITIVES.extend(
     + FOLLOWED_BY_COLON_RE.get('positives').get('quotes_not_required')
     + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_required')
     + FOLLOWED_BY_EQUAL_SIGNS_RE.get('positives').get('quotes_not_required')
-    + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get('positives').get('quotes_required'),
+    + FOLLOWED_BY_QUOTES_AND_SEMICOLON_RE.get('positives').get('quotes_required')
+    + FOLLOWED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required')
+    + PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX.get('positives').get('quotes_required'),
 )
 
 


### PR DESCRIPTION
This Pull Request solves some issues detected in #414 and includes some improvements described in #396 to the latest version of detect-secrets.

This code includes:

- Support to secret detection in comparisons. You can see it in `FOLLOWED_BY_EQUAL_SIGNS_REGEX` and `FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX` regexes. For example: 
```JAVASCRIPT
if (password == "value") {}
else if (password === "value") {}
else if (password != "value") {}
else if (password !== "value") {}
```
- Support to secret detection in reverse comparisons. You can see it in the `PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX` regex. For example:
```JAVASCRIPT
if ("value" == password) {}
else if ("value" === password) {}
else if ("value" != password) {}
else if ("value" !== password) {}
```
- Corrections in the `SECRET` regex to avoid some problems detected in #414 and reduce the false positive percentage. The regex can be decomposed in the following sections:

   -  `[^\r\n]*`: this section match with every character except line breaks. This allows to find secrets that starts with symbols or alphanumeric characters.
   - `[a-zA-Z0-9]+`: this section match only with alphanumeric characters, and at least one is required. This allows to reduce the false positives number.
   - `[^\r\n]*`:  this section match with every character except line breaks. This allows to find secrets with symbols at the end. 
   - `[^\r\n,\'"]`: this section match with the last secret character that can be everything except line breaks, comma or quotes. This allows to reduce the false positives number and to prevent errors in the code snippet highlighting. Next you can see an example:  
<img width="829" alt="last_comma" src="https://user-images.githubusercontent.com/69458381/110000683-dd903c00-7d13-11eb-8ba7-5bd4516597eb.png">
The following image shows a test with this new regex:

<img width="702" alt="regex_example" src="https://user-images.githubusercontent.com/69458381/109998709-ccdec680-7d11-11eb-92bb-f3729d05f471.png">

Of course, `keyword_test.py` has been updated to check all this changes.
 