### PR TITLE
Filter compiled folders

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -198,14 +198,13 @@ def is_compiled_file(filename: str) -> bool:
         'package.json'
     }:
         return True
-    regexes = [re.compile(r) for r in [
-            r'^dist{}.*'.format(os.path.sep),
-            r'^build{}.*'.format(os.path.sep),
-            r'^\.tox{}.*'.format(os.path.sep),
-            r'.*node_modules{}.*'.format(os.path.sep),
-            r'.*target{}.*'.format(os.path.sep),
-            r'.*__pycache__{}.*'.format(os.path.sep),
-            r'*.egg-info{}.*'.format(os.path.sep),
+    regexes = [re.compile(r.format(sep=os.path.sep)) for r in [
+            r'^dist{sep}.*',
+            r'^build{sep}.*',
+            r'.*node_modules{sep}.*',
+            r'.*target{sep}.*',
+            r'.*__pycache__{sep}.*',
+            r'.*egg-info{sep}.*',
         ]
     ]
     for regex in regexes:

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -191,3 +191,24 @@ def is_lock_file(filename: str) -> bool:
         'Podfile.lock',
         'yarn.lock',
     }
+
+
+def is_compiled_file(filename: str) -> bool:
+    if os.path.basename(filename) in {
+        'package.json'
+    }:
+        return True
+    regexes = [re.compile(r) for r in [
+            r'^dist{}.*'.format(os.path.sep),
+            r'^build{}.*'.format(os.path.sep),
+            r'^\.tox{}.*'.format(os.path.sep),
+            r'.*node_modules{}.*'.format(os.path.sep),
+            r'.*target{}.*'.format(os.path.sep),
+            r'.*__pycache__{}.*'.format(os.path.sep),
+            r'*.egg-info{}.*'.format(os.path.sep),
+        ]
+    ]
+    for regex in regexes:
+        if regex.search(filename):
+            return True
+    return False

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -198,10 +198,11 @@ def is_compiled_file(filename: str) -> bool:
     Filters files related to compiled sources
     """
     if os.path.basename(filename) in {
-        'package.json'         # It's not a compiled source, but it won't include secrets
+        'package.json',         # It's not a compiled source, but it won't include secrets
     }:
         return True
-    regexes = [re.compile(r.format(sep=os.path.sep)) for r in [
+    regexes = [
+        re.compile(r.format(sep=os.path.sep)) for r in [
             r'^dist{sep}.*',
             r'^build{sep}.*',
             r'.*node_modules{sep}.*',

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -194,8 +194,11 @@ def is_lock_file(filename: str) -> bool:
 
 
 def is_compiled_file(filename: str) -> bool:
+    """
+    Filters files related to compiled sources
+    """
     if os.path.basename(filename) in {
-        'package.json'
+        'package.json'         # It's not a compiled source, but it won't include secrets
     }:
         return True
     regexes = [re.compile(r.format(sep=os.path.sep)) for r in [

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from detect_secrets import filters
@@ -138,3 +140,21 @@ def test_is_lock_file():
 
     # assert non-regex
     assert not filters.heuristic.is_lock_file('Gemfilealock')
+
+
+def test_is_compiled_file():
+    # Apache Maven
+    assert filters.heuristic.is_compiled_file('my-project{sep}target{sep}classes{sep}someclass.class'.format(sep=os.path.sep))
+
+    # Node JS
+    assert filters.heuristic.is_compiled_file('my-poject{sep}node_modules{sep}my-dependencies'.format(sep=os.path.sep))
+
+    # Python
+    assert filters.heuristic.is_compiled_file('my-poject{sep}__pycache__{sep}my-cached-dependencies'.format(sep=os.path.sep))
+    assert filters.heuristic.is_compiled_file('my-poject{sep}detect_secrets.egg-info{sep}PKG-INFO'.format(sep=os.path.sep))
+    assert filters.heuristic.is_compiled_file('dist{sep}detect_secrets-1.0.3-py3.8.egg'.format(sep=os.path.sep))
+    assert not filters.heuristic.is_compiled_file('my-project{sep}dist{sep}detect_secrets-1.0.3-py3.8.egg'.format(sep=os.path.sep))
+    assert filters.heuristic.is_compiled_file('build{sep}lib{sep}detect_secrets'.format(sep=os.path.sep))
+    assert not filters.heuristic.is_compiled_file('my-project{sep}build{sep}lib{sep}detect_secrets'.format(sep=os.path.sep))
+    assert filters.heuristic.is_compiled_file('.tox{sep}dist{sep}detect_secrets.zip'.format(sep=os.path.sep))
+    assert not filters.heuristic.is_compiled_file('my-project{sep}.tox{sep}dist{sep}detect_secrets.zip'.format(sep=os.path.sep))

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -142,19 +142,19 @@ def test_is_lock_file():
     assert not filters.heuristic.is_lock_file('Gemfilealock')
 
 
-def test_is_compiled_file():
-    # Apache Maven
-    assert filters.heuristic.is_compiled_file('my-project{sep}target{sep}classes{sep}someclass.class'.format(sep=os.path.sep))
-
-    # Node JS
-    assert filters.heuristic.is_compiled_file('my-poject{sep}node_modules{sep}my-dependencies'.format(sep=os.path.sep))
-
-    # Python
-    assert filters.heuristic.is_compiled_file('my-poject{sep}__pycache__{sep}my-cached-dependencies'.format(sep=os.path.sep))
-    assert filters.heuristic.is_compiled_file('my-poject{sep}detect_secrets.egg-info{sep}PKG-INFO'.format(sep=os.path.sep))
-    assert filters.heuristic.is_compiled_file('dist{sep}detect_secrets-1.0.3-py3.8.egg'.format(sep=os.path.sep))
-    assert not filters.heuristic.is_compiled_file('my-project{sep}dist{sep}detect_secrets-1.0.3-py3.8.egg'.format(sep=os.path.sep))
-    assert filters.heuristic.is_compiled_file('build{sep}lib{sep}detect_secrets'.format(sep=os.path.sep))
-    assert not filters.heuristic.is_compiled_file('my-project{sep}build{sep}lib{sep}detect_secrets'.format(sep=os.path.sep))
-    assert filters.heuristic.is_compiled_file('.tox{sep}dist{sep}detect_secrets.zip'.format(sep=os.path.sep))
-    assert not filters.heuristic.is_compiled_file('my-project{sep}.tox{sep}dist{sep}detect_secrets.zip'.format(sep=os.path.sep))
+@pytest.mark.parametrize(
+    'filename, result',
+    (
+        ('my-project{sep}target{sep}classes{sep}someclass.class', True),
+        ('my-poject{sep}node_modules{sep}my-dependencies', True),
+        ('my-project{sep}package.json', True),
+        ('my-poject{sep}__pycache__{sep}my-cached-dependencies', True),
+        ('my-poject{sep}detect_secrets.egg-info{sep}PKG-INFO', True),
+        ('dist{sep}detect_secrets-1.0.3-py3.8.egg', True),
+        ('my-project{sep}dist{sep}detect_secrets-1.0.3-py3.8.egg', False),
+        ('build{sep}lib{sep}detect_secrets', True),
+        ('my-project{sep}build{sep}lib{sep}detect_secrets', False),
+    )
+)
+def test_is_compiled_file(filename, result):
+    assert filters.heuristic.is_compiled_file(filename.format(sep=os.path.sep)) is result

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -154,7 +154,7 @@ def test_is_lock_file():
         ('my-project{sep}dist{sep}detect_secrets-1.0.3-py3.8.egg', False),
         ('build{sep}lib{sep}detect_secrets', True),
         ('my-project{sep}build{sep}lib{sep}detect_secrets', False),
-    )
+    ),
 )
 def test_is_compiled_file(filename, result):
     assert filters.heuristic.is_compiled_file(filename.format(sep=os.path.sep)) is result


### PR DESCRIPTION
This Pull Request introduce the `heuristic.is_compiled_file` filter that excludes compiled folders like:

- `dist/`: generated after python setup
- `build/`: generated after python setup
- `/__pycache__/`: generated after python execution
- `/.*egg-info/`: generated after python setup
- `/node_modules/`: generated by npm install (Node JS)
- `/target/`: generated by mvn install (Apache Maven)

We added this filter in the default settings and completed the filters documentation.

Everything is working fine, but note that the keyword plugin has a bug in the master branch (solved in #420) that can cause fails on the tests if you run all of them with `tox`.