### PR TITLE
Capitalize GitHub and SendGrid Secret Types

### DIFF
--- a/detect_secrets/plugins/github_token.py
+++ b/detect_secrets/plugins/github_token.py
@@ -8,7 +8,7 @@ from detect_secrets.plugins.base import RegexBasedDetector
 
 class GitHubTokenDetector(RegexBasedDetector):
     """Scans for GitHub tokens."""
-    secret_type = 'GitHub token'
+    secret_type = 'GitHub Token'
 
     denylist = [
         # ref. https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/

--- a/detect_secrets/plugins/sendgrid.py
+++ b/detect_secrets/plugins/sendgrid.py
@@ -8,7 +8,7 @@ from detect_secrets.plugins.base import RegexBasedDetector
 
 class SendGridDetector(RegexBasedDetector):
     """Scans for SendGrid API keys."""
-    secret_type = 'SendGrid API key'
+    secret_type = 'SendGrid API Key'
 
     denylist = [
         # SendGrid API key


### PR DESCRIPTION
I am not editing the plugins merged in PRs #347 and #359 because of how disruptive that would be to users that already made baselines.

I just merged the GitHub and SendGrid PRs a few minutes ago and have not released a new version, so this should be minimally disruptive to anyone.