### PR TITLE
Persist '# pragma: allowlist nextline secret' in IniFileParser For ConfigFileTransformers

### DIFF
--- a/detect_secrets/filters/allowlist.py
+++ b/detect_secrets/filters/allowlist.py
@@ -58,18 +58,18 @@ def _get_allowlist_regexes_for_file(filename: str) -> Iterable[List[Pattern]]:
         comment_tuples = [comment_tuples[_get_file_to_index_dict()[ext[1:]]]]
 
     yield [
-        _get_allowlist_regexes(comment_tuple=t, nextline=False)
+        get_allowlist_regexes(comment_tuple=t, nextline=False)
         for t in comment_tuples
     ]
     yield [
-        _get_allowlist_regexes(comment_tuple=t, nextline=True)
+        get_allowlist_regexes(comment_tuple=t, nextline=True)
         for t in comment_tuples
     ]
 
 
 # Note: Cache size should be 2x the number of comment types
 @lru_cache(maxsize=12)
-def _get_allowlist_regexes(comment_tuple: Tuple[str, str], nextline: bool) -> Pattern:
+def get_allowlist_regexes(comment_tuple: Tuple[str, str], nextline: bool) -> Pattern:
     start = comment_tuple[0]
     end = comment_tuple[1]
     return re.compile(

--- a/detect_secrets/transformers/config.py
+++ b/detect_secrets/transformers/config.py
@@ -232,7 +232,7 @@ def _construct_values_list(values: str) -> List[str]:
     return values_list
 
 
-def _is_allowlist_nextline_secret_comment(line):
+def _is_allowlist_nextline_secret_comment(line: str) -> bool:
     # Valid tuples for config file comments (start_char, end_char)
     comment_tuple = [('#', ''), (';', '')]
 


### PR DESCRIPTION
# Problem
- `# pragma: allowlist nextline secret` are not filtered out and secrets on the proceeding line are alerted on
- This is an issue with the `ConfigFileTransformer` which leverages the `IniFileParser`
- The transformer and the parser does not track comments in files - This is why our logic is alerting on the secrets which should be whitelisted

# Solution
- When parsing files in the `IniFileParser` persist comments that match the allowlist_nextline_secret comment
- We do not want to keep all comments and we do not want to keep allowlist_secret comment (Which occur on the same line as a secret) since this is working properly