### PR TITLE
#559: Refactor AWS Access Key Regex To Minimize False Positives

### DIFF
--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -22,13 +22,21 @@ class AWSKeyDetector(RegexBasedDetector):
     """Scans for AWS keys."""
     secret_type = 'AWS Access Key'
 
+    secret_keyword = r'(?:key|pwd|pw|password|pass|token)'
+
     denylist = (
         re.compile(r'AKIA[0-9A-Z]{16}'),
 
         # This examines the variable name to identify AWS secret tokens.
         # The order is important since we want to prefer finding `AKIA`-based
         # keys (since they can be verified), rather than the secret tokens.
-        re.compile(r'aws.{0,20}?[\'\"]([0-9a-zA-Z/+]{40})[\'\"]'),
+
+        re.compile(
+            r'aws.{{0,20}}?{secret_keyword}.{{0,20}}?[\'\"]([0-9a-zA-Z/+]{{40}})[\'\"]'.format(
+                secret_keyword=secret_keyword,
+            ),
+            flags=re.IGNORECASE,
+        ),
     )
 
     def verify(       # type: ignore[override]  # noqa: F821

--- a/tests/core/secrets_collection_test.py
+++ b/tests/core/secrets_collection_test.py
@@ -173,7 +173,7 @@ class TestScanDiff:
 def test_merge():
     old_secrets = SecretsCollection()
     old_secrets.scan_file('test_data/each_secret.py')
-    assert len(list(old_secrets)) >= 3      # otherwise, this test won't work.
+    assert len(list(old_secrets)) >= 4      # otherwise, this test won't work.
 
     index = 0
     for _, secret in old_secrets:
@@ -188,7 +188,7 @@ def test_merge():
 
     new_secrets = SecretsCollection()
     new_secrets.scan_file('test_data/each_secret.py')
-    list(new_secrets)[-1][1].is_secret = True
+    list(new_secrets)[-2][1].is_secret = True
 
     new_secrets.merge(old_secrets)
 
@@ -203,6 +203,9 @@ def test_merge():
         elif index == 2:
             assert secret.is_secret is True
             assert secret.is_verified is True
+        elif index == 3:
+            assert secret.is_secret is None
+            assert secret.is_verified is False
 
         index += 1
 
@@ -370,8 +373,8 @@ class TestSubtraction:
         assert secrets != baseline
 
         result = secrets - baseline
-        assert len(result['test_data/each_secret.py']) == 2
-        assert len(secrets['test_data/each_secret.py']) == 4
+        assert len(result['test_data/each_secret.py']) == 3
+        assert len(secrets['test_data/each_secret.py']) == 5
 
     @staticmethod
     def test_no_overlapping_files(configure_plugins):


### PR DESCRIPTION
Problem:
- The AWS plugin is producing false positives for example: 
`"aws:cdk:path": "VaDataVaultCdkPoc/rBucketKeyCdk/Resource"`
- The regex for the real secret is correct since all aws secret access keys follow the format `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`
- However, there is no restriction on the variable name other than that it must prefix with `aws` followed by any characters

Solution:
- The solution here is to add another restriction in addition to the `aws` prefix which is adding that there must be some form of secret keyword like `key|pwd|pw|password|pass|token` in the variable name
- This will allow us to constrain the subset of results filtering out some false postiives ensuring the variable name is prefixed with `aws`, must contain a secret keyword, and the secret regex must match the standard aws format. 
- Please Note: I also increased the allowed variable name length. The reasoning behind this is a user can potentially set this to something longer than the original 20 characters. Also multiple other aws resource identifier names are longer than 20 characters. 
- Some tests needed to be updated since one test case `aws_secret_access_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'` was not picked up by the AWS detector since the variable name was too long. This in my opinion should be detected. It is detected as an `AWS Access Key` and detected as a `Base64 High Entropy String`