### PR TITLE
Fixe #611: audit fails with custom plugin

### DIFF
--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -71,6 +71,7 @@ def default_settings() -> Generator['Settings', None, None]:
             for plugin_type in get_mapping_from_secret_type_to_class().values()
         ],
     }) as settings:
+        get_mapping_from_secret_type_to_class.cache_clear()
         yield settings
 
 


### PR DESCRIPTION
Clear a lru_cache when creating default_settings