### PR TITLE
Fix flake8 `do not compare types` error

### DIFF
--- a/detect_secrets/plugins/ibm_cloud_iam.py
+++ b/detect_secrets/plugins/ibm_cloud_iam.py
@@ -34,7 +34,7 @@ class IbmCloudIamDetector(RegexBasedDetector):
 
 
 def verify_cloud_iam_api_key(apikey: Union[str, bytes]) -> requests.Response:  # pragma: no cover
-    if type(apikey) == bytes:
+    if type(apikey) is bytes:
         apikey = apikey.decode('UTF-8')
 
     headers = {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**
Build fix
<!-- (Bug fix, feature, docs update, ...) -->

* **What is the current behavior?**
Running `tox -e py39` or `pre-commit run --all-files` leads to a flake8 failure:
  ```
  detect_secrets/plugins/ibm_cloud_iam.py:37:8: E721 do not compare types, for exact checks use `is` / `is not`, for 
  instance checks use `isinstance()`
  ```

* **What is the new behavior (if this is a feature change)?**
flake8 passes. For example:
  ```
  (.venv)
  abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/detect-secrets (fix-flake8-do-not-compare-types-error●)
  $ pre-commit run --all-files
  Check builtin type constructor use.......................................Passed
  Check docstring is first.................................................Passed
  Debug Statements (Python)................................................Passed
  Fix double quoted strings................................................Passed
  Fix End of Files.........................................................Passed
  Tests should end in _test.py.............................................Passed
  Flake8...................................................................Passed
  Trim Trailing Whitespace.................................................Passed
  Reorder python imports...................................................Passed
  Add trailing commas......................................................Passed
  autopep8.................................................................Passed
  Detect secrets...........................................................Passed
  ```

* **Does this PR introduce a breaking change?**
No

* **Other information**:
