### PR TITLE
Gcp key detector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -21,6 +21,9 @@
       "name": "CloudantDetector"
     },
     {
+      "name":"GcpkeyDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -112,127 +115,8 @@
       ]
     }
   ],
-  "results": {
-    "detect_secrets/plugins/private_key.py": [
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
-        "is_verified": false,
-        "line_number": 45
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
-        "is_verified": false,
-        "line_number": 46
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
-        "is_verified": false,
-        "line_number": 47
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
-        "is_verified": false,
-        "line_number": 48
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 49
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
-        "is_verified": false,
-        "line_number": 50
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "9279619d0c9a9529b0b223e3b809f4df24b8ba8b",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Private Key",
-        "filename": "detect_secrets/plugins/private_key.py",
-        "hashed_secret": "11200d1bf5e1eb358b5d823c443347d97e982a85",
-        "is_verified": false,
-        "line_number": 52
-      }
-    ],
-    "detect_secrets/plugins/twilio.py": [
-      {
-        "type": "Twilio API Key",
-        "filename": "detect_secrets/plugins/twilio.py",
-        "hashed_secret": "34c2246140bc39b1fce81d9be2124f713a06bdaf",
-        "is_verified": false,
-        "line_number": 17
-      }
-    ],
-    "docs/audit.md": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "docs/audit.md",
-        "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
-        "is_verified": false,
-        "line_number": 25
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/audit.md",
-        "hashed_secret": "63e1b8ad9e948f948bc19035801e8529c4c94b13",
-        "is_verified": false,
-        "line_number": 25
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "docs/audit.md",
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/audit.md",
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_verified": false,
-        "line_number": 183
-      }
-    ],
-    "docs/design.md": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "docs/design.md",
-        "hashed_secret": "2785b2a1c217669b3bd8fbcb4516006e61181237",
-        "is_verified": false,
-        "line_number": 53
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/design.md",
-        "hashed_secret": "2785b2a1c217669b3bd8fbcb4516006e61181237",
-        "is_verified": false,
-        "line_number": 53
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/design.md",
-        "hashed_secret": "513e0a36963ae1e8431c041b744679ee578b7c44",
-        "is_verified": false,
-        "line_number": 200
-      }
-    ]
+  "results":{
+    
   },
   "generated_at": "2021-04-15T17:02:50Z"
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ BasicAuthDetector
 CloudantDetector
 DiscordBotTokenDetector
 GitHubTokenDetector
+GcpkeyDetector
 Base64HighEntropyString
 HexHighEntropyString
 IbmCloudIamDetector

--- a/detect_secrets/plugins/gcp_key.py
+++ b/detect_secrets/plugins/gcp_key.py
@@ -1,0 +1,17 @@
+import re
+from re import IGNORECASE
+from .base import RegexBasedDetector
+
+
+class GcpkeyDetector(RegexBasedDetector):
+
+    secret_type = 'google cloud API Token'
+
+    denylist = [
+        ## API Key  reference = https://developers.google.com/workspace/guides/create-credentials?hl=pt-br#oauth-client-id
+        re.compile(r'AIza[0-9a-zA-Z0-9_-]{35}'),   
+
+        #Oauth key  
+        re.compile(r'[0-9]+-[0-9A-Za-z_]{32}.apps.googleusercontent.com')
+        
+        ]

--- a/tests/plugins/gcp_api_test.py
+++ b/tests/plugins/gcp_api_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+from detect_secrets.plugins.gcp_key import GcpkeyDetector
+from detect_secrets.plugins.discord import DiscordBotTokenDetector
+
+
+class TestGcpKeyDetector:
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            # reference = https://cloud.google.com/docs/authentication/api-keys?hl=pt-br
+            ("AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe", True),
+
+            # random string for api key testing
+            ("AIZA SNDSAUDHS ASASA DSIAOSIA", False),
+
+            # changed oauth client-id 
+            ("625842392116-saklt1i2jf2bjbtf6gneknq3lrgg96ca.apps.googleusercontent.com", True)
+        ],
+    )
+    def test_analyze(self, payload, should_flag):
+        print(payload,should_flag)
+        assert payload != None
+        logic = GcpkeyDetector()
+        output = logic.analyze_line(filename='mock_filename', line=payload)
+        print(len(output))
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [X] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [X] All CI checks are green

* **What kind of change does this PR introduce?**
This changes adds to detect-secrets a new plugin to find Google Cloud API keys and oauth2 client ids.


* **What is the current behavior?**
When detect secrets finds a GCP API key in code, it shows the key as 64base key and as GCP Keys. 
With oauth2 cgp client-id the detect-secrets does not find it as secrets.



* **What is the new behavior (if this is a feature change)?**
With the currently changes, the detect secrets is now able to correctly show infos about GCP Keys.



* **Does this PR introduce a breaking change?**
No changes are need.

* **Other information**:
Hi, I'am Lucas and I working on a team where we are interested on using Detect-secrets in our CI pipeline. Although this projects is already completed and it has much plugins, we miss some of detections like GCP, Firebase and Facebook tokens plugins. And that's the reason I'am making this pull request, to help detect-secrets to help us and the community in general.