### PR TITLE
Bug Fix: Plugins Fail To Load on Python 3.8+

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -55,7 +55,8 @@ class SecretsCollection:
         if not num_processors:
             num_processors = mp.cpu_count()
 
-        with mp.Pool(processes=num_processors) as p:
+        # Default to fork multiprocessing. Python 3.8+ defaults to spawn which doesn't share memory.
+        with mp.get_context('fork').Pool(processes=num_processors) as p:
             for secrets in p.imap_unordered(
                 _scan_file_and_serialize,
                 [os.path.join(self.root, filename) for filename in filenames],


### PR DESCRIPTION
# Problem
- Python 3.8+ multiprocessing library has switched to `spawn` where before it was `fork`
- This is an issue since `spawn` does not share any memory between the parent and child processes. 
- The plugins/filters are stored as singleton global variable in the Settings class

# Solution
- Default the multiprocessing to `fork` when creating a pool of processes
- Python does have a shared memory library now however I find that it is only useful when sharing simple data types like strings, ints, list but not custom classes