### PR TITLE
don't override the root logger

### DIFF
--- a/detect_secrets/core/log.py
+++ b/detect_secrets/core/log.py
@@ -64,4 +64,4 @@ class CustomLogger(logging.Logger):
         )
 
 
-log = get_logger()
+log = get_logger('detect-secrets')


### PR DESCRIPTION
## Summary

With this change, the `detect-secrets` logger will not use the root logger. I've tested this by running:

```
detect-secrets -vv scan
```

and the logs seem to still work. This way, when we modify the debug level, it won't cause all other packages (that use the root logger) to show debug logs too.