### PR TITLE
Improve b261af9fbd8bfcc3f412ab48f283c1970e5841c0 (#568)

### DIFF
--- a/detect_secrets/audit/io.py
+++ b/detect_secrets/audit/io.py
@@ -9,6 +9,7 @@ from enum import Enum
 from ..types import SecretContext
 from ..util.color import AnsiColor
 from ..util.color import colorize
+from detect_secrets.exceptions import SecretNotFoundOnSpecifiedLineError
 
 
 def print_message(message: str) -> None:
@@ -34,7 +35,10 @@ def print_context(context: SecretContext) -> None:
 
     context.snippet.add_line_numbers()
     if context.secret.secret_value:
-        context.snippet.highlight_line(context.secret.secret_value)
+        try:
+            context.snippet.highlight_line(context.secret.secret_value)
+        except (ValueError, IndexError):
+            raise SecretNotFoundOnSpecifiedLineError(context.secret.line_number)
     else:
         context.snippet.target_line = colorize(context.snippet.target_line, AnsiColor.BOLD)
     print_message(str(context.snippet))

--- a/detect_secrets/util/code_snippet.py
+++ b/detect_secrets/util/code_snippet.py
@@ -3,7 +3,6 @@ from typing import List
 
 from .color import AnsiColor
 from .color import colorize
-from detect_secrets.exceptions import SecretNotFoundOnSpecifiedLineError
 
 
 def get_code_snippet(
@@ -72,19 +71,16 @@ class CodeSnippet:
         """
         :param payload: string to highlight, on chosen line
         """
-        try:
-            index_of_payload = self.target_line.lower().index(payload.lower())
-            end_of_payload = index_of_payload + len(payload)
+        index_of_payload = self.target_line.lower().index(payload.lower())
+        end_of_payload = index_of_payload + len(payload)
 
-            self.target_line = u'{}{}{}'.format(
-                self.target_line[:index_of_payload],
-                self.apply_highlight(self.target_line[index_of_payload:end_of_payload]),
-                self.target_line[end_of_payload:],
-            )
+        self.target_line = "{}{}{}".format(
+            self.target_line[:index_of_payload],
+            self.apply_highlight(self.target_line[index_of_payload:end_of_payload]),
+            self.target_line[end_of_payload:],
+        )
 
-            return self
-        except ValueError:
-            raise SecretNotFoundOnSpecifiedLineError(self.target_index)
+        return self
 
     def get_line_number(self, line_number: int) -> str:
         """Broken out, for custom colorization."""


### PR DESCRIPTION
- move try-except up the stack, so we actually have a line number and not only the column
- also catch IndexError (eg. if the file has fewer lines than secret.line_number)