### PR TITLE
Filter of i18n files

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -202,7 +202,7 @@ def is_i18n_file(filename: str) -> bool:
             r'.*i18n{sep}.*',
             r'.*translations{sep}.*',
             r'.*locale{sep}.*',
-            r'.*{sep}((m|M)essages|storetext)(_[a-z]{{2}}(_[A-Z]{{2}})?)?\.(properties|yml|yaml|json)',
+            r'.*{sep}((m|M)essages|storetext)(_[a-z]{{2}}(_[A-Z]{{2}})?)?\.(properties|yml|yaml|json)',  # noqa: E501
             r'.*english{sep}.*',
             r'italian{sep}.*',
             r'italiano{sep}.*',

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -192,41 +192,37 @@ def is_lock_file(filename: str) -> bool:
         'yarn.lock',
     }
 
-INTERNATIONALIZATION_LANGUAGES = [
-    r'.*english{}.*'.format(os.path.sep),
-    r'italian{}.*'.format(os.path.sep),
-    r'italiano{}.*'.format(os.path.sep),
-    r'spanish{}.*'.format(os.path.sep),
-    r'español{}.*'.format(os.path.sep),
-    r'espanol{}.*'.format(os.path.sep),
-    r'french{}.*'.format(os.path.sep),
-    r'français{}.*'.format(os.path.sep),
-    r'portuguese{}.*'.format(os.path.sep),
-    r'português{}.*'.format(os.path.sep),
-    r'deutsch{}.*'.format(os.path.sep),
-    r'deutsche{}.*'.format(os.path.sep),
-    r'chinese{}.*'.format(os.path.sep),
-    r'japanese{}.*'.format(os.path.sep),
-    r'polski{}.*'.format(os.path.sep),
-    r'turkish{}.*'.format(os.path.sep),
-    r'hindi{}.*'.format(os.path.sep),
-    r'arabic{}.*'.format(os.path.sep),
-    r'russian{}.*'.format(os.path.sep),
-]
 
-def is_internationalization_file(filename: str) -> bool:
+def is_i18n_file(filename: str) -> bool:
     """
-    Filters files if they have internationalization text
+    Filters files related to internationalization messages
     """
-
-    regexes = [ re.compile(r) for r in [
-            r'.*i18n{}.*'.format(os.path.sep),
-            r'.*translations{}.*'.format(os.path.sep),
-            r'.*locale{}.*'.format(os.path.sep),
-            r'.*{}((m|M)essages|storetext)(_[a-z]{2}(_[A-Z]{2})?)?\.(properties|yml|yaml|json)'.format(os.path.sep),
+    regexes = [ re.compile(r.format(sep=os.path.sep)) for r in [
+            r'.*i18n{sep}.*',
+            r'.*translations{sep}.*',
+            r'.*locale{sep}.*',
+            r'.*{sep}((m|M)essages|storetext)(_[a-z]{{2}}(_[A-Z]{{2}})?)?\.(properties|yml|yaml|json)',
+            r'.*english{sep}.*',
+            r'italian{sep}.*',
+            r'italiano{sep}.*',
+            r'spanish{sep}.*',
+            r'español{sep}.*',
+            r'espanol{sep}.*',
+            r'french{sep}.*',
+            r'français{sep}.*',
+            r'portuguese{sep}.*',
+            r'português{sep}.*',
+            r'deutsch{sep}.*',
+            r'deutsche{sep}.*',
+            r'chinese{sep}.*',
+            r'japanese{sep}.*',
+            r'polski{sep}.*',
+            r'turkish{sep}.*',
+            r'hindi{sep}.*',
+            r'arabic{sep}.*',
+            r'russian{sep}.*',
         ]
     ]
-    regexes = regexes + INTERNATIONALIZATION_LANGUAGES
     for regex in regexes:
         if regex.search(filename):
             return True

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -191,3 +191,44 @@ def is_lock_file(filename: str) -> bool:
         'Podfile.lock',
         'yarn.lock',
     }
+
+INTERNATIONALIZATION_LANGUAGES = [
+    r'.*english{}.*'.format(os.path.sep),
+    r'italian{}.*'.format(os.path.sep),
+    r'italiano{}.*'.format(os.path.sep),
+    r'spanish{}.*'.format(os.path.sep),
+    r'español{}.*'.format(os.path.sep),
+    r'espanol{}.*'.format(os.path.sep),
+    r'french{}.*'.format(os.path.sep),
+    r'français{}.*'.format(os.path.sep),
+    r'portuguese{}.*'.format(os.path.sep),
+    r'português{}.*'.format(os.path.sep),
+    r'deutsch{}.*'.format(os.path.sep),
+    r'deutsche{}.*'.format(os.path.sep),
+    r'chinese{}.*'.format(os.path.sep),
+    r'japanese{}.*'.format(os.path.sep),
+    r'polski{}.*'.format(os.path.sep),
+    r'turkish{}.*'.format(os.path.sep),
+    r'hindi{}.*'.format(os.path.sep),
+    r'arabic{}.*'.format(os.path.sep),
+    r'russian{}.*'.format(os.path.sep),
+]
+
+def is_internationalization_file(filename: str) -> bool:
+    """
+    Filters files if they have internationalization text
+    """
+
+    regexes = [ re.compile(r) for r in [
+            r'.*i18n{}.*'.format(os.path.sep),
+            r'.*translations{}.*'.format(os.path.sep),
+            r'.*locale{}.*'.format(os.path.sep),
+            r'.*{}((m|M)essages|storetext)(_[a-z]{2}(_[A-Z]{2})?)?\.(properties|yml|yaml|json)'.format(os.path.sep),
+        ]
+    ]
+    regexes = regexes + INTERNATIONALIZATION_LANGUAGES
+    for regex in regexes:
+        if regex.search(filename):
+            return True
+    
+    return False

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -197,7 +197,8 @@ def is_i18n_file(filename: str) -> bool:
     """
     Filters files related to internationalization messages
     """
-    regexes = [ re.compile(r.format(sep=os.path.sep)) for r in [
+    regexes = [
+        re.compile(r.format(sep=os.path.sep)) for r in [
             r'.*i18n{sep}.*',
             r'.*translations{sep}.*',
             r'.*locale{sep}.*',
@@ -226,5 +227,5 @@ def is_i18n_file(filename: str) -> bool:
     for regex in regexes:
         if regex.search(filename):
             return True
-    
+
     return False

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -119,7 +119,7 @@ class Settings:
                 'detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign',
                 'detect_secrets.filters.heuristic.is_indirect_reference',
                 'detect_secrets.filters.heuristic.is_lock_file',
-                'detect_secrets.filters.heuristic.is_internationalization_file',
+                'detect_secrets.filters.heuristic.is_i18n_file',
             }
         }
 

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -119,6 +119,7 @@ class Settings:
                 'detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign',
                 'detect_secrets.filters.heuristic.is_indirect_reference',
                 'detect_secrets.filters.heuristic.is_lock_file',
+                'detect_secrets.filters.heuristic.is_internationalization_file',
             }
         }
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -47,10 +47,10 @@ the `detect_secrets.filters` namespace.
 | `common.is_baseline_file`                        | Ignores the baseline file itself.                                                   |
 | `common.is_ignored_due_to_verification_policies` | Powers secret verification functionality.                                           |
 | `gibberish.should_exclude_secret`                | Excludes secrets that are not gibberish looking strings.                            |
+| `heuristic.is_i18n_file`                         | Ignores common internationalization files like files in i18n or languages paths.    |
 | `heuristic.is_indirect_reference`                | Primarily for `KeywordDetector`, filters secrets like `secret = get_secret_key()`.  |
 | `heuristic.is_likely_id_string`                  | Ignores secret values prefixed with `id`.                                           |
 | `heuristic.is_lock_file`                         | Ignores common lock files.                                                          |
-| `heuristic.is_internationalization_file`         | Ignores common internationalization files like files in i18n or languages paths.    |
 | `heuristic.is_non_text_file`                     | Ignores non-text files (e.g. archives, images).                                     |
 | `heuristic.is_potential_uuid`                    | Ignores uuid looking secret values.                                                 |
 | `heuristic.is_prefixed_with_dollar_sign`         | Primarily for `KeywordDetector`, filters secrets like `secret = $variableName;`.    |

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -50,6 +50,7 @@ the `detect_secrets.filters` namespace.
 | `heuristic.is_indirect_reference`                | Primarily for `KeywordDetector`, filters secrets like `secret = get_secret_key()`.  |
 | `heuristic.is_likely_id_string`                  | Ignores secret values prefixed with `id`.                                           |
 | `heuristic.is_lock_file`                         | Ignores common lock files.                                                          |
+| `heuristic.is_internationalization_file`         | Ignores common internationalization files like files in i18n or languages paths.    |
 | `heuristic.is_non_text_file`                     | Ignores non-text files (e.g. archives, images).                                     |
 | `heuristic.is_potential_uuid`                    | Ignores uuid looking secret values.                                                 |
 | `heuristic.is_prefixed_with_dollar_sign`         | Primarily for `KeywordDetector`, filters secrets like `secret = $variableName;`.    |

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from detect_secrets import filters
@@ -139,15 +141,15 @@ def test_is_lock_file():
     # assert non-regex
     assert not filters.heuristic.is_lock_file('Gemfilealock')
 
-def test_is_internationalization_file():
-    # i18n test
-    assert filters.heuristic.is_internationalization_file('/something/i18n/text_en.txt')
 
-    # locale test
-    assert filters.heuristic.is_internationalization_file('locale/text_es.yml')
-
-    # messages with locale keys
-    assert filters.heuristic.is_internationalization_file('path/text/Messages_es_ES.json')
-
-    # assert non-regex
-    assert not filters.heuristic.is_internationalization_file('/src/messages/MessageClass.java')
+@pytest.mark.parametrize(
+    'filename, result',
+    (
+        ('{sep}something{sep}i18n{sep}text_en.txt', True),
+        ('locale{sep}text_es.yml', True),
+        ('path{sep}text{sep}Messages_es_ES.json', True),
+        ('{sep}src{sep}messages{sep}MessageClass.java', False),
+    ),
+)
+def test_is_i18n_file(filename, result):
+    assert filters.heuristic.is_i18n_file(filename.format(sep=os.path.sep)) is result

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -138,3 +138,16 @@ def test_is_lock_file():
 
     # assert non-regex
     assert not filters.heuristic.is_lock_file('Gemfilealock')
+
+def test_is_internationalization_file():
+    # i18n test
+    assert filters.heuristic.is_internationalization_file('/something/i18n/text_en.txt')
+
+    # locale test
+    assert filters.heuristic.is_internationalization_file('locale/text_es.yml')
+
+    # messages with locale keys
+    assert filters.heuristic.is_internationalization_file('path/text/Messages_es_ES.json')
+
+    # assert non-regex
+    assert not filters.heuristic.is_internationalization_file('/src/messages/MessageClass.java')


### PR DESCRIPTION
This Pull Request introduce the `heuristic.is_i18n_file` filter that excludes some internationalization files from the plugins scan. This files should be excluded because only content text that will be printed in the frontends, so all the findings in these files will be false positives.

We added this filter in the default settings and completed the filters documentation.

Everything is working fine, but note that the keyword plugin has a bug in the master branch (solved in #420) that can cause fails on the tests if you run all of them with `tox`.