### PR TITLE
Make is_likely_id_string More Strict

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -68,7 +68,7 @@ def is_likely_id_string(secret: str, line: str) -> bool:
 
 @lru_cache(maxsize=1)
 def _get_id_detector_regex() -> Pattern:
-    return re.compile(r'id[^a-z0-9]', re.IGNORECASE)
+    return re.compile(r'^(id|myid|userid)|_id[^a-z0-9]', re.IGNORECASE)
 
 
 def is_non_text_file(filename: str) -> bool:

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -63,6 +63,12 @@ class TestIsLikelyIdString:
             ('RANDOM_STRING', 'myid: RANDOM_STRING'),
             ('RANDOM_STRING', 'myid=RANDOM_STRING'),
             ('RANDOM_STRING', 'myid = RANDOM_STRING'),
+            ('RANDOM_STRING', 'userid: RANDOM_STRING'),
+            ('RANDOM_STRING', 'userid=RANDOM_STRING'),
+            ('RANDOM_STRING', 'userid = RANDOM_STRING'),
+            ('RANDOM_STRING', 'data test_id: RANDOM_STRING'),
+            ('RANDOM_STRING', 'data test_id=RANDOM_STRING'),
+            ('RANDOM_STRING', 'data test_id = RANDOM_STRING'),
         ],
     )
     def test_success(self, secret, line):
@@ -79,6 +85,9 @@ class TestIsLikelyIdString:
 
             # fail silently if the secret isn't even on the line
             ('SOME_RANDOM_STRING', 'id: SOME_OTHER_RANDOM_STRING'),
+
+            # fail if the word david ends in id
+            ('RANDOM_STRING', 'postgres://david:RANDOM_STRING'),
         ],
     )
     def test_failure(self, secret, line):


### PR DESCRIPTION
Issue: [489](https://github.com/Yelp/detect-secrets/issues/489)

Problem:
- The `is_likely_id_string` regex can eliminate true positives by mistake.
- Ex. Anything ending in `id` like the name `david` followed by a non-letter/non-numeric character will match

Solution:
- Make the regex more strict to identify id strings.
- This can be achieved by enforcing the string starts with the `id` identifier however we lose out on the other typical id_string identifiers like `myid`, `userid` etc.
- We can enforce these additional identifiers
- Also enforce the `_id` identifier and this can exist in the middle of a string