### PR TITLE
New keywords in the denylist

### DIFF
--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -54,6 +54,7 @@ DENYLIST = (
     'key_?pass',
     'password',
     'passwd',
+    'pwd',
     'secret',
     'contraseña',
     'contrasena',

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -40,15 +40,23 @@ from .base import BasePlugin
 
 # Note: All values here should be lowercase
 DENYLIST = (
-    'apikey',
-    'api_key',
-    'aws_secret_access_key',
-    'db_pass',
+    'api_?key',
+    'auth_?key',
+    'service_?key',
+    'account_?key',
+    'db_?key',
+    'database_?key',
+    'priv_?key',
+    'private_?key',
+    'client_?key',
+    'db_?pass',
+    'database_?pass',
+    'key_?pass',
     'password',
     'passwd',
-    'private_key',
     'secret',
-    'secrete',
+    'contraseña',
+    'contrasena',
 )
 # Includes ], ', " as closing
 CLOSING = r'[]\'"]{0,2}'


### PR DESCRIPTION
This Pull Request includes new items in the `DENYLIST` variable of the `KeywordDetector` plugin. Moreover, It also removes the following words:

- `aws_secret_access_key`: it will be detected due to the keyword `secret`. The `aws_` section will be captured as a prefix and `_access_key` as a suffix.
- `secrete`: it will be detected due to the keyword `secret` and the character `e` will be captured as a suffix.

All the tests has been passed and I think the performance is not affected by this changes.