### PR TITLE
Don't use Ansi Colors if not supported.

### DIFF
--- a/detect_secrets/util/color.py
+++ b/detect_secrets/util/color.py
@@ -1,4 +1,11 @@
 from enum import Enum
+from os import getenv
+from sys import stdout
+
+
+def support_ansi_colors():
+    return (getenv('CLICOLOR', '1') != '0' and stdout.isatty())\
+        or getenv('CLICOLOR_FORCE', '0') != '0'
 
 
 class AnsiColor(Enum):
@@ -11,6 +18,9 @@ class AnsiColor(Enum):
 
 
 def colorize(text: str, color: AnsiColor) -> str:
+    if not support_ansi_colors():
+        return text
+
     return '\x1b{}{}\x1b{}'.format(
         color.value,
         text,

--- a/detect_secrets/util/color.py
+++ b/detect_secrets/util/color.py
@@ -3,7 +3,7 @@ from os import getenv
 from sys import stdout
 
 
-def support_ansi_colors() -> bool:
+def supports_ansi_colors() -> bool:
     return (getenv('CLICOLOR', '1') != '0' and stdout.isatty())\
         or getenv('CLICOLOR_FORCE', '0') != '0'
 
@@ -18,7 +18,7 @@ class AnsiColor(Enum):
 
 
 def colorize(text: str, color: AnsiColor) -> str:
-    if not support_ansi_colors():
+    if not supports_ansi_colors():
         return text
 
     return '\x1b{}{}\x1b{}'.format(

--- a/detect_secrets/util/color.py
+++ b/detect_secrets/util/color.py
@@ -3,7 +3,7 @@ from os import getenv
 from sys import stdout
 
 
-def support_ansi_colors():
+def support_ansi_colors() -> bool:
     return (getenv('CLICOLOR', '1') != '0' and stdout.isatty())\
         or getenv('CLICOLOR_FORCE', '0') != '0'
 

--- a/tests/util/color_test.py
+++ b/tests/util/color_test.py
@@ -23,7 +23,7 @@ def expect_disabled(text: str):
         assert colorize(text, color) == text
 
 
-def test_colorize_1(monkeypatch):
+def test_colorize_enabled_terminal_disabled_piped(monkeypatch):
     monkeypatch.setenv('CLICOLOR', '1')
 
     if stdout.isatty():
@@ -32,13 +32,13 @@ def test_colorize_1(monkeypatch):
         expect_disabled('abc')
 
 
-def test_colorize_2(monkeypatch):
+def test_colorize_enabled_force(monkeypatch):
     monkeypatch.setenv('CLICOLOR_FORCE', '1')
 
     expect_enabled('abc')
 
 
-def test_colorize_3(monkeypatch):
+def test_colorize_disabled(monkeypatch):
     monkeypatch.setenv('CLICOLOR', '0')
 
     expect_disabled('abc')

--- a/tests/util/color_test.py
+++ b/tests/util/color_test.py
@@ -1,0 +1,44 @@
+from sys import stdout
+
+from detect_secrets.util.color import AnsiColor
+from detect_secrets.util.color import colorize
+
+
+def colorize_enabled(text: str, color: AnsiColor) -> str:
+    return '\x1b{}{}\x1b{}'.format(
+        color.value,
+        text,
+        AnsiColor.RESET.value,
+    )
+
+
+def expect_enabled(text: str):
+    for color in AnsiColor:
+        expected = colorize_enabled(text, color)
+        assert colorize(text, color) == expected
+
+
+def expect_disabled(text: str):
+    for color in AnsiColor:
+        assert colorize(text, color) == text
+
+
+def test_colorize_1(monkeypatch):
+    monkeypatch.setenv('CLICOLOR', '1')
+
+    if stdout.isatty():
+        expect_enabled('abc')
+    else:
+        expect_disabled('abc')
+
+
+def test_colorize_2(monkeypatch):
+    monkeypatch.setenv('CLICOLOR_FORCE', '1')
+
+    expect_enabled('abc')
+
+
+def test_colorize_3(monkeypatch):
+    monkeypatch.setenv('CLICOLOR', '0')
+
+    expect_disabled('abc')


### PR DESCRIPTION
We are using this tool in an environment that doesn't support ANSI Color code. So we have made a small change to enable them only when the environment supports them.

![image](https://user-images.githubusercontent.com/92514278/157423936-d96bc90b-f309-4a57-a4bb-948bbddf432a.png)


> We referred to this website to construct the `support_ansi_colors` function
> https://bixense.com/clicolors/