### PR TITLE
Fix is_verified not stored in PotentialSecret

### DIFF
--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -17,6 +17,7 @@ from ..transformers import get_transformed_file
 from ..types import NamedIO
 from ..types import SelfAwareCallable
 from ..util import git
+from ..util.code_snippet import CodeSnippet
 from ..util.code_snippet import get_code_snippet
 from ..util.inject import call_function_with_arguments
 from ..util.path import get_relative_path
@@ -112,6 +113,7 @@ def scan_line(line: str) -> Generator[PotentialSecret, None, None]:
         'detect_secrets.filters.common.is_invalid_file',
     )
     get_filters.cache_clear()
+    context = get_code_snippet(lines=[line], line_number=1)
 
     yield from (
         secret
@@ -122,6 +124,7 @@ def scan_line(line: str) -> Generator[PotentialSecret, None, None]:
             line=line,
             line_number=0,
             enable_eager_search=True,
+            context=context,
         )
         if not _is_filtered_out(
             required_filter_parameters=['context'],
@@ -129,10 +132,7 @@ def scan_line(line: str) -> Generator[PotentialSecret, None, None]:
             secret=secret.secret_value,
             plugin=plugin,
             line=line,
-            context=get_code_snippet(
-                lines=[line],
-                line_number=1,
-            ),
+            context=context,
         )
     )
 
@@ -225,10 +225,11 @@ def _scan_for_allowlisted_secrets_in_lines(
     line_numbers, lines = zip(*lines)
     line_content = [line.rstrip() for line in lines]
     for line_number, line in zip(line_numbers, line_content):
+        context = get_code_snippet(line_content, line_number)
         if not is_line_allowlisted(
             filename,
             line,
-            context=get_code_snippet(line_content, line_number),
+            context=context,
         ):
             continue
 
@@ -236,7 +237,7 @@ def _scan_for_allowlisted_secrets_in_lines(
             continue
 
         for plugin in get_plugins():
-            yield from _scan_line(plugin, filename, line, line_number)
+            yield from _scan_line(plugin, filename, line, line_number, context)
 
 
 def _get_lines_from_file(filename: str) -> Generator[List[str], None, None]:
@@ -323,7 +324,7 @@ def _process_line_based_plugins(
         yield from (
             secret
             for plugin in get_plugins()
-            for secret in _scan_line(plugin, filename, line, line_number)
+            for secret in _scan_line(plugin, filename, line, line_number, code_snippet)
             if not _is_filtered_out(
                 required_filter_parameters=['context'],
                 filename=secret.filename,
@@ -340,6 +341,7 @@ def _scan_line(
     filename: str,
     line: str,
     line_number: int,
+    context: CodeSnippet,
     **kwargs: Any,
 ) -> Generator[PotentialSecret, None, None]:
     # NOTE: We don't apply filter functions here yet, because we don't have any filters
@@ -349,6 +351,7 @@ def _scan_line(
         filename=filename,
         line=line,
         line_number=line_number,
+        context=context,
         **kwargs,
     )
     if not secrets:

--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -11,6 +11,7 @@ from typing import Set
 
 from ..core.potential_secret import PotentialSecret
 from .base import BasePlugin
+from detect_secrets.util.code_snippet import CodeSnippet
 
 
 class HighEntropyStringsPlugin(BasePlugin, metaclass=ABCMeta):
@@ -45,10 +46,16 @@ class HighEntropyStringsPlugin(BasePlugin, metaclass=ABCMeta):
         filename: str,
         line: str,
         line_number: int = 0,
+        context: CodeSnippet = None,
         enable_eager_search: bool = False,
         **kwargs: Any,
     ) -> Set[PotentialSecret]:
-        output = super().analyze_line(filename=filename, line=line, line_number=line_number)
+        output = super().analyze_line(
+            filename=filename,
+            line=line,
+            line_number=line_number,
+            context=context,
+        )
         if output or not enable_eager_search:
             # NOTE: We perform the limit filter at this layer (rather than analyze_string) so
             # that we can surface secrets that do not meet the limit criteria when

--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -36,6 +36,7 @@ from ..core.potential_secret import PotentialSecret
 from ..util.filetype import determine_file_type
 from ..util.filetype import FileType
 from .base import BasePlugin
+from detect_secrets.util.code_snippet import CodeSnippet
 
 
 # Note: All values here should be lowercase
@@ -306,6 +307,7 @@ class KeywordDetector(BasePlugin):
         filename: str,
         line: str,
         line_number: int = 0,
+        context: CodeSnippet = None,
         **kwargs: Any,
     ) -> Set[PotentialSecret]:
         filetype = determine_file_type(filename)
@@ -314,6 +316,7 @@ class KeywordDetector(BasePlugin):
             filename=filename,
             line=line,
             line_number=line_number,
+            context=context,
             denylist_regex_to_group=denylist_regex_to_group,
         )
 

--- a/tests/filters/common_filter_test.py
+++ b/tests/filters/common_filter_test.py
@@ -1,4 +1,5 @@
 import re
+from unittest import mock
 
 import pytest
 import requests
@@ -44,7 +45,12 @@ class TestVerify:
         # NOTE: This test case relies on the fact that this file contains a multi-factor
         # AWS KeyPair.
         with register_plugin(ContextAwareMockPlugin()):
-            main_module.main(['scan', 'test_data/each_secret.py'])
+            with mock.patch(
+                'detect_secrets.plugins.aws.verify_aws_secret_access_key',
+                return_value=False,
+            ):
+
+                main_module.main(['scan', 'test_data/each_secret.py'])
 
     @staticmethod
     def test_handles_request_error_gracefully():

--- a/tests/plugins/base_test.py
+++ b/tests/plugins/base_test.py
@@ -1,4 +1,14 @@
+from typing import Generator
+
+import pytest
+import requests
+
+from detect_secrets.constants import VerifiedResult
 from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
+from detect_secrets.plugins.base import BasePlugin
+from detect_secrets.settings import get_settings
+from detect_secrets.util.code_snippet import CodeSnippet
+from detect_secrets.util.code_snippet import get_code_snippet
 
 
 def test_ensure_all_plugins_have_unique_secret_types():
@@ -7,3 +17,96 @@ def test_ensure_all_plugins_have_unique_secret_types():
         secret_types.add(plugin_type.secret_type)
 
     assert len(secret_types) == len(get_mapping_from_secret_type_to_class())
+
+
+class MockPlugin(BasePlugin):
+    secret_type = 'MockPlugin'
+
+    def __init__(self, verify_result: VerifiedResult):
+        self.verify_result = verify_result
+        self.verify_call_count = 0
+
+    def verify(self, secret: str, context: CodeSnippet) -> VerifiedResult:
+        self.verify_call_count += 1
+        return self.verify_result
+
+    def analyze_string(self, string: str) -> Generator[str, None, None]:
+        yield string
+
+
+class MockExceptionRaisingPlugin(BasePlugin):
+    secret_type = 'MockExceptionRaisingPlugin'
+
+    def analyze_string(self, string: str) -> Generator[str, None, None]:
+        yield string
+
+    def verify(self, secret: str, context: CodeSnippet):
+        raise requests.exceptions.Timeout
+
+
+class TestAnalyzeLine():
+    def setup(self):
+        self.line = 'some-secret'
+        self.filename = 'secrets.py'
+        self.context = get_code_snippet(lines=[self.line], line_number=1)
+
+    @pytest.mark.parametrize(
+        'verified_result ,is_verified',
+        [
+            (VerifiedResult.UNVERIFIED, False),
+            (VerifiedResult.VERIFIED_FALSE, False),
+            (VerifiedResult.VERIFIED_TRUE, True),
+        ],
+    )
+    def test_potential_secret_constructed_correctly(self, verified_result, is_verified):
+        self._enable_filter()
+        plugin = MockPlugin(verified_result)
+        output = plugin.analyze_line(
+            filename=self.filename,
+            line=self.line,
+            line_number=1,
+            context=self.context,
+        )
+        secret = list(output)[0]
+        assert secret.secret_value == self.line
+        assert secret.type == plugin.secret_type
+        assert secret.filename == self.filename
+        assert secret.line_number == 1
+        assert secret.is_verified == is_verified
+
+    def test_no_verification_call_if_verification_filter_is_disabled(self):
+        self._disable_filter()
+        plugin = MockPlugin(VerifiedResult.VERIFIED_TRUE)
+        output = plugin.analyze_line(
+            filename=self.filename,
+            line=self.line,
+            line_number=1,
+            context=self.context,
+        )
+        secret = list(output)[0]
+        assert secret.is_verified is False
+        assert plugin.verify_call_count == 0
+
+    def test_handle_verify_exception_gracefully(self):
+        self._enable_filter()
+        plugin = MockExceptionRaisingPlugin()
+        output = plugin.analyze_line(
+            filename=self.filename,
+            line=self.line,
+            line_number=1,
+            context=self.context,
+        )
+        secret = list(output)[0]
+        assert secret.is_verified is False
+
+    def _enable_filter(self):
+        get_settings().filters[
+            'detect_secrets.filters.common.is_ignored_due_to_verification_policies'
+        ] = {
+            'min_value': 0,
+        }
+
+    def _disable_filter(self):
+        get_settings().disable_filters(
+            'detect_secrets.filters.common.is_ignored_due_to_verification_policies',
+        )


### PR DESCRIPTION
Problem:

- `is_verified` flag does not get stored in PotentialSecret which results in its value being always `false`. 
- This problem didn't affect `--only-verified` flag because verification was running but not persisted.

Solution:

- When a secret is found, run `verify` method and store the result within `PotentialSecret`.
-  pass down `CodeSnippet` to `analyze_line` as it is required to verify secrets in some plugins.
- `verify` will not run in case `--no-verify` flag was passed. 