### PR TITLE
Add String Implementation - StatisticsAggregator

### DIFF
--- a/detect_secrets/audit/analytics.py
+++ b/detect_secrets/audit/analytics.py
@@ -104,7 +104,7 @@ class StatisticsCounter:
             },
         }
 
-    def calculate_precision(self):
+    def calculate_precision(self) -> float:
         precision = (
             round(float(self.correct) / (self.correct + self.incorrect), 4)
             if (self.correct and self.incorrect)
@@ -113,7 +113,7 @@ class StatisticsCounter:
 
         return precision
 
-    def calculate_recall(self):
+    def calculate_recall(self) -> float:
         # NOTE(2020-11-08|domanchi): This isn't the formal definition of `recall`, however,
         # this is the definition that we're going to attribute to it.
         #

--- a/detect_secrets/audit/analytics.py
+++ b/detect_secrets/audit/analytics.py
@@ -58,7 +58,14 @@ class StatisticsAggregator:
         return cast(StatisticsCounter, self.data[secret_type]['stats'])
 
     def __str__(self) -> str:
-        raise NotImplementedError
+        output = ''
+
+        for secret_type, framework in self.data.items():
+            output += f'Plugin: {get_mapping_from_secret_type_to_class()[secret_type].__name__}\n'
+            for value in framework.values():
+                output += f'Statistics: {value}\n\n'
+
+        return output
 
     def json(self) -> Dict[str, Any]:
         output = {}
@@ -77,19 +84,36 @@ class StatisticsCounter:
         self.incorrect: int = 0
         self.unknown: int = 0
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return (
-            f'{self.__class__.__name__}(correct={self.correct}, '
-            'incorrect={self.incorrect}, unknown={self.unknown},)'
+            f'True Positives: {self.correct}, False Positives: {self.incorrect}, '
+            f'Unknown: {self.unknown}, Precision: {self.calculate_precision()}, '
+            f'Recall: {self.calculate_recall()}'
         )
 
     def json(self) -> Dict[str, Any]:
+        return {
+            'raw': {
+                'true-positives': self.correct,
+                'false-positives': self.incorrect,
+                'unknown': self.unknown,
+            },
+            'score': {
+                'precision': self.calculate_precision(),
+                'recall': self.calculate_recall(),
+            },
+        }
+
+    def calculate_precision(self):
         precision = (
             round(float(self.correct) / (self.correct + self.incorrect), 4)
             if (self.correct and self.incorrect)
             else 0.0
         )
 
+        return precision
+
+    def calculate_recall(self):
         # NOTE(2020-11-08|domanchi): This isn't the formal definition of `recall`, however,
         # this is the definition that we're going to attribute to it.
         #
@@ -124,14 +148,4 @@ class StatisticsCounter:
             else 0.0
         )
 
-        return {
-            'raw': {
-                'true-positives': self.correct,
-                'false-positives': self.incorrect,
-                'unknown': self.unknown,
-            },
-            'score': {
-                'precision': precision,
-                'recall': recall,
-            },
-        }
+        return recall

--- a/tests/audit/analytics_test.py
+++ b/tests/audit/analytics_test.py
@@ -66,9 +66,14 @@ def test_no_divide_by_zero(secret):
         main(['audit', f.name, '--stats', '--json'])
 
 
-@pytest.mark.skip(reason='TODO')
-def test_basic_statistics_str():
-    pass
+def test_basic_statistics_str(printer):
+    with labelled_secrets() as filename:
+        main(['audit', filename, '--stats'])
+
+    assert printer.message == (
+        'Plugin: BasicAuthDetector\nStatistics: True Positives: 1, ' +
+        'False Positives: 2, Unknown: 1, Precision: 0.3333, Recall: 0.5\n\n\n'
+    )
 
 
 @contextmanager


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**
Bug Fix

* **What is the current behavior?**
#662 
When calling `detect-secrets audit .secrets. baseline --stats` we get an error since there is no implementation for the StatisticsAggregator `__str__` method.

* **What is the new behavior (if this is a feature change)?**
Return a string representation of the statistics. See below for an example

* **Does this PR introduce a breaking change?**
No

* **Other information**:

```
Plugin: PrivateKeyDetector
Statistics: True Positives: 0, False Positives: 0, Unknown: 8, Precision: 0.0, Recall: 0.0

Plugin: TwilioKeyDetector
Statistics: True Positives: 0, False Positives: 0, Unknown: 1, Precision: 0.0, Recall: 0.0

Plugin: HexHighEntropyString
Statistics: True Positives: 0, False Positives: 0, Unknown: 2, Precision: 0.0, Recall: 0.0

Plugin: KeywordDetector
Statistics: True Positives: 0, False Positives: 0, Unknown: 3, Precision: 0.0, Recall: 0.0

Plugin: JwtTokenDetector
Statistics: True Positives: 0, False Positives: 0, Unknown: 1, Precision: 0.0, Recall: 0.0

Plugin: Base64HighEntropyString
Statistics: True Positives: 0, False Positives: 0, Unknown: 1, Precision: 0.0, Recall: 0.0
```