### PR TITLE
Support new python versions and upgrade pytest to 7.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pyahocorasick==1.4.4
 pycodestyle==2.3.1
 pyflakes==1.6.0
 pyparsing==2.4.7
-pytest==6.2.2
+pytest==7.4.3
 PyYAML==6.0
 requests==2.26.0
 responses==0.16.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = detect_secrets
 # These should match the ci python env list
-envlist = py{37,38,39},mypy
+envlist = py{37,38,39,310,311},mypy
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [X] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**
Adds support for new Python versions

* **What is the current behavior?**
Tests run only up to Python 3.9

* **What is the new behavior (if this is a feature change)?**
  - Tests run up to Python 3.11
  - Upgrades `pytest` from `6.2.2` to `7.4.3` (this was necessary to prevent `TypeError: required field "lineno" missing from alias` errors that I was experiencing when testing with Python 3.10).

* **Does this PR introduce a breaking change?**
No.

* **Other information**:
