### PR TITLE
Fixing npm detector

### DIFF
--- a/detect_secrets/plugins/npm.py
+++ b/detect_secrets/plugins/npm.py
@@ -13,5 +13,5 @@ class NpmDetector(RegexBasedDetector):
     denylist = [
         # npmrc authToken
         # ref. https://stackoverflow.com/questions/53099434/using-auth-tokens-in-npmrc
-        re.compile(r'\/\/.+\/:_authToken=.+'),
+        re.compile(r'\/\/.+\/:_authToken=\s*((npm_.+)|([A-Fa-f0-9-]{36})).*'),
     ]

--- a/tests/plugins/npm_test.py
+++ b/tests/plugins/npm_test.py
@@ -8,12 +8,16 @@ class TestNpmDetector:
     @pytest.mark.parametrize(
         'payload, should_flag',
         [
-            ('//registry.npmjs.org/:_authToken=xxxxxxxxxxxxxxxxxxxx', True),
-            ('//registry.npmjs.org:_authToken=xxxxxxxxxxxxxxxxxxxx', False),
-            ('registry.npmjs.org/:_authToken=xxxxxxxxxxxxxxxxxxxx', False),
-            ('///:_authToken=xxxxxxxxxxxxxxxxxxxx', False),
-            ('_authToken=xxxxxxxxxxxxxxxxxxxx', False),
+            ('//registry.npmjs.org/:_authToken=743b294a-cd03-11ec-9d64-0242ac120002', True),
+            ('//registry.npmjs.org/:_authToken=346a14f2-a672-4668-a892-956a462ab56e', True),
+            ('//registry.npmjs.org/:_authToken= 743b294a-cd03-11ec-9d64-0242ac120002', True),
+            ('//registry.npmjs.org/:_authToken=npm_xxxxxxxxxxx', True),
+            ('//registry.npmjs.org:_authToken=743b294a-cd03-11ec-9d64-0242ac120002', False),
+            ('registry.npmjs.org/:_authToken=743b294a-cd03-11ec-9d64-0242ac120002', False),
+            ('///:_authToken=743b294a-cd03-11ec-9d64-0242ac120002', False),
+            ('_authToken=743b294a-cd03-11ec-9d64-0242ac120002', False),
             ('foo', False),
+            ('//registry.npmjs.org/:_authToken=${NPM_TOKEN}', False),
         ],
     )
     def test_analyze(self, payload, should_flag):


### PR DESCRIPTION
The npm detector incorrectly detects environment variables. The patch adds a test for this and improves the detector to check for the format of "authToken=" with one or more whitespace characters and then either:

- a UUID
- or npm_ with some characters (https://github.blog/2021-09-23-announcing-npms-new-access-token-format/)