### PR TITLE
Support for XML secrets in Keyword plugin

### DIFF
--- a/detect_secrets/util/filetype.py
+++ b/detect_secrets/util/filetype.py
@@ -17,7 +17,8 @@ class FileType(Enum):
     C_SHARP = 11
     C = 12
     C_PLUS_PLUS = 13
-    OTHER = 14
+    XML = 14
+    OTHER = 15
 
 
 def determine_file_type(filename: str) -> FileType:
@@ -39,5 +40,6 @@ def determine_file_type(filename: str) -> FileType:
         '.yml': FileType.YAML,
         '.cs': FileType.C_SHARP,
         '.c': FileType.C,
-        '.cpp': FileType.C_PLUS_PLUS
+        '.cpp': FileType.C_PLUS_PLUS,
+        '.xml': FileType.XML
     }.get(file_extension, FileType.OTHER)

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -6,6 +6,7 @@ from detect_secrets.settings import transient_settings
 
 
 COMMON_SECRET = 'm{{h}o)p${e]nob(ody[finds>-_$#thisone}}'
+COMMON_TAG_SECRET = 'm{{h}o)p${e]nob(ody[finds-_$#thisone}}'
 WHITES_SECRET = 'value with quotes and spaces'
 LETTER_SECRET = 'A,.:-¨@*¿?!'
 SYMBOL_SECRET = ',.:-¨@*¿?!'
@@ -142,6 +143,25 @@ QUOTES_REQUIRED_TEST_CASES = [
     ('private_key "hopenobodyfindsthisone\';', None),  # Double-quote does not match single-quote)
 ]
 
+XML_TEST_CASES = [
+    ('apikey = "{}"'.format(WHITES_SECRET), WHITES_SECRET),
+    ('password_super_secure = "{}"'.format(WHITES_SECRET), WHITES_SECRET),  # Suffix
+    ('my_password_super_secure = "{}"'.format(WHITES_SECRET), WHITES_SECRET),  # Prefix/suffix
+    ('<password>{}</password>'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<api_key expires="15">{}</api_key>'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<db_pass>{}</db_pass>'.format(WHITES_SECRET), WHITES_SECRET),
+    ('<password value="{}"/>'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<passwd value="{}"></passwd>'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<sometag name="private_key">{}</sometag>'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<sometag name="secret" value="{}" />'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<sometag value="{}" name="secrete" />'.format(COMMON_TAG_SECRET), COMMON_TAG_SECRET),
+    ('<apikey>{}</apikey>'.format(SYMBOL_SECRET), None),  # At least 1 alphanumeric char is required
+    ('<password>{}</password>'.format(LETTER_SECRET), LETTER_SECRET),  # All symbols are allowed
+    ('<db_pass value=""/>', None),    # Nothing in the quotes
+    ('<secret value="somefakekey"/>', None),    # 'fake' in the secret
+    ('<some_key>real_secret</some_key>', None),     # We cannot make 'key' a Keyword, too noisy)
+]
+
 
 def parse_test_cases(test_cases):
     for file_extension, test_case in test_cases:
@@ -166,6 +186,7 @@ def parse_test_cases(test_cases):
             ('js', QUOTES_REQUIRED_TEST_CASES),
             ('swift', QUOTES_REQUIRED_TEST_CASES),
             ('tf', QUOTES_REQUIRED_TEST_CASES),
+            ('xml', XML_TEST_CASES),
         ])
     ),
 )


### PR DESCRIPTION
This Pull Request introduces some regex in the KeywordDetector plugin to detect secrets in XML files. The are a lot of situations where a secret can be hardcoded in a XML file, I think that this regexes will detect secrets in the most of them.

I know that in other Pull Request, we talked with @domanchi about create a XML transformer to perform this secrets detection, but I think that it will be more complex than YAML transformer and we have to analyze what is the better approach to implement it, to get the best result as possible. We will keep it in mind for future optimizations, but now I think that this standard regexes in the Keyword plugin could achieve a good performance.

I hope you will like it!