### PR TITLE
Pre-Commit Hook Fix

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -241,8 +241,12 @@ class SecretsCollection:
             return False
 
         for filename in self.files:
-            self_mapping = {secret.secret_hash: secret for secret in self[filename]}
-            other_mapping = {secret.secret_hash: secret for secret in other[filename]}
+            self_mapping = {
+                (secret.secret_hash, secret.type): secret for secret in self[filename]
+            }
+            other_mapping = {
+                (secret.secret_hash, secret.type): secret for secret in other[filename]
+            }
 
             # Since PotentialSecret is hashable, we compare their identities through this.
             if set(self_mapping.values()) != set(other_mapping.values()):
@@ -252,7 +256,7 @@ class SecretsCollection:
                 continue
 
             for secretA in self_mapping.values():
-                secretB = other_mapping[secretA.secret_hash]
+                secretB = other_mapping[(secretA.secret_hash, secretA.type)]
 
                 valuesA = vars(secretA)
                 valuesA.pop('secret_value')


### PR DESCRIPTION
# Problem
- When running the pre-commit hook the only change to the .secrets.baseline file is the `generated_at key`. This causes the hook to fail although there is no other change. This is side-effect of the underlying problem. 
- When running the pre-commit, we compare the .secrets.baseline file result and the current scanned results of the hook. 
- Secrets are stored in a collection with key being the hashed secret
- A single secret can have multiple types - for example - we match a secret as Hex High Entropy String & Secret Keyword with a single hash
- This results in a collection size of 1 since the key is the hash and both types have the same hash. It should have a size of 2.
- Overall result is on different runs - the collections may have the first type or the second type - causing a difference between the baseline and current. This triggers an update to the baseline but there are no result changes but it does cause a change to the generated timestamp.

# Solution
- When creating and comparing this set - we need to set the key as the tuple of `(secret_hash, type)` to accommodate for this scenario. 
- This is valid since when creating a `PotentalSecret` object - the comparison keys are the following `self.fields_to_compare = ['filename', 'secret_hash', 'type']`
- Since upon comparing we already know the filenames are the same - the key needs to be the later two identifiers. 