### PR TITLE
Updated pre-commit hook from v1.0.0 to v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ We recommend setting this up as a pre-commit hook. One way to do this is by usin
 # .pre-commit-config.yaml
 repos:
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v1.0.0
+    rev: v1.0.3
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']


### PR DESCRIPTION
Hello!
I was trying to use detect-secrets for the first time yesterday, with pre-commit. I followed the documentation presented here, but I was struggling with the problem described in issue #407.

I discovered that it was just needed to update the `v1.0.0` to `v1.0.3` in `.pre-commit-config.yaml`. I tried to update to `v1.1.0`, as it is the last one released. But for some reason, the hook isn't preventing commits 🤔 . So I decided to just keep it `v1.0.3`.

Anyway, to avoid other newbies struggling with this, I think it may be a good idea to just update the README file for now :)