### PR TITLE
Fix Catastophic Backtracking for Indirect Reference

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -165,6 +165,8 @@ def is_indirect_reference(line: str) -> bool:
 
         secret = request.headers['apikey']
     """
+    if len(line) > 1000:
+        return False
     return bool(_get_indirect_reference_regex().search(line))
 
 
@@ -181,7 +183,7 @@ def _get_indirect_reference_regex() -> Pattern:
     #       [^\v]*      ->  Something except line breaks
     #       [\]\)]      ->  End of indirect reference: ] or )
     #   )
-    return re.compile(r'(\w+)\s*(:=?|[!=]{1,3})\s*([\w.-]+[\[\(][^\v]*[\]\)])')
+    return re.compile(r'([^\v=!:]*)\s*(:=?|[!=]{1,3})\s*([\w.-]+[\[\(][^\v]*[\]\)])')
 
 
 def is_lock_file(filename: str) -> bool:

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -181,7 +181,7 @@ def _get_indirect_reference_regex() -> Pattern:
     #       [^\v]*      ->  Something except line breaks
     #       [\]\)]      ->  End of indirect reference: ] or )
     #   )
-    return re.compile(r'([^\v=!:]*)\s*(:=?|[!=]{1,3})\s*([\w.-]+[\[\(][^\v]*[\]\)])')
+    return re.compile(r'(\w+)\s*(:=?|[!=]{1,3})\s*([\w.-]+[\[\(][^\v]*[\]\)])')
 
 
 def is_lock_file(filename: str) -> bool:


### PR DESCRIPTION
# Problem
- I've noticed that there is a hang when running detect-secrets.
- This is due to the regex that the Indirect-Reference filter utilizes.
- The problem here is catastrophic backtracking. This occurs when we are trying to match a line that is typically more than 25k characters against the regex. 

# Solution
- We have a few options here 
1) Add conditions on when to run the regex for a line - 1k characters or less (or some agreed up length)
2) Update the regex 
- I resorted to option 1. The intention of the heuristic should be for short and simple lines. 