### PR TITLE
Secret regex bugfix & suffix and prefix support

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -165,6 +165,11 @@ def is_indirect_reference(line: str) -> bool:
 
         secret = request.headers['apikey']
     """
+    return bool(_get_indirect_reference_regex().search(line))
+
+
+@lru_cache(maxsize=1)
+def _get_indirect_reference_regex() -> Pattern:
     # Regex details:
     #   ([^\v=!:]*)     ->  Something before the assignment or comparison
     #   \s*             ->  Some optional whitespaces
@@ -176,8 +181,7 @@ def is_indirect_reference(line: str) -> bool:
     #       [^\v]*      ->  Something except line breaks
     #       [\]\)]      ->  End of indirect reference: ] or )
     #   )
-    regex = re.compile(r'([^\v=!:]*)\s*(:=?|[!=]{1,3})\s*([\w.-]+[\[\(][^\v]*[\]\)])')
-    return bool(regex.search(line))
+    return re.compile(r'([^\v=!:]*)\s*(:=?|[!=]{1,3})\s*([\w.-]+[\[\(][^\v]*[\]\)])')
 
 
 def is_lock_file(filename: str) -> bool:

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -58,23 +58,23 @@ OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
 # Secret regex details:
-#    [^\v\\g<{quote_group}>]*   -> this section match with every character except line breaks
-#                                  and the previous quote if exists. This allows to find 
-#                                  secrets that starts with symbols or alphanumeric characters.
+#    [^\v\g{quote_group}]*  -> this section match with every character except line breaks
+#                              and the previous quote if exists. This allows to find 
+#                              secrets that starts with symbols or alphanumeric characters.
 #
-#    \w+                        -> this section match only with words (letters, numbers or _ 
-#                                  are allowed), and at least one character is required. This 
-#                                  allows to reduce the false positives number.
+#    \w+                    -> this section match only with words (letters, numbers or _ 
+#                              are allowed), and at least one character is required. This 
+#                              allows to reduce the false positives number.
 #
-#    [^\v\\g<{quote_group}>]*   -> this section match with every character except line breaks
-#                                  and the previous quote if exists. This allows to find secrets 
-#                                  with symbols at the end.
+#    [^\v\g{quote_group}]*  -> this section match with every character except line breaks
+#                              and the previous quote if exists. This allows to find secrets 
+#                              with symbols at the end.
 #
-#    [^\v,\'"`]                 -> this section match with the last secret character that can be
-#                                  everything except line breaks, comma, backticks or quotes. This
-#                                  allows to reduce the false positives number and to prevent
-#                                  errors in the code snippet highlighting.
-SECRET = r'[^\v\\g<{quote_group}>]*\w+[^\v\\g<{quote_group}>]*[^\v,\'"`]'
+#    [^\v,\'"`]             -> this section match with the last secret character that can be
+#                              everything except line breaks, comma, backticks or quotes. This
+#                              allows to reduce the false positives number and to prevent
+#                              errors in the code snippet highlighting.
+SECRET = r'[^\v\\g{quote_group}]*\w+[^\v\\g{quote_group}]*[^\v,\'"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
@@ -243,7 +243,6 @@ class KeywordDetector(BasePlugin):
         has_results = False
         for denylist_regex_to_group in attempts:
             for denylist_regex, group_number in denylist_regex_to_group.items():
-                print(str(denylist_regex))
                 match = denylist_regex.search(string)
                 if match:
                     has_results = True

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -59,55 +59,55 @@ DENYLIST_REGEX = r'({denylist}){suffix}'.format(
     denylist=DENYLIST_REGEX,
     suffix=AFFIX_REGEX,
 )
-# Support for preffix and suffix with keyword, needed for reverse comparisons
+# Support for prefix and suffix with keyword, needed for reverse comparisons
 # i.e. if ("value" == my_password_secure) {}
-DENYLIST_REGEX_WITH_PREFFIX = r'{preffix}{denylist}'.format(
-    preffix=AFFIX_REGEX,
+DENYLIST_REGEX_WITH_PREFFIX = r'{prefix}{denylist}'.format(
+    prefix=AFFIX_REGEX,
     denylist=DENYLIST_REGEX,
 )
 # Non-greedy match
 OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
-QUOTE = r'[\'"`]'
+QUOTE = r'?P<quote>[\'"`]'
 # Secret regex details:
-#    [^\v\g{quote_group}]*  -> this section match with every character except line breaks
-#                              and the previous quote if exists. This allows to find
-#                              secrets that starts with symbols or alphanumeric characters.
+#    [^\v(?P=quote)]*  -> this section match with every character except line breaks
+#                         and the previous quote if exists. This allows to find
+#                         secrets that starts with symbols or alphanumeric characters.
 #
-#    \w+                    -> this section match only with words (letters, numbers or _
-#                              are allowed), and at least one character is required. This
-#                              allows to reduce the false positives number.
+#    \w+               -> this section match only with words (letters, numbers or _
+#                         are allowed), and at least one character is required. This
+#                         allows to reduce the false positives number.
 #
-#    [^\v\g{quote_group}]*  -> this section match with every character except line breaks
-#                              and the previous quote if exists. This allows to find secrets
-#                              with symbols at the end.
+#    [^\v(?P=quote)]*  -> this section match with every character except line breaks
+#                         and the previous quote if exists. This allows to find secrets
+#                         with symbols at the end.
 #
-#    [^\v,\'"`]             -> this section match with the last secret character that can be
-#                              everything except line breaks, comma, backticks or quotes. This
-#                              allows to reduce the false positives number and to prevent
-#                              errors in the code snippet highlighting.
-SECRET = r'[^\v\\g{quote_group}]*\w+[^\v\\g{quote_group}]*[^\v,\'"`]'
+#    [^\v,\'"`]        -> this section match with the last secret character that can be
+#                         everything except line breaks, comma, backticks or quotes. This
+#                         allows to reduce the false positives number and to prevent
+#                         errors in the code snippet highlighting.
+SECRET = r'[^\v(?P=quote)]*\w+[^\v(?P=quote)]*[^\v,\'"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password := "bar" or my_password := bar
-    r'{denylist}({closing})?{whitespace}:=?{whitespace}({quote}?)({secret})(\3)'.format(
+    r'{denylist}({closing})?{whitespace}:=?{whitespace}({quote})?({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=3),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )
 FOLLOWED_BY_COLON_REGEX = re.compile(
     # e.g. api_key: foo
-    r'{denylist}({closing})?:{whitespace}({quote}?)({secret})(\3)'.format(
+    r'{denylist}({closing})?:{whitespace}({quote})?({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=3),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )
@@ -118,7 +118,7 @@ FOLLOWED_BY_COLON_QUOTES_REQUIRED_REGEX = re.compile(
         closing=CLOSING,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=4),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )
@@ -130,7 +130,7 @@ FOLLOWED_BY_EQUAL_SIGNS_OPTIONAL_BRACKETS_OPTIONAL_AT_SIGN_QUOTES_REQUIRED_REGEX
         denylist=DENYLIST_REGEX,
         square_brackets=SQUARE_BRACKETS,
         optional_whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=5),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )
@@ -140,12 +140,12 @@ FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
     # or my_password !== "bar"
     # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
     # or my_password !== 'bar'
-    r'{denylist}({closing})?{whitespace}(={{1,3}}|!==?){whitespace}({quote}?)({secret})(\4)'.format(  # noqa: E501
+    r'{denylist}({closing})?{whitespace}(={{1,3}}|!==?){whitespace}({quote})?({secret})(\4)'.format(  # noqa: E501
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=4),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )
@@ -160,7 +160,7 @@ FOLLOWED_BY_EQUAL_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
         closing=CLOSING,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=4),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )
@@ -174,7 +174,7 @@ PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
         denylist=DENYLIST_REGEX_WITH_PREFFIX,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=1),
+        secret=SECRET,
     ),
 )
 
@@ -185,7 +185,7 @@ FOLLOWED_BY_QUOTES_AND_SEMICOLON_REGEX = re.compile(
         nonWhitespace=OPTIONAL_NON_WHITESPACE,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
-        secret=SECRET.format(quote_group=2),
+        secret=SECRET,
     ),
     flags=re.IGNORECASE,
 )

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -68,30 +68,30 @@ DENYLIST_REGEX_WITH_PREFFIX = r'{prefix}{denylist}'.format(
 # Non-greedy match
 OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
-QUOTE = r'?P<quote>[\'"`]'
+QUOTE = r'[\'"`]'
 # Secret regex details:
-#    [^\v(?P=quote)]*  -> this section match with every character except line breaks
-#                         and the previous quote if exists. This allows to find
-#                         secrets that starts with symbols or alphanumeric characters.
+#    [^\v\'"]*      -> this section match with every character except line breaks
+#                      and the previous quote if exists. This allows to find
+#                      secrets that starts with symbols or alphanumeric characters.
 #
-#    \w+               -> this section match only with words (letters, numbers or _
-#                         are allowed), and at least one character is required. This
-#                         allows to reduce the false positives number.
+#    \w+            -> this section match only with words (letters, numbers or _
+#                      are allowed), and at least one character is required. This
+#                      allows to reduce the false positives number.
 #
-#    [^\v(?P=quote)]*  -> this section match with every character except line breaks
-#                         and the previous quote if exists. This allows to find secrets
-#                         with symbols at the end.
+#    [^\v\'"]*      -> this section match with every character except line breaks
+#                      and the previous quote if exists. This allows to find secrets
+#                      with symbols at the end.
 #
-#    [^\v,\'"`]        -> this section match with the last secret character that can be
-#                         everything except line breaks, comma, backticks or quotes. This
-#                         allows to reduce the false positives number and to prevent
-#                         errors in the code snippet highlighting.
-SECRET = r'[^\v(?P=quote)]*\w+[^\v(?P=quote)]*[^\v,\'"`]'
+#    [^\v,\'"`]     -> this section match with the last secret character that can be
+#                      everything except line breaks, comma, backticks or quotes. This
+#                      allows to reduce the false positives number and to prevent
+#                      errors in the code snippet highlighting.
+SECRET = r'[^\v\'"]*\w+[^\v\'"]*[^\v,\'"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password := "bar" or my_password := bar
-    r'{denylist}({closing})?{whitespace}:=?{whitespace}({quote})?({secret})(\3)'.format(
+    r'{denylist}({closing})?{whitespace}:=?{whitespace}({quote}?)({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -102,7 +102,7 @@ FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
 )
 FOLLOWED_BY_COLON_REGEX = re.compile(
     # e.g. api_key: foo
-    r'{denylist}({closing})?:{whitespace}({quote})?({secret})(\3)'.format(
+    r'{denylist}({closing})?:{whitespace}({quote}?)({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,
@@ -140,7 +140,7 @@ FOLLOWED_BY_EQUAL_SIGNS_REGEX = re.compile(
     # or my_password !== "bar"
     # e.g. my_password == 'bar' or my_password != 'bar' or my_password === 'bar'
     # or my_password !== 'bar'
-    r'{denylist}({closing})?{whitespace}(={{1,3}}|!==?){whitespace}({quote})?({secret})(\4)'.format(  # noqa: E501
+    r'{denylist}({closing})?{whitespace}(={{1,3}}|!==?){whitespace}({quote}?)({secret})(\4)'.format(  # noqa: E501
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -70,22 +70,28 @@ OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
 # Secret regex details:
-#   [^\v\'"]*      ->  this section match with every character except line breaks
-#                      and quotes. This allows to find secrets that starts with
-#                      symbols or alphanumeric characters.
+#   [^\v\'"]*   ->  this section match with every character except line breaks and quotes. This
+#                   allows to find secrets that starts with
+#                   symbols or alphanumeric characters.
 #
-#   \w+            ->  this section match only with words (letters, numbers or _
-#                      are allowed), and at least one character is required. This
-#                      allows to reduce the false positives number.
+#   \w+         ->  this section match only with words (letters, numbers or _ are allowed), and at
+#                   least one character is required. This allows to reduce the false positives 
+#                   number.
 #
-#   [^\v\'"]*      ->  this section match with every character except line breaks
-#                      and quotes. This allows to find secrets with symbols at the end.
+#   [^\v\'"]*   ->  this section match with every character except line breaks and quotes. This 
+#                   allows to find secrets with symbols at the end.
 #
-#   [^\v,\'"`]     ->  this section match with the last secret character that can be
-#                      everything except line breaks, comma, backticks or quotes. This
-#                      allows to reduce the false positives number and to prevent
-#                      errors in the code snippet highlighting.
-SECRET = r'[^\v\'\"]*\w+[^\v\'\"]*([\[(][\'\"]?\w+[\'\"]?[\])]?)?[^\v,\'\"`]'
+#  ([\[\(][\'\"]?\w+[\'\"]?[\]\)]?)?  ->  this section allow the presence of quotes in cases like:
+#                                           secret = get_secret_key() 
+#                                               or
+#                                           secret = request.headers['apikey']
+#                                       This cases should be managed as secrets because they will 
+#                                       be filtered by is is_indirect_reference
+#
+#   [^\v,\'"`]  ->  this section match with the last secret character that can be everything except
+#                   line breaks, comma, backticks or quotes. This allows to reduce the false 
+#                   positives number and to prevent errors in the code snippet highlighting.
+SECRET = r'[^\v\'\"]*\w+[^\v\'\"]*([\[\(][\'\"]?\w+[\'\"]?[\]\)]?)?[^\v,\'\"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -80,17 +80,10 @@ QUOTE = r'[\'"`]'
 #   [^\v\'"]*   ->  this section match with every character except line breaks and quotes. This
 #                   allows to find secrets with symbols at the end.
 #
-#  ([\[\(][\'\"]?\w+[\'\"]?[\]\)]?)?  ->  this section allow the presence of quotes in cases like:
-#                                           secret = get_secret_key()
-#                                               or
-#                                           secret = request.headers['apikey']
-#                                       This cases should be managed as secrets because they will
-#                                       be filtered by is is_indirect_reference
-#
 #   [^\v,\'"`]  ->  this section match with the last secret character that can be everything except
 #                   line breaks, comma, backticks or quotes. This allows to reduce the false
 #                   positives number and to prevent errors in the code snippet highlighting.
-SECRET = r'[^\v\'\"]*\w+[^\v\'\"]*([\[\(][\'\"]?\w+[\'\"]?[\]\)]?)?[^\v,\'\"`]'
+SECRET = r'[^\v\'\"]*\w+[^\v\'\"]*[^\v,\'\"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -61,7 +61,7 @@ DENYLIST_REGEX = r'({denylist}){suffix}'.format(
 )
 # Support for prefix and suffix with keyword, needed for reverse comparisons
 # i.e. if ("value" == my_password_secure) {}
-DENYLIST_REGEX_WITH_PREFFIX = r'{prefix}{denylist}'.format(
+DENYLIST_REGEX_WITH_PREFIX = r'{prefix}{denylist}'.format(
     prefix=AFFIX_REGEX,
     denylist=DENYLIST_REGEX,
 )
@@ -70,22 +70,22 @@ OPTIONAL_WHITESPACE = r'\s*'
 OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
 # Secret regex details:
-#    [^\v\'"]*      -> this section match with every character except line breaks
-#                      and quotes. This allows to find secrets that starts with 
+#   [^\v\'"]*      ->  this section match with every character except line breaks
+#                      and quotes. This allows to find secrets that starts with
 #                      symbols or alphanumeric characters.
 #
-#    \w+            -> this section match only with words (letters, numbers or _
+#   \w+            ->  this section match only with words (letters, numbers or _
 #                      are allowed), and at least one character is required. This
 #                      allows to reduce the false positives number.
 #
-#    [^\v\'"]*      -> this section match with every character except line breaks
+#   [^\v\'"]*      ->  this section match with every character except line breaks
 #                      and quotes. This allows to find secrets with symbols at the end.
 #
-#    [^\v,\'"`]     -> this section match with the last secret character that can be
+#   [^\v,\'"`]     ->  this section match with the last secret character that can be
 #                      everything except line breaks, comma, backticks or quotes. This
 #                      allows to reduce the false positives number and to prevent
 #                      errors in the code snippet highlighting.
-SECRET = r'[^\v\'"]*\w+[^\v\'"]*[^\v,\'"`]'
+SECRET = r'[^\v\'\"]*\w+[^\v\'\"]*([\[(][\'\"]?\w+[\'\"]?[\])]?)?[^\v,\'\"`]'
 SQUARE_BRACKETS = r'(\[\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
@@ -170,7 +170,7 @@ PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX = re.compile(
     # e.g. 'bar' == my_password or 'bar' != my_password or 'bar' === my_password
     # or 'bar' !== my_password
     r'({quote})({secret})(\1){whitespace}[!=]{{2,3}}{whitespace}{denylist}'.format(
-        denylist=DENYLIST_REGEX_WITH_PREFFIX,
+        denylist=DENYLIST_REGEX_WITH_PREFIX,
         quote=QUOTE,
         whitespace=OPTIONAL_WHITESPACE,
         secret=SECRET,

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -71,25 +71,24 @@ OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
 # Secret regex details:
 #   [^\v\'"]*   ->  this section match with every character except line breaks and quotes. This
-#                   allows to find secrets that starts with
-#                   symbols or alphanumeric characters.
+#                   allows to find secrets that starts with symbols or alphanumeric characters.
 #
 #   \w+         ->  this section match only with words (letters, numbers or _ are allowed), and at
-#                   least one character is required. This allows to reduce the false positives 
+#                   least one character is required. This allows to reduce the false positives
 #                   number.
 #
-#   [^\v\'"]*   ->  this section match with every character except line breaks and quotes. This 
+#   [^\v\'"]*   ->  this section match with every character except line breaks and quotes. This
 #                   allows to find secrets with symbols at the end.
 #
 #  ([\[\(][\'\"]?\w+[\'\"]?[\]\)]?)?  ->  this section allow the presence of quotes in cases like:
-#                                           secret = get_secret_key() 
+#                                           secret = get_secret_key()
 #                                               or
 #                                           secret = request.headers['apikey']
-#                                       This cases should be managed as secrets because they will 
+#                                       This cases should be managed as secrets because they will
 #                                       be filtered by is is_indirect_reference
 #
 #   [^\v,\'"`]  ->  this section match with the last secret character that can be everything except
-#                   line breaks, comma, backticks or quotes. This allows to reduce the false 
+#                   line breaks, comma, backticks or quotes. This allows to reduce the false
 #                   positives number and to prevent errors in the code snippet highlighting.
 SECRET = r'[^\v\'\"]*\w+[^\v\'\"]*([\[\(][\'\"]?\w+[\'\"]?[\]\)]?)?[^\v,\'\"`]'
 SQUARE_BRACKETS = r'(\[\])'

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -71,16 +71,15 @@ OPTIONAL_NON_WHITESPACE = r'[^\s]{0,50}?'
 QUOTE = r'[\'"`]'
 # Secret regex details:
 #    [^\v\'"]*      -> this section match with every character except line breaks
-#                      and the previous quote if exists. This allows to find
-#                      secrets that starts with symbols or alphanumeric characters.
+#                      and quotes. This allows to find secrets that starts with 
+#                      symbols or alphanumeric characters.
 #
 #    \w+            -> this section match only with words (letters, numbers or _
 #                      are allowed), and at least one character is required. This
 #                      allows to reduce the false positives number.
 #
 #    [^\v\'"]*      -> this section match with every character except line breaks
-#                      and the previous quote if exists. This allows to find secrets
-#                      with symbols at the end.
+#                      and quotes. This allows to find secrets with symbols at the end.
 #
 #    [^\v,\'"`]     -> this section match with the last secret character that can be
 #                      everything except line breaks, comma, backticks or quotes. This

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -112,21 +112,13 @@ def test_is_prefixed_with_dollar_sign():
 @pytest.mark.parametrize(
     'line, result',
     (
-        ('secret = get_secret_key()', False),
-        ('secret = request.headers["apikey"]', False),
-        ('secret = hunter2', True),
+        ('secret = get_secret_key()', True),
+        ('secret = request.headers["apikey"]', True),
+        ('secret = hunter2', False),
     ),
 )
 def test_is_indirect_reference(line, result):
-    with transient_settings({
-        'plugins_used': [{
-            'name': 'KeywordDetector',
-        }],
-        'filters_used': [{
-            'path': 'detect_secrets.filters.heuristic.is_indirect_reference',
-        }],
-    }):
-        assert bool(list(scan_line(line))) is result
+    assert filters.heuristic.is_indirect_reference(line) is result
 
 
 def test_is_lock_file():

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -27,7 +27,7 @@ GENERIC_TEST_CASES = [
     ('if (aws_secret_access_key === "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if (db_pass !== "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" == password) {{'.format(COMMON_SECRET), COMMON_SECRET),
-    ('if ("{}" == my_super_password) {{'.format(COMMON_SECRET), COMMON_SECRET),     # Preffix
+    ('if ("{}" == my_super_password) {{'.format(COMMON_SECRET), COMMON_SECRET),     # Prefix
     ('if ("{}" != passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" !== secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
@@ -55,7 +55,7 @@ GOLANG_TEST_CASES = [
     ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" != secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" !== password) {{'.format(COMMON_SECRET), COMMON_SECRET),
-    ('if ("{}" !== my_password_sec) {{'.format(COMMON_SECRET), COMMON_SECRET),    # Preffix/suffix
+    ('if ("{}" !== my_password_sec) {{'.format(COMMON_SECRET), COMMON_SECRET),    # Prefix/suffix
     ('apikey = "{}"'.format(COMMON_SECRET), COMMON_SECRET),
     ("api_key = '{}'".format(COMMON_SECRET), COMMON_SECRET),
     ('aws_secret_access_key = `{}`'.format(COMMON_SECRET), COMMON_SECRET),
@@ -82,7 +82,7 @@ GOLANG_TEST_CASES = [
 OBJECTIVE_C_TEST_CASES = [
     ('apikey = "{}";'.format(COMMON_SECRET), COMMON_SECRET),
     ('password = @"{}";'.format(COMMON_SECRET), COMMON_SECRET),
-    ('my_password_secure = @"{}";'.format(COMMON_SECRET), COMMON_SECRET),   # Preffix/suffix
+    ('my_password_secure = @"{}";'.format(COMMON_SECRET), COMMON_SECRET),   # Prefix/suffix
     ('secrete[] = "{}";'.format(COMMON_SECRET), COMMON_SECRET),
     ('secrete = "{}"'.format(LETTER_SECRET), LETTER_SECRET),    # All symbols are allowed
     ('password = "{}"'.format(SYMBOL_SECRET), None),  # At least 1 alphanumeric char is required
@@ -107,7 +107,7 @@ QUOTES_REQUIRED_TEST_CASES = [
     ("password: '{}'".format(SYMBOL_SECRET), None),  # At least 1 alphanumeric character is required
     ('if ("{}" == passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
-    ('if ("{}" === my_private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),   # Preffix
+    ('if ("{}" === my_private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),   # Prefix
     ('if ("{}" != secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" !== password) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('secrete = "{}"'.format(COMMON_SECRET), COMMON_SECRET),

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -7,8 +7,8 @@ from detect_secrets.settings import transient_settings
 
 COMMON_SECRET = 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
 WHITES_SECRET = 'value with quotes and spaces'
-LETTER_SECRET = 'A,.:-¨Ç*¿?!'
-SYMBOL_SECRET = ',.:-¨Ç*¿?!'
+LETTER_SECRET = 'A,.:-¨@*¿?!'
+SYMBOL_SECRET = ',.:-¨@*¿?!'
 
 GENERIC_TEST_CASES = [
     ('password = "{}"'.format(WHITES_SECRET), WHITES_SECRET),

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -12,6 +12,8 @@ SYMBOL_SECRET = ',.:-¨@*¿?!'
 
 GENERIC_TEST_CASES = [
     ('password = "{}"'.format(WHITES_SECRET), WHITES_SECRET),
+    ('password_super_secure = "{}"'.format(WHITES_SECRET), WHITES_SECRET),  # Suffix
+    ('my_password_super_secure = "{}"'.format(WHITES_SECRET), WHITES_SECRET),  # Prefix/suffix
     ('apikey = {}'.format(COMMON_SECRET), COMMON_SECRET),
     ("api_key: '{}'".format(WHITES_SECRET), WHITES_SECRET),
     ('aws_secret_access_key: {}'.format(WHITES_SECRET), WHITES_SECRET),
@@ -25,6 +27,7 @@ GENERIC_TEST_CASES = [
     ('if (aws_secret_access_key === "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if (db_pass !== "{}") {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" == password) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" == my_super_password) {{'.format(COMMON_SECRET), COMMON_SECRET),     # Preffix
     ('if ("{}" != passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" !== secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
@@ -43,6 +46,7 @@ GOLANG_TEST_CASES = [
     ("api_key := '{}'".format(COMMON_SECRET), COMMON_SECRET),
     ('aws_secret_access_key := `{}`'.format(COMMON_SECRET), COMMON_SECRET),
     ('db_pass := {}'.format(COMMON_SECRET), COMMON_SECRET),
+    ('db_pass_secure := {}'.format(COMMON_SECRET), COMMON_SECRET),  # Suffix
     ('passwd := {},'.format(COMMON_SECRET), COMMON_SECRET),         # Last character is ignored
     ("private_key := {}'".format(COMMON_SECRET), COMMON_SECRET),    # Last character is ignored
     ('secret := {}"'.format(COMMON_SECRET), COMMON_SECRET),         # Last character is ignored
@@ -51,6 +55,7 @@ GOLANG_TEST_CASES = [
     ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" != secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" !== password) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" !== my_password_sec) {{'.format(COMMON_SECRET), COMMON_SECRET),    # Preffix/suffix
     ('apikey = "{}"'.format(COMMON_SECRET), COMMON_SECRET),
     ("api_key = '{}'".format(COMMON_SECRET), COMMON_SECRET),
     ('aws_secret_access_key = `{}`'.format(COMMON_SECRET), COMMON_SECRET),
@@ -77,6 +82,7 @@ GOLANG_TEST_CASES = [
 OBJECTIVE_C_TEST_CASES = [
     ('apikey = "{}";'.format(COMMON_SECRET), COMMON_SECRET),
     ('password = @"{}";'.format(COMMON_SECRET), COMMON_SECRET),
+    ('my_password_secure = @"{}";'.format(COMMON_SECRET), COMMON_SECRET),   # Preffix/suffix
     ('secrete[] = "{}";'.format(COMMON_SECRET), COMMON_SECRET),
     ('secrete = "{}"'.format(LETTER_SECRET), LETTER_SECRET),    # All symbols are allowed
     ('password = "{}"'.format(SYMBOL_SECRET), None),  # At least 1 alphanumeric char is required
@@ -94,12 +100,14 @@ OBJECTIVE_C_TEST_CASES = [
 
 QUOTES_REQUIRED_TEST_CASES = [
     ('apikey: "{}"'.format(COMMON_SECRET), COMMON_SECRET),
+    ('apikey_myservice: "{}"'.format(COMMON_SECRET), COMMON_SECRET),    # Suffix
     ('api_key: `{}`'.format(COMMON_SECRET), COMMON_SECRET),
     ("aws_secret_access_key: '{}'".format(COMMON_SECRET), COMMON_SECRET),
     ("db_pass: '{}'".format(LETTER_SECRET), LETTER_SECRET),  # All symbols are allowed
     ("password: '{}'".format(SYMBOL_SECRET), None),  # At least 1 alphanumeric character is required
     ('if ("{}" == passwd) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" === private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),
+    ('if ("{}" === my_private_key) {{'.format(COMMON_SECRET), COMMON_SECRET),   # Preffix
     ('if ("{}" != secret) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('if ("{}" !== password) {{'.format(COMMON_SECRET), COMMON_SECRET),
     ('secrete = "{}"'.format(COMMON_SECRET), COMMON_SECRET),


### PR DESCRIPTION
## Secret regex bugfix

The performance bug described by @domanchi in #418 has been fixed. The bug happens when the PRECEDED_BY_EQUAL_COMPARISON_SIGNS_QUOTES_REQUIRED_REGEX regex is checked in files with long lines that includes many quotes. The regex engine must check a lot of combinations to determine the line section that matches the secret regex. To solve this issue the quote before the secret (if it exists) has been excluded in the secret regex, improving the regex engine performance.

The secret regex has been replaced by **[^\v\\g{quote_group}]*\w+[^\v\\g{quote_group}]*[^\v,\'"`]**. The main changes in the regex are the following:

- Replace of `\r\n` by `\v` because they are equivalent. This change simplifies the regex.
- Exclusion of `\g{quote_group}` in all the regexes. `quote_group` is the regex group number of the quote before the secret value (if it exists) and it is configured in each specific regex. This change prevents the bug to occur and reduce the false positives number.
- Replace of `[a-zA-Z0-9]+` by `\w+`because they are equivalent. This change simplifies the regex.

Next you can see the result of the time command:

<img width="455" alt="time" src="https://user-images.githubusercontent.com/69458381/110341262-71bb1580-802a-11eb-8fa7-b05685e58e8d.PNG">

## Suffix and prefix support

The original plugin KeywordDetector doesn't detect secrets in lines like:

```JAVA
String my_password_secure = "value"

if ("value" == my_password_secure) {
```

This problem happens because the plugin searches for variable names that ends in any keyword, but it doesn't take into account variable names that contains keywords in the middle. So we add the following lines to allow the presence of words arround the keywords:

```PYTHON
AFFIX_REGEX = r'\w*'
DENYLIST_REGEX = r'|'.join(DENYLIST)
# Support for suffix after keyword i.e. password_secure = "value"
DENYLIST_REGEX = r'({denylist}){suffix}'.format(
    denylist=DENYLIST_REGEX,
    suffix=AFFIX_REGEX,
)
# Support for prefix and suffix with keyword, needed for reverse comparisons
# i.e. if ("value" == my_password_secure) {}
DENYLIST_REGEX_WITH_PREFIX = r'{prefix}{denylist}'.format(
    prefix=AFFIX_REGEX,
    denylist=DENYLIST_REGEX,
)
```

We add new test cases with suffix and prefix. Thank you!