### PR TITLE
Hook currently fails to interpret filenames with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ For baselines older than version 0.9, just recreate it.
 **Scanning Staged Files Only:**
 
 ```bash
-$ detect-secrets-hook --baseline .secrets.baseline $(git diff --staged --name-only)
+$ git diff --staged --name-only -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
 ```
 
 **Scanning All Tracked Files:**
 
 ```bash
-$ detect-secrets-hook --baseline .secrets.baseline $(git ls-files)
+$ git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline 
 ```
 
 ### Viewing All Enabled Plugins:


### PR DESCRIPTION
I noticed that `detect-secrets-hook -v --baseline .secrets.baseline $(git ls-files)` interprets filenames containing spaces as separate arguments, preventing them from being scanned. It seems like with the current README.md command it is possible to evade secrets detection by naming files in this way.

To prevent that, it would be better to use the `-z` argument for `git diff` and `git ls-files`, splitting by NUL instead, and passing the arglist to `detect-secrets-hook` via xargs -0.

I'm not sure if the change needs to be made elsewhere as well, possibly in the .pre-commit hook?

Thanks! 