### PR TITLE
Return actual secret strings for private keys when appear in same line

### DIFF
--- a/tests/plugins/private_key_test.py
+++ b/tests/plugins/private_key_test.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 from detect_secrets.core.secrets_collection import SecretsCollection
 from detect_secrets.settings import transient_settings
@@ -6,21 +7,41 @@ from testing.mocks import mock_named_temporary_file
 
 
 @pytest.mark.parametrize(
-    'file_content',
+    'file_content, secrets_amount, expected_secret',
     [
         (
-            '-----BEGIN RSA PRIVATE KEY-----\n'
-            'super secret private key here\n'
-            '-----END RSA PRIVATE KEY-----'
+            json.dumps(
+                '-----BEGIN RSA PRIVATE KEY-----\n'
+                'c3VwZXIgZHVwZXIgc2VjcmV0IHBhc3N3b3JkLCBzdXBlciBkdXBlciBzZ\n'
+                'WNyZXQgcGFzc3dvcmQhMTIzNCMkJQpzdXBlciBkdXBlciBzZWNyZXQgcGFzc3'
+                'dvcmQsIHN1cGVyIGR1cGVyIHNlY3JldCBwYXNzd29yZCExMjM0IyQlCgo=\n'
+                '-----END RSA PRIVATE KEY-----',
+            ),
+            1,
+            '\\nc3VwZXIgZHVwZXIgc2VjcmV0IHBhc3N3b3JkLCBzdXBlciBkdXBlciBzZ\\n'
+            'WNyZXQgcGFzc3dvcmQhMTIzNCMkJQpzdXBlciBkdXB'
+            'lciBzZWNyZXQgcGFzc3dvcmQsIHN1cGVyIGR1cGVyIHNlY3JldCBwYXNzd29yZCExMjM0IyQlCgo=',
         ),
         (
             'some text here\n'
             '-----BEGIN PRIVATE KEY-----\n'
-            'yabba dabba doo'
+            'c3VwZXIgZHVwZXIgc2VjcmV0IHBhc3N3b3JkLCBzdXBlciBkdXBlciBzZWNyZXQgcGFzc3'
+            'dvcmQhMTIzNCMkJQpzdXBlciBkdXBlciBzZWNyZXQgcGFzc3dvcmQsIHN1cGVyIGR1cGVy'
+            'IHNlY3JldCBwYXNzd29yZCExMjM0IyQlCgo=\n'
+            '-----END PRIVATE KEY-----',
+            1,
+            'BEGIN PRIVATE KEY-----',
+        ),
+        (
+            'some text here\n'
+            'PuTTY-User-Key-File-2\n'
+            'secret key',
+            1,
+            'PuTTY-User-Key-File-2',
         ),
     ],
 )
-def test_basic(file_content):
+def test_basic(file_content, secrets_amount, expected_secret):
     with mock_named_temporary_file() as f:
         f.write(file_content.encode())
         f.seek(0)
@@ -28,7 +49,9 @@ def test_basic(file_content):
         secrets = SecretsCollection()
         secrets.scan_file(f.name)
 
-    assert len(list(secrets)) == 1
+    temp_file = list(secrets.files)[0]
+    assert len(list(secrets)) == secrets_amount
+    assert list(secrets.data[temp_file])[0].secret_value == expected_secret
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Currently when private key secrets are detected, the secret value returns refers only to the generic `BEGIN PRIVATE KEY` opening and not to the secret key itself.
Ideally this should be handled as a multiline secret, since its mostly includeing new lines within it and so the opening wrapper is inspected in a different `scan_line` iteration that the key itself. 
For now, I added this change that returns the actual key, if the input is parsed in a way that escapes new line characters, like json.dumps(). So it still doesnt cover all of the use cases with the right secret value, but at least those that can be easily treated with the single line scanning method.