### PR TITLE
Bug Fix: Fix Inline Dictionary For YAML Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ git diff --staged --name-only -z | xargs -0 detect-secrets-hook --baseline .se
 **Scanning All Tracked Files:**
 
 ```bash
-$ git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline 
+$ git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
 ```
 
 ### Viewing All Enabled Plugins:

--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -219,8 +219,8 @@ class SecretsCollection:
                 key=lambda secret: (
                     getattr(secret, 'line_number', 0),
                     secret.secret_hash,
-                    secret.type
-                )
+                    secret.type,
+                ),
             ):
                 yield filename, secret
 

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -146,7 +146,7 @@ class RegexBasedDetector(BasePlugin, metaclass=ABCMeta):
         for regex in self.denylist:
             for match in regex.findall(string):
                 if isinstance(match, tuple):
-                    for submatch in filter(bool, tuple):
+                    for submatch in filter(bool, match):
                         # It might make sense to paste break after yielding
                         yield submatch
                 else:

--- a/detect_secrets/transformers/yaml.py
+++ b/detect_secrets/transformers/yaml.py
@@ -164,7 +164,7 @@ class YAMLFileParser:
 
         to_search = deque([self.json()])
         while to_search:
-            item: Any = to_search.pop()
+            item: Any = to_search.popleft()
 
             if not item:
                 # mainly for base case (e.g. if file is all comments)

--- a/detect_secrets/transformers/yaml.py
+++ b/detect_secrets/transformers/yaml.py
@@ -14,6 +14,8 @@ from typing import Tuple
 from typing import Union
 
 import yaml
+from yaml.tokens import FlowEntryToken
+from yaml.tokens import KeyToken
 
 from ..types import NamedIO
 from ..util.filetype import determine_file_type
@@ -152,6 +154,9 @@ class YAMLFileParser:
         self.loader = yaml.SafeLoader(self.content)
         self.loader.compose_node = self._compose_node_shim  # type: ignore
 
+        self.is_inline_flow_mapping_key = False
+        self.loader.parse_flow_mapping_key = self._parse_flow_mapping_key_shim  # type: ignore
+
     def json(self) -> Dict[str, Any]:
         return cast(Dict[str, Any], self.loader.get_single_data())
 
@@ -206,7 +211,11 @@ class YAMLFileParser:
         parent: Optional[yaml.nodes.Node],
         index: Optional[yaml.nodes.Node],
     ) -> yaml.nodes.Node:
-        line = self.loader.line
+        line = (
+            self.loader.marks[-1].line
+            if self.is_inline_flow_mapping_key
+            else self.loader.line
+        )
 
         node = yaml.composer.Composer.compose_node(self.loader, parent, index)
         node.__line__ = line + 1
@@ -217,6 +226,41 @@ class YAMLFileParser:
         # TODO: Not sure if need to do :seq
 
         return cast(yaml.nodes.Node, node)
+
+    def _parse_flow_mapping_key_shim(
+        self,
+        first: bool = False,
+    ) -> yaml.nodes.Node:
+        if (
+            first
+            and self.loader.marks[-1].line == self.loader.peek_token().start_mark.line
+            or self._check_next_tokens_shim(FlowEntryToken, KeyToken)
+        ):
+            self.is_inline_flow_mapping_key = True
+        else:
+            self.is_inline_flow_mapping_key = False
+
+        return cast(yaml.nodes.Node, yaml.parser.Parser.parse_flow_mapping_key(self.loader, first))
+
+    def _check_next_tokens_shim(
+        self,
+        *choices: Any,
+    ) -> bool:
+        # Check the next tokens type match the argument list of token types
+        result = True
+        i = 0
+
+        if self.loader.tokens:
+            if not choices:
+                return result
+            for choice in choices:
+                if i < len(self.loader.tokens):
+                    result = result and isinstance(self.loader.tokens[i], choice)
+                    i += 1
+        else:
+            result = False
+
+        return result
 
 
 def _tag_dict_values(map_node: yaml.nodes.MappingNode) -> yaml.nodes.MappingNode:

--- a/detect_secrets/transformers/yaml.py
+++ b/detect_secrets/transformers/yaml.py
@@ -231,6 +231,14 @@ class YAMLFileParser:
         self,
         first: bool = False,
     ) -> yaml.nodes.Node:
+        # There exists an edge case when a key and flow mapping start character `{` are on the same
+        # line (Ex. '{key: value}) followed by an empty line. The parser will produce an off-by-one
+        # error for the line number that it tracks internally. Since we track the start of the
+        # mapping, we will use this line number when we are processing:
+        # A) The first key in an inline dictionary where the flow mapping start character is on the
+        # same line as the key
+        # B) The n key of an inline dictionary that is followed by a FlowEntryToken (',') and
+        # KeyToken ('key:')
         if (
             first
             and self.loader.marks[-1].line == self.loader.peek_token().start_mark.line

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ monotonic==1.5
 mypy==0.790
 mypy-extensions==0.4.3
 nodeenv==1.5.0
-packaging==20.7
+packaging==20.9
 pluggy==0.13.1
 pre-commit==2.9.2
 py==1.10.0
@@ -26,7 +26,7 @@ pyahocorasick==1.4.0
 pycodestyle==2.3.1
 pyflakes==1.6.0
 pyparsing==2.4.7
-pytest==6.1.2
+pytest==6.2.2
 PyYAML==5.4
 requests==2.25.0
 responses==0.12.1
@@ -38,5 +38,5 @@ typed-ast==1.4.1
 typing-extensions==3.7.4.3
 unidiff==0.6.0
 urllib3==1.26.4
-virtualenv==20.2.1
+virtualenv==20.6.0
 zipp==3.4.0

--- a/tests/transformers/yaml_transformer_test.py
+++ b/tests/transformers/yaml_transformer_test.py
@@ -80,6 +80,26 @@ class TestYAMLTransformer:
 
         assert YAMLTransformer().parse_file(file) == ['']
 
+    @staticmethod
+    def test_single_line_flow_mapping():
+        file = mock_file_object(
+            textwrap.dedent("""
+            batch:
+                cpus: 1
+                extra_volumes:
+                    - {containerPath: /nail/tmp, hostPath: /nail/tmp, mode: RW}
+            """)[1:-1],
+        )
+
+        assert YAMLTransformer().parse_file(file) == [
+            '',
+            '',
+            '',
+            'containerPath: "/nail/tmp"',
+            'hostPath: "/nail/tmp"',
+            'mode: "RW"',
+        ]
+
 
 class TestYAMLFileParser:
     @staticmethod

--- a/tests/transformers/yaml_transformer_test.py
+++ b/tests/transformers/yaml_transformer_test.py
@@ -258,7 +258,7 @@ class TestYAMLFileParser:
         )
 
         assert YAMLFileParser(file).json() == {
-            'extra_volumes': [
+            'dictionary': [
                 {
                     'keyA': {
                         '__value__': 'valueA',
@@ -290,7 +290,7 @@ class TestYAMLFileParser:
         )
 
         assert YAMLFileParser(file).json() == {
-            'extra_volumes': [
+            'dictionary': [
                 {
                     'keyA': {
                         '__value__': 'valueA',


### PR DESCRIPTION
## Problem
- When running detect-secrets on YAML files - there is a miscalculation that occurs when calculating the line number of an inline dictionary (FlowMapping). 
- This is an issue with the PyYAML library. 
- This issue occurs when there is an empty line after the inline dictionary.
- An example of where the miscalculation occurs:
```
dictionary: 
     - {keyA: valueA, keyB: valueB, keyC: valueC}
     
```
## Solution

- This solution was inspired by this [PR](https://github.com/Yelp/detect-secrets/pull/449) but was expanded on to fix a few other use-cases
- The parser keeps track of the the start of the FlowMapping character under `self.marks`
- We need to use this values line number when the inline dictionary has a key on the same line as the start of the FlowMapping.
- The PR above handles the case only when there is a SINGLE key value pair followed by an empty line. Ex. `{key: value}`
- To handle the cases where there are multiple key value pairs on a single line - we must check that the next upcoming tokens are of type `FlowEntryToken, KeyToken` (Comma, new Key). This will tell us if this dictionary has more values on the same line. Ex. `{keyA: valueA, keyB: valueB, keyC: valueC}`

## Verification
- A suite of unit tests were created to validate the approach. 