### PR TITLE
Add Pipfile.lock to list of excluded lockfiles

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -194,6 +194,7 @@ def is_lock_file(filename: str) -> bool:
         'package-lock.json',
         'Podfile.lock',
         'yarn.lock',
+        'Pipfile.lock',
     }
 
 


### PR DESCRIPTION
Updates is_lock_file to include Pipfile.lock when checking for lock files to exclude.