### PR TITLE
Bug Fix: Yaml Line Numbering Empty Mapping Fix

### DIFF
--- a/detect_secrets/transformers/yaml.py
+++ b/detect_secrets/transformers/yaml.py
@@ -221,6 +221,7 @@ class YAMLFileParser:
         node.__line__ = line + 1
 
         if node.tag.endswith(':map'):
+            self.is_inline_flow_mapping_key = False
             return _tag_dict_values(node)
 
         # TODO: Not sure if need to do :seq

--- a/tests/transformers/yaml_transformer_test.py
+++ b/tests/transformers/yaml_transformer_test.py
@@ -357,3 +357,45 @@ class TestYAMLFileParser:
                 '__original_key__': 'b',
             },
         }
+
+    @staticmethod
+    def test_inline_empty_dictionary_line_number():
+        file = mock_file_object(
+            textwrap.dedent("""
+                a: {}
+                b: "2"
+            """)[1:-1],
+        )
+
+        assert YAMLFileParser(file).json() == {
+            'a': {},
+            'b': {
+                '__value__': '2',
+                '__line__': 2,
+                '__original_key__': 'b',
+            },
+        }
+
+    @staticmethod
+    def test_inline_dictionary_single_line_line_number():
+        file = mock_file_object(
+            textwrap.dedent("""
+                a: {b: "2"}
+                c: "3"
+            """)[1:-1],
+        )
+
+        assert YAMLFileParser(file).json() == {
+            'a': {
+                'b': {
+                    '__value__': '2',
+                    '__line__': 1,
+                    '__original_key__': 'b',
+                },
+            },
+            'c': {
+                '__value__': '3',
+                '__line__': 2,
+                '__original_key__': 'c',
+            },
+        }

--- a/tests/transformers/yaml_transformer_test.py
+++ b/tests/transformers/yaml_transformer_test.py
@@ -359,7 +359,7 @@ class TestYAMLFileParser:
         }
 
     @staticmethod
-    def test_inline_empty_dictionary_line_number():
+    def test_inline_empty_mapping_line_numbers():
         file = mock_file_object(
             textwrap.dedent("""
                 a: {}
@@ -377,7 +377,7 @@ class TestYAMLFileParser:
         }
 
     @staticmethod
-    def test_inline_dictionary_single_line_line_number():
+    def test_inline_mapping_single_line_single_key_line_numbers():
         file = mock_file_object(
             textwrap.dedent("""
                 a: {b: "2"}
@@ -397,5 +397,34 @@ class TestYAMLFileParser:
                 '__value__': '3',
                 '__line__': 2,
                 '__original_key__': 'c',
+            },
+        }
+
+    @staticmethod
+    def test_inline_mapping_single_line_multikey_line_numbers():
+        file = mock_file_object(
+            textwrap.dedent("""
+                a: {b: "2", c: "3"}
+                d: "4"
+            """)[1:-1],
+        )
+
+        assert YAMLFileParser(file).json() == {
+            'a': {
+                'b': {
+                    '__value__': '2',
+                    '__line__': 1,
+                    '__original_key__': 'b',
+                },
+                'c': {
+                    '__value__': '3',
+                    '__line__': 1,
+                    '__original_key__': 'c',
+                },
+            },
+            'd': {
+                '__value__': '4',
+                '__line__': 2,
+                '__original_key__': 'd',
             },
         }


### PR DESCRIPTION
# Problem
- When we have an empty mapping (dictionary) included in a file - the line numbering of the file is off
- It is specifically off by `actual line number - 1`
- The issue here is that the only time we parse a flow mapping key for an empty mapping is once. (At function `_parse_flow_mapping_key_shim`)
- When we parse a flow mapping key we determine if this is an inline mapping or not. 
- We determine that this is an inline mapping (correct) - however since it is empty mapping, we never come back into parsing the flow mapping to change the `is_inline_flow_mapping_key` to False. 

# Solution
- Set the `is_inline_flow_mapping_key` to False when the mapping has ended.