### PR TITLE
Account for Anchor & Alias Tags in yaml Transformer

### DIFF
--- a/detect_secrets/transformers/yaml.py
+++ b/detect_secrets/transformers/yaml.py
@@ -37,8 +37,17 @@ class YAMLTransformer(BaseTransformer):
         except yaml.YAMLError:
             raise ParsingError
 
+        seen = set()
+
         lines: List[str] = []
         for item in items:
+            # Filter out previous lines seen before. This removes duplicates when it comes
+            # to anchor & and alias * tags.
+            if item in seen:
+                continue
+            else:
+                seen.add(item)
+
             while len(lines) < item.line_number - 1:
                 lines.append('')
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**

Bug fix - #632 

* **What is the current behavior?**

There is an issue when the yaml transformer is parsing a yaml file. 
Yaml has notions of anchor & and alias * tags. You can mark a section of code with an anchor tag and leverage it somewhere else in the yaml file with the * tags. 

This causes duplicate lines in transformer which makes line numbers incorrect for the entire file. 

* **What is the new behavior (if this is a feature change)?**

When parsing through the yaml file. We keep the nodes as returned by pyyaml. However, when returning the lines from the transformer we trim our list to ignore duplicate line items. It is important we keep the ordering the same as we always want to return the first instance of a line and ignore the later references. 

We a line item consists of (key, value, line_number, and line). We should not need to account for duplicates.

This will continue to account for duplicate key, value pairs that are on different lines. 

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->

No

* **Other information**:
