### PR TITLE
Added checks to avoid AttributeError in potential_secret.py

### DIFF
--- a/detect_secrets/core/potential_secret.py
+++ b/detect_secrets/core/potential_secret.py
@@ -103,10 +103,10 @@ class PotentialSecret:
             'is_verified': self.is_verified,
         }
 
-        if self.line_number:
+        if hasattr(self, 'line_number') and self.line_number:
             attributes['line_number'] = self.line_number
 
-        if self.is_secret is not None:
+        if hasattr(self, 'is_secret') and self.is_secret is not None:
             attributes['is_secret'] = self.is_secret
 
         return attributes


### PR DESCRIPTION
## Description:
These changes are an attempt to fix the issue described in #479. Based on some research I made, it appears that the issue is caused by multithreading [1]. This _theory_ is reinforced by what was previously described by the same reported in #471. Thus, I added some additional checks that make sure `PotentialSecret` has the attributes it is supposed to have before accessing them.

[1] https://stackoverflow.com/a/31701465
## Testing Done:
✅ `python -m pytest tests`

## Note:
This is a band-aid fix more than anything, as this could lead to the line number not being added at all when this multithreading issue occurs. This should not be a problem, s #471 mentioned it happens using the slim version of the baseline, but it might need further investigation on a more definitive fix.