### PR TITLE
Improve `DiscordBotTokenDetector` and its tests.

### DIFF
--- a/detect_secrets/plugins/discord.py
+++ b/detect_secrets/plugins/discord.py
@@ -11,7 +11,8 @@ class DiscordBotTokenDetector(RegexBasedDetector):
     secret_type = 'Discord Bot Token'
 
     denylist = [
-        # Discord Bot Token ([M|N]XXXXXXXXXXXXXXXXXXXXXXX.XXXXXX.XXXXXXXXXXXXXXXXXXXXXXXXXXX)
+        # Discord Bot Token ([M|N|O]XXXXXXXXXXXXXXXXXXXXXXX[XX].XXXXXX.XXXXXXXXXXXXXXXXXXXXXXXXXXX)
         # Reference: https://discord.com/developers/docs/reference#authentication
-        re.compile(r'[MN][a-zA-Z\d_-]{23}\.[a-zA-Z\d_-]{6}\.[a-zA-Z\d_-]{27}'),
+        # Also see: https://github.com/Yelp/detect-secrets/issues/627
+        re.compile(r'[MNO][a-zA-Z\d_-]{23,25}\.[a-zA-Z\d_-]{6}\.[a-zA-Z\d_-]{27}'),
     ]

--- a/tests/plugins/discord_test.py
+++ b/tests/plugins/discord_test.py
@@ -22,17 +22,67 @@ class TestDiscordBotTokenDetector:
                 'MZ1yGvKTjE0rY0cV8i47CjAa.uRHQPq.Xb1Mk2nEhe-4iUcrGOuegj57zMC',
                 True,
             ),
-            # Random values to fail
+            # From https://github.com/Yelp/detect-secrets/issues/627
+            (
+                'OTUyNED5MDk2MTMxNzc2MkEz.YjESug.UNf-1GhsIG8zWT409q2C7Bh_zWQ',
+                True,
+            ),
+            (
+                'OTUyNED5MDk2MTMxNzc2MkEz.GSroKE.g2MTwve8OnUAAByz8KV_ZTV1Ipzg4o_NmQWUMs',
+                True,
+            ),
+            (
+                'MTAyOTQ4MTN5OTU5MTDwMEcxNg.GSwJyi.sbaw8msOR3Wi6vPUzeIWy_P0vJbB0UuRVjH8l8',
+                True,
+            ),
+            # Pass - token starts on the 3rd character (first segment is 24 characters)
+            (
+                'ATMyOTQ4MTN5OTU5MTDwMEcxNg.GSwJyi.sbaw8msOR3Wi6vPUzeIWy_P0vJbB0UuRVjH8l8',
+                True,
+            ),
+            # Pass - token starts on the 2nd character (first segment is 25 characters)
+            (
+                '=MTAyOTQ4MTN5OTU5MTDwMEcxN.GSwJyi.sbaw8msOR3Wi6vPUzeIWy_P0vJbB0UuRVjH8l8',
+                True,
+            ),
+            # Pass - token ends before the '!' (last segment is 27 characters)
+            (
+                'MTAyOTQ4MTN5OTU5MTDwMEcxNg.YjESug.UNf-1GhsIG8zWT409q2C7Bh_zWQ!4o_NmQWUMs',
+                True,
+            ),
+            # Fail - all segments too short (23.5.26)
             (
                 'MZ1yGvKTj0rY0cV8i47CjAa.uHQPq.Xb1Mk2nEhe-4icrGOuegj57zMC',
                 False,
             ),
+            # Fail - first segment too short (23.6.27)
             (
-                'SZ1yGvKTj0rY0cV8i47CjAa.uHQPq.Xb1Mk2nEhe-4icrGOuegj57zMC',
+                'MZ1yGvKTj0rY0cV8i47CjAa.uRHQPq.Xb1Mk2nEhe-4iUcrGOuegj57zMC',
                 False,
             ),
+            # Fail - middle segment too short (24.5.27)
             (
-                'MZ1yGvKTj0rY0cV8i47CjAa.uHQPq.Xb1Mk2nEhe-4icrGOuegj57zM',
+                'MZ1yGvKTjE0rY0cV8i47CjAa.uHQPq.Xb1Mk2nEhe-4iUcrGOuegj57zMC',
+                False,
+            ),
+            # Fail - last segment too short (24.6.26)
+            (
+                'MZ1yGvKTjE0rY0cV8i47CjAa.uRHQPq.Xb1Mk2nEhe-4iUcrGOuegj57zM',
+                False,
+            ),
+            # Fail - contains invalid character ','
+            (
+                'MZ1yGvKTjE0rY0cV8i47CjAa.uRHQPq.Xb1Mk2nEhe,4iUcrGOuegj57zMC',
+                False,
+            ),
+            # Fail - invalid first character 'P' (must be one of M/N/O)
+            (
+                'PZ1yGvKTjE0rY0cV8i47CjAa.uRHQPq.Xb1Mk2nEhe-4iUcrGOuegj57zMC',
+                False,
+            ),
+            # Fail - first segment 1 character too long; causes invalid first character 'T'
+            (
+                'MTAyOTQ4MTN5OTU5MTDwMEcxNg0.GSwJyi.sbaw8msOR3Wi6vPUzeIWy_P0vJbB0UuRVjH8l8',
                 False,
             ),
         ],


### PR DESCRIPTION
Fixes #627.

See the linked issue for more context. As mentioned, this is the "bare minimum" fix for the implementation. Lots of test cases have also been added and/or clarified.