### PR TITLE
fix precommit version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ We recommend setting this up as a pre-commit hook. One way to do this is by usin
 # .pre-commit-config.yaml
 repos:
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']


### PR DESCRIPTION
version 1.0.0 still fails with `No module named 'requests'`.
use 1.0.1 in pre-commit, avoid `No module named 'requests'` solved in https://github.com/Yelp/detect-secrets/issues/407 .