### PR TITLE
#467: Catch ValueError - Audit

### DIFF
--- a/detect_secrets/util/code_snippet.py
+++ b/detect_secrets/util/code_snippet.py
@@ -3,6 +3,7 @@ from typing import List
 
 from .color import AnsiColor
 from .color import colorize
+from detect_secrets.exceptions import SecretNotFoundOnSpecifiedLineError
 
 
 def get_code_snippet(
@@ -71,16 +72,19 @@ class CodeSnippet:
         """
         :param payload: string to highlight, on chosen line
         """
-        index_of_payload = self.target_line.lower().index(payload.lower())
-        end_of_payload = index_of_payload + len(payload)
+        try:
+            index_of_payload = self.target_line.lower().index(payload.lower())
+            end_of_payload = index_of_payload + len(payload)
 
-        self.target_line = u'{}{}{}'.format(
-            self.target_line[:index_of_payload],
-            self.apply_highlight(self.target_line[index_of_payload:end_of_payload]),
-            self.target_line[end_of_payload:],
-        )
+            self.target_line = u'{}{}{}'.format(
+                self.target_line[:index_of_payload],
+                self.apply_highlight(self.target_line[index_of_payload:end_of_payload]),
+                self.target_line[end_of_payload:],
+            )
 
-        return self
+            return self
+        except ValueError:
+            raise SecretNotFoundOnSpecifiedLineError(self.target_index)
 
     def get_line_number(self, line_number: int) -> str:
         """Broken out, for custom colorization."""


### PR DESCRIPTION
Problem: 
- There is an existing issue with the YAML file parser with respect to block vs literal style
- This causes secret line numbers to be 1 off the actual line number
- When performing an audit - and the secret line number is off by 1, an error causing the tool to fail occurs since the secret cannot be found on that line

Solution:
- Catch the error when we cannot find the secret on that specified line
- Will be looking into how to fix the YAML parser to accomodate for block vs literal styles