### PR TITLE
Improve Release Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ If you love `detect-secrets`, please star our project on GitHub to show your sup
 
 #### :bug: Bugfixes
 - Fixed the verify flow in audit report by adding the code snippet of the verified secret ([#620])
+- Fixed deploy process to be environment configuration independent ([#625])
 
 #### :snake: Miscellaneous
 - Added support for .NET packages.lock.json files in the heuristic filter ([#593])
@@ -63,6 +64,7 @@ If you love `detect-secrets`, please star our project on GitHub to show your sup
 [#616]: https://github.com/Yelp/detect-secrets/pull/616
 [#619]: https://github.com/Yelp/detect-secrets/pull/619
 [#620]: https://github.com/Yelp/detect-secrets/pull/620
+[#625]: https://github.com/Yelp/detect-secrets/pull/625
 
 ### v1.3.0
 ##### July 22nd, 2022

--- a/scripts/bump-version
+++ b/scripts/bump-version
@@ -79,6 +79,9 @@ function installDependency() {
     # NOTE: We don't specify this in requirements-dev-minimal, since not all developers need
     # to bump the version.
     venv/bin/pip install bump2version
+    # Install local version of detect-secrets since when performing a commit, the pre-commit
+    # hook detect-secrets version (old) will be out of sync with the .secrets.baseline version (new)
+    venv/bin/pip install -e .
 }
 
 function setVersion() {


### PR DESCRIPTION
Problem:
- When releasing detect-secrets - different deployers may get different results depending on env setup
- Mainly revolving around if they are using a local copy of detect-secrets or not
- When deploying we perform a commit - therefore we run pre-commit hook detect-secrets. Since in the commit we just updated the .secrets.baseline to a new version. If the installed version of detect-secrets is different - the hook will fail.

Solution:
- When installing dependencies in the deploy process. Install a local copy of detect-secrets so there are no differences in .secrets.baseline upgraded version and old hook version. 