### PR TITLE
add py.typed file to enable type hints for package consumers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(
     ],
     include_package_data=True,
     package_data={
-        "detect_secrets": ["py.typed"],
+        'detect_secrets': [
+            'py.typed',
+        ],
     },
     extras_require={
         'word_list': [
@@ -61,6 +63,6 @@ setup(
         'Environment :: Console',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
-        "Typing :: Typed",
+        'Typing :: Typed',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
         'requests',
     ],
     include_package_data=True,
+    package_data={
+        "detect_secrets": ["py.typed"],
+    },
     extras_require={
         'word_list': [
             'pyahocorasick',
@@ -58,5 +61,6 @@ setup(
         'Environment :: Console',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
+        "Typing :: Typed",
     ],
 )


### PR DESCRIPTION
Just added the missing `py.typed` file. So other projects, which add the project as a library will benefit from the inline type hints. Without this file type checkers, like `mypy`, think the whole project is untyped. And also added the `Typed` classifier to make it searchable in `pypi` 🙂 great work by the way 🚀 