### PR TITLE
Yielding submatches when findall() returns tuples

### DIFF
--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -146,7 +146,7 @@ class RegexBasedDetector(BasePlugin, metaclass=ABCMeta):
         for regex in self.denylist:
             for match in regex.findall(string):
                 if isinstance(match, tuple):
-                    for submatch in filter(len, tuple):
+                    for submatch in filter(bool, tuple):
                         # It might make sense to paste break after yielding
                         yield submatch
                 else:

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -145,7 +145,12 @@ class RegexBasedDetector(BasePlugin, metaclass=ABCMeta):
     def analyze_string(self, string: str) -> Generator[str, None, None]:
         for regex in self.denylist:
             for match in regex.findall(string):
-                yield match
+                if isinstance(match, tuple):
+                    for submatch in filter(len, tuple):
+                        # It might make sense to paste break after yielding
+                        yield submatch
+                else:
+                    yield match
 
     @staticmethod
     def build_assignment_regex(


### PR DESCRIPTION
Hello!
I assume such changes can be helpful for several users. Let me explain.
For instance, some user writes its own plugin like the following:

``` python
import re
from .base import RegexBasedDetector


class SomeKeyDetector(RegexBasedDetector):
    secret_type = 'Some Detector'

    denylist = [
        re.compile(r'^(key|token|password)=(prefix_)?.*$'),
    ]

```

As you can see, the only regex of the detector contains two match groups: `(key|token|password)` and `(prefix_)` and the function `re.findall()` can return a tuple(s). For exmaple:

``` python
>>> import re
>>> regex = r"^(key|token|password)=(prefix_)?.*$"
>>> string = "key=prefix_45guh245ghihfrgjdsfguhrwth"
>>> print(re.findall(regex, string))
[('key', 'prefix_')]
>>> 

```

In this case, just yielding a `match` with such a plugin will lead to exception in the `detect_secrets/core/potential_secret.py:71`, because it will try to call `.encode()` method for the instance of a `tuple`.