### PR TITLE
Add bump2version config file upgrades

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,11 @@ description_file = README.md
 [bumpversion:file:detect_secrets/__version__.py]
 search = VERSION = '{current_version}'
 replace = VERSION = '{new_version}'
+
+[bumpversion:file:.secrets.baseline]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
+
+[bumpversion:file:README.md]
+search = rev: v{current_version}
+replace = rev: v{new_version}


### PR DESCRIPTION
Problem:
- During the release process we need to manually upgrade the `.secrets.baseline` and `README.md` to upgrade the version contained in those files.

Solution:
- Add bump2version config file methods to automatically search for versions in the `.secrets.baseline` and `README.md` and upgrade them during a release. 
- This eliminates 2 additional steps during a release and now release will become 1 step. 