### PR TITLE
Drop py36 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,10 @@ sys     0m2.486s
 
 ### Running the Entire Test Suite
 
-You can run the test suite in the interpreter of your choice (in this example, `py36`) by doing:
+You can run the test suite in the interpreter of your choice (in this example, `py37`) by doing:
 
 ```bash
-tox -e py36
+tox -e py37
 ```
 
 This will also run the code through our series of coverage tests, `mypy` rules and other linting

--- a/detect_secrets/types.py
+++ b/detect_secrets/types.py
@@ -9,25 +9,6 @@ from .core.potential_secret import PotentialSecret
 from .exceptions import SecretNotFoundOnSpecifiedLineError
 from .util.code_snippet import CodeSnippet
 
-try:
-    from typing import NoReturn     # noqa: F811
-except ImportError:     # pragma: no cover
-    # NOTE: NoReturn was introduced in Python3.6.2. However, we need to support Python3.6.0.
-    # This section of code is inline imported from `typing-extensions`, so that we don't need
-    # to introduce an additional package for such an edge case.
-    from typing import _FinalTypingBase     # type: ignore
-
-    class _NoReturn(_FinalTypingBase):
-        __slots__ = ()
-
-        def __instancecheck__(self, obj: Any) -> None:
-            raise TypeError('NoReturn cannot be used with isinstance().')
-
-        def __subclasscheck__(self, cls: Any) -> None:
-            raise TypeError('NoReturn cannot be used with issubclass().')
-
-    NoReturn = _NoReturn(_root=True)
-
 
 class SelfAwareCallable:
     """

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,6 +1,4 @@
-# coveragepy==5.0 fails with `Safety level may not be changed inside a transaction
-# on python 3.6.0 (xenial)
-coverage<5
+coverage
 flake8==3.5.0
 gibberish-detector>=0.1.1
 monotonic

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 project = detect_secrets
 # These should match the ci python env list
-envlist = py{36,37,38,39},mypy
+envlist = py{37,38,39},mypy
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 
 [testenv]
 passenv = SSH_AUTH_SOCK
 # NO_PROXY is needed to call requests API within a forked process
-# when using macOS and python version 3.6/3.7
+# when using macOS and python version 3.7
 setenv =
     NO_PROXY = '*'
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
- Feature

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->
- Currently detect-secrets supports py36-39. 

* **What is the new behavior (if this is a feature change)?**
- Drop py36 support as it has reached EOL on December 23, 2021.

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->
- Yes. Upgrade python versions. 

* **Other information**:
