### PR TITLE
[#471] Safely get line_number from PotentialSecret

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -213,8 +213,8 @@ class SecretsCollection:
         for filename in sorted(self.files):
             secrets = self[filename]
 
-            # NOTE: If line numbers aren't supplied, they will default to 0.
-            for secret in sorted(secrets, key=lambda x: (x.line_number, x.secret_hash, x.type)):
+            # NOTE: If line numbers aren't supplied, they are supposed to default to 0.
+            for secret in sorted(secrets, key=lambda x: (x.get(line_number, 0), x.secret_hash, x.type)):
                 yield filename, secret
 
     def __bool__(self) -> bool:


### PR DESCRIPTION
This is a relatively naive approach to solving the issue in #471. I looked at the PotentialSecret class and it very clearly has a default value of 0 for `line_number`. But alas, intermittently it does not. So this should safely fall back to 0 if `line_number` isn't present.

Closes #471 (I think)