### PR TITLE
feature: adding multiprocessing support

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -21,13 +21,9 @@ from .secrets_collection import SecretsCollection
 def create(*paths: str, should_scan_all_files: bool = False, root: str = '') -> SecretsCollection:
     """Scans all the files recursively in path to initialize a baseline."""
     secrets = SecretsCollection(root=root)
-
-    for filename in get_files_to_scan(
-        *paths,
-        should_scan_all_files=should_scan_all_files,
-        root=root,
-    ):
-        secrets.scan_file(filename)
+    secrets.scan_files(
+        *get_files_to_scan(*paths, should_scan_all_files=should_scan_all_files, root=root)
+    )
 
     return secrets
 

--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -5,6 +5,7 @@ from typing import Callable
 from typing import cast
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Union
 
 from . import upgrades
@@ -18,11 +19,21 @@ from .scan import get_files_to_scan
 from .secrets_collection import SecretsCollection
 
 
-def create(*paths: str, should_scan_all_files: bool = False, root: str = '') -> SecretsCollection:
+def create(
+    *paths: str,
+    should_scan_all_files: bool = False,
+    root: str = '',
+    num_processors: Optional[int] = None,
+) -> SecretsCollection:
     """Scans all the files recursively in path to initialize a baseline."""
+    kwargs = {}
+    if num_processors:
+        kwargs['num_processors'] = num_processors
+
     secrets = SecretsCollection(root=root)
     secrets.scan_files(
-        *get_files_to_scan(*paths, should_scan_all_files=should_scan_all_files, root=root)
+        *get_files_to_scan(*paths, should_scan_all_files=should_scan_all_files, root=root),
+        **kwargs,
     )
 
     return secrets

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -46,11 +46,14 @@ class SecretsCollection:
     def files(self) -> Set[str]:
         return set(self.data.keys())
 
-    def scan_files(self, *filenames: str, num_processors: int = mp.cpu_count()) -> None:
+    def scan_files(self, *filenames: str, num_processors: Optional[int] = None) -> None:
         """Just like scan_file, but optimized through parallel processing."""
         if len(filenames) == 1:
             self.scan_file(filenames[0])
             return
+
+        if not num_processors:
+            num_processors = mp.cpu_count()
 
         with mp.Pool(processes=num_processors) as p:
             for secrets in p.imap_unordered(

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -48,6 +48,10 @@ class SecretsCollection:
 
     def scan_files(self, *filenames: str, num_processors: int = mp.cpu_count()) -> None:
         """Just like scan_file, but optimized through parallel processing."""
+        if len(filenames) == 1:
+            self.scan_file(filenames[0])
+            return
+
         with mp.Pool(processes=num_processors) as p:
             for secrets in p.imap_unordered(
                 _scan_file_and_serialize,

--- a/detect_secrets/core/usage/__init__.py
+++ b/detect_secrets/core/usage/__init__.py
@@ -47,6 +47,18 @@ class ParserBuilder:
                 'working directory.'
             ),
         )
+        self._parser.add_argument(
+            '-c',
+            '--cores',
+            dest='num_cores',
+            nargs=1,
+            type=int,
+            default=[None],
+            help=(
+                'Specify the number of cores to use for parallel processing. Defaults to '
+                'using the max cores on the current host.'
+            ),
+        )
 
         return self
 
@@ -160,6 +172,8 @@ class ParserBuilder:
             # custom root directory itself.
             if args.path == ['.']:
                 args.path = [args.custom_root]
+
+        args.num_cores = args.num_cores[0]
 
         return args
 

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -71,6 +71,7 @@ def handle_scan_action(args: argparse.Namespace) -> None:
         *args.path,
         should_scan_all_files=args.all_files,
         root=args.custom_root,
+        num_processors=args.num_cores,
     )
     if args.baseline is not None:
         # The pre-commit hook's baseline upgrade is to trim the supplied baseline for non-existent


### PR DESCRIPTION
I never knew parallel processing could be so easy. ❤️   python

## Summary

This increases the efficiency of scans by throwing some parallel processing to it.

Since scanning files are independent of each other, it seemed like a prime candidate for this. I considered parallelizing line scanning, but then realized that this may not be such a good idea, since lines are somewhat dependent on each other (e.g. context-based filters).

## Testing Done

I ran this on our internal monolith, and these were the stats I got:

```bash
# Some stats on the repository itself
$ git ls-files | wc -l
35519
$ cloc $(git ls-files)
...
--------------------------------------------------------------------------------
Language                      files          blank        comment           code
--------------------------------------------------------------------------------
...
--------------------------------------------------------------------------------
SUM:                          22948         660907         422368        3680522
--------------------------------------------------------------------------------
$ lscpu
...
CPU(s):              16

# Running with single process
$ time detect-secrets scan > /tmp/single.baseline
real    23m41.917s
user    23m20.518s
sys     0m3.527s

# Running with multiprocessor
$ time detect-secrets scan > /tmp/mp.baseline
real    6m4.887s
user    37m4.611s
sys     0m8.304s

# Comparing results
$ diff /tmp/single.baseline /tmp/mp.baseline
4961c4961
<   "generated_at": "2021-04-01T14:42:50Z"
---
>   "generated_at": "2021-04-01T15:05:30Z"
```

That's like a 74% optimization. Heck yeah!