### PR TITLE
bug fix: upgrading from v0.12-0.14 incorrectly handles exclude_regex

### DIFF
--- a/detect_secrets/core/upgrades/v0_12.py
+++ b/detect_secrets/core/upgrades/v0_12.py
@@ -5,8 +5,8 @@ from typing import Dict
 def upgrade(baseline: Dict[str, Any]) -> None:
     if 'exclude_regex' in baseline:
         baseline['exclude'] = {
-            'files': None,
-            'lines': baseline.pop('exclude_regex'),
+            'files': baseline.pop('exclude_regex'),
+            'lines': None,
         }
 
     baseline['word_list'] = {


### PR DESCRIPTION
This is a suboptimal patch, but is the best that we can do.

In older versions, it looks like `exclude_regex` deals with files, not lines ([source](https://github.com/Yelp/detect-secrets/blob/v0.14.3/detect_secrets/main.py#L210-L220)). This change modifies the auto-upgrade script to handle this properly for all other users who haven't upgraded yet.

However, for those users who upgraded their baselines between <0.12 and =~1.0, they will need to apply the change **manually**. This is because once this change has been made, we cannot assume that the regex that applies to lines should have been applied to files (as new `--exclude-line` regexes could have been applied). As such, there's no automated manner to upgrade this. ☹️ 

Kudos to @calvinli for finding this one.