### PR TITLE
Add Occurences to Potential Secrets

### DIFF
--- a/detect_secrets/core/baseline.py
+++ b/detect_secrets/core/baseline.py
@@ -85,6 +85,7 @@ def format_for_output(secrets: SecretsCollection, is_slim_mode: bool = False) ->
         ).items():
             for secret_dict in secret_list:
                 secret_dict.pop('line_number')
+                secret_dict.pop('occurrences')
 
     return output
 

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -29,6 +29,7 @@ class PotentialSecret:
         line_number: int = 0,
         is_secret: Optional[bool] = None,
         is_verified: bool = False,
+        occurrences: int = 0,
     ) -> None:
         """
         :param type: human-readable secret type, defined by the plugin
@@ -46,6 +47,7 @@ class PotentialSecret:
         self.set_secret(secret)
         self.is_secret = is_secret
         self.is_verified = is_verified
+        self.occurrences = occurrences
 
         # If two PotentialSecrets have the same values for these fields,
         # they are considered equal. Note that line numbers aren't included
@@ -84,6 +86,7 @@ class PotentialSecret:
             'line_number',
             'is_secret',
             'is_verified',
+            'occurrences',
         }:
             if parameter in data:
                 kwargs[parameter] = data[parameter]
@@ -101,6 +104,7 @@ class PotentialSecret:
             'filename': self.filename,
             'hashed_secret': self.secret_hash,
             'is_verified': self.is_verified,
+            'occurrences': self.occurrences,
         }
 
         if self.line_number:

--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -104,7 +104,6 @@ class PotentialSecret:
             'filename': self.filename,
             'hashed_secret': self.secret_hash,
             'is_verified': self.is_verified,
-            'occurrences': self.occurrences,
         }
 
         if self.line_number:
@@ -112,6 +111,9 @@ class PotentialSecret:
 
         if self.is_secret is not None:
             attributes['is_secret'] = self.is_secret
+
+        if self.occurrences:
+            attributes['occurrences'] = self.occurrences
 
         return attributes
 

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -62,7 +62,7 @@ def handle_scan_action(args: argparse.Namespace) -> None:
             root=args.custom_root,
         ):
             for secret in scan_for_allowlisted_secrets_in_file(filename):
-                secrets[secret.filename].add(secret)
+                secrets[secret.filename].append(secret)
 
         print(json.dumps(baseline.format_for_output(secrets), indent=2))
         return

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -57,6 +57,7 @@ class BasePlugin(metaclass=ABCMeta):
                     filename=filename,
                     secret=match,
                     line_number=line_number,
+                    occurrences=1,
                 ),
             )
 

--- a/test_data/files/file_with_duplicate_secrets.py
+++ b/test_data/files/file_with_duplicate_secrets.py
@@ -1,0 +1,2 @@
+tokenA = 'gX69YO4CvBsVjzAwYxdGyDd30t5+9ez31gKATtj4'
+tokenB = 'gX69YO4CvBsVjzAwYxdGyDd30t5+9ez31gKATtj4'

--- a/testing/factories.py
+++ b/testing/factories.py
@@ -8,6 +8,7 @@ def potential_secret_factory(
     filename: str = 'filename',
     secret: str = 'secret',
     line_number: int = 1,
+    occurrences: int = 1,
     **kwargs: Any,
 ) -> PotentialSecret:
     """This is only marginally better than creating PotentialSecret objects directly,
@@ -18,5 +19,6 @@ def potential_secret_factory(
         filename=filename,
         secret=secret,
         line_number=line_number,
+        occurrences=occurrences,
         **kwargs
     )

--- a/tests/audit/analytics_test.py
+++ b/tests/audit/analytics_test.py
@@ -58,7 +58,7 @@ def test_basic_statistics_json(printer):
 )
 def test_no_divide_by_zero(secret):
     secrets = SecretsCollection()
-    secrets['file'].add(secret)
+    secrets['file'].append(secret)
     with tempfile.NamedTemporaryFile() as f:
         baseline.save_to_file(secrets, f.name)
         f.seek(0)

--- a/tests/audit/audit_test.py
+++ b/tests/audit/audit_test.py
@@ -33,7 +33,7 @@ def test_nothing_to_audit(printer):
 
 def test_file_no_longer_exists():
     secrets = SecretsCollection()
-    secrets['non-existent'].add(potential_secret_factory())
+    secrets['non-existent'].append(potential_secret_factory())
 
     run_logic(secrets)
 

--- a/tests/audit/compare_test.py
+++ b/tests/audit/compare_test.py
@@ -119,10 +119,10 @@ def parse_ordering(printer) -> str:
 
 def test_file_no_longer_exists(printer, mock_user_decision):
     secretsA = SecretsCollection()
-    secretsA['fileB'].add(potential_secret_factory('a'))
+    secretsA['fileB'].append(potential_secret_factory('a'))
 
     secretsB = SecretsCollection()
-    secretsB['fileA'].add(potential_secret_factory('a'))
+    secretsB['fileA'].append(potential_secret_factory('a'))
 
     run_logic(secretsA, secretsB)
     assert not mock_user_decision.called
@@ -149,7 +149,7 @@ def run_logic(secretsA: SecretsCollection, secretsB: SecretsCollection):
 def get_secrets(*secrets) -> SecretsCollection:
     output = SecretsCollection()
     for secret in secrets:
-        output[secret.filename].add(secret)
+        output[secret.filename].append(secret)
 
     return output
 

--- a/tests/core/potential_secret_test.py
+++ b/tests/core/potential_secret_test.py
@@ -52,6 +52,9 @@ def test_json():
             'is_secret': True,
             'is_verified': False,
         },
+        {
+            'occurrences': 2,
+        },
     ),
 )
 def test_load_secret_from_dict(kwargs):

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -105,6 +105,13 @@ class TestScanFile:
         ]
 
     @staticmethod
+    def test_jp():
+        secrets = SecretsCollection()
+        secrets.scan_file('docs/design.md')
+
+        print(secrets)
+
+    @staticmethod
     def test_file_based_yaml_only_comments():
         secrets = SecretsCollection()
         secrets.scan_file('test_data/only_comments.yaml')
@@ -332,11 +339,11 @@ class TestEqual:
     def test_strict_equality():
         secret = potential_secret_factory()
         secretsA = SecretsCollection()
-        secretsA[secret.filename].add(secret)
+        secretsA[secret.filename].append(secret)
 
         secret = potential_secret_factory(line_number=2)
         secretsB = SecretsCollection()
-        secretsB[secret.filename].add(secret)
+        secretsB[secret.filename].append(secret)
 
         assert secretsA == secretsB
         assert not secretsA.exactly_equals(secretsB)

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -105,13 +105,6 @@ class TestScanFile:
         ]
 
     @staticmethod
-    def test_jp():
-        secrets = SecretsCollection()
-        secrets.scan_file('docs/design.md')
-
-        print(secrets)
-
-    @staticmethod
     def test_file_based_yaml_only_comments():
         secrets = SecretsCollection()
         secrets.scan_file('test_data/only_comments.yaml')
@@ -135,6 +128,15 @@ class TestScanFile:
         secrets.scan_file(filename)
 
         assert bool(secrets)
+
+    @staticmethod
+    def test_duplicate_secrets_occurrences():
+        secrets = SecretsCollection()
+        secrets.scan_file('test_data/files/file_with_duplicate_secrets.py')
+
+        secret = next(iter(secrets['test_data/files/file_with_duplicate_secrets.py']))
+        assert len(secrets['test_data/files/file_with_duplicate_secrets.py']) == 1
+        assert secret.occurrences == 2
 
 
 class TestScanDiff:


### PR DESCRIPTION
A potential secret is uniquely identified by three main properties: `filename, secret_hash, type`. Since `line_number` is not included this means we will only track a single potential secret in a file although it may appear on multiple lines. This is a fundamental design decision. 

The idea behind this pull request is to give users some insight to how many occurences a potential secret is showing up in their files. This does not violate the fundamental design above but rather serves as an improvement hopefully giving better insight to developers on the overall scope of their potential secrets. 

One of the key changes is changing the `SecretsCollection` data structure from a `Set` to a `List`. The reasoning behind this decision is when we are scanning through the file - we do not only want to deny duplicate secrets to the data structure but alter the existing potential secrets occurrences. `List` gives us a lot of flexibility with changing properties in the data structure while `Set` is a little restricted. The new `List` will operate almost identically to the previous `Set` in terms of not allowing duplicate secrets but with the addition of tracking occurrences. 

The `occurrences` property will operate very similar to the `line_number` property. They are similar in the way that we will not alert on the change of this property but rather only notify the user that the baseline file changed with updated information on their secrets. 