### PR TITLE
Restrict Golang Keyword Detection

### DIFF
--- a/detect_secrets/plugins/keyword.py
+++ b/detect_secrets/plugins/keyword.py
@@ -98,7 +98,7 @@ SQUARE_BRACKETS = r'(\[[0-9]*\])'
 
 FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX = re.compile(
     # e.g. my_password := "bar" or my_password := bar
-    r'{denylist}({closing})?{whitespace}:=?{whitespace}({quote}?)({secret})(\3)'.format(
+    r'{denylist}({closing})?{whitespace}:={whitespace}({quote}?)({secret})(\3)'.format(
         denylist=DENYLIST_REGEX,
         closing=CLOSING,
         quote=QUOTE,

--- a/tests/plugins/keyword_test.py
+++ b/tests/plugins/keyword_test.py
@@ -83,6 +83,8 @@ GOLANG_TEST_CASES = [
     ('password := "somefakekey"', None),    # 'fake' in the secret
     ('some_key = "real_secret"', None),     # We cannot make 'key' a Keyword, too noisy)
     ('private_key "hopenobodyfindsthisone\';', None),  # Double-quote does not match single-quote)
+    ('password: real_key', None),
+    ('password: "real_key"', None),
     (LONG_LINE, None),  # Long line test
 ]
 


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**
Bug Fix

* **What is the current behavior?**
[Issue](https://github.com/Yelp/detect-secrets/issues/629) was brought up that there are false positives for the goland keyword detector. This is verified since the regex that should be tracked - FOLLOWED_BY_COLON_EQUAL_SIGNS_REGEX - tracks `:=?` assignment. Where the equal sign is optional. Therefore we detect `key: secret`. 

* **What is the new behavior (if this is a feature change)?**
The equal sign cannot be optional in golang. The `:=` operator is used for assignment and declaration. This is what we are trying to track - not the possibility of `:`. 

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->
No

* **Other information**:
