### PR TITLE
Audit prompt wording

### DIFF
--- a/detect_secrets/audit/audit.py
+++ b/detect_secrets/audit/audit.py
@@ -78,7 +78,7 @@ def _classify_secrets(iterator: BidirectionalIterator) -> bool:
         if decision == io.InputOptions.BACK:
             iterator.step_back_on_next_iteration()
 
-        # The question asked is: "Should this be committed to the repository?"
+        # The question asked is: "Should this string be committed to the repository?"
         elif decision == io.InputOptions.NO:
             secret.is_secret = True
             has_changes = True

--- a/detect_secrets/audit/io.py
+++ b/detect_secrets/audit/io.py
@@ -130,7 +130,7 @@ class UserPrompt:
 
     def __str__(self) -> str:
         if 'Y' in self.valid_input:
-            output = 'Should this be committed to the repository?'
+            output = 'Should this string be committed to the repository?'
         else:
             output = 'What would you like to do?'
 

--- a/detect_secrets/audit/io.py
+++ b/detect_secrets/audit/io.py
@@ -130,7 +130,7 @@ class UserPrompt:
 
     def __str__(self) -> str:
         if 'Y' in self.valid_input:
-            output = 'Is this a secret that should be committed to this repository?'
+            output = 'Should this be committed to the repository?'
         else:
             output = 'What would you like to do?'
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -29,7 +29,7 @@ Secret Type: Secret Keyword
 68:      }
 69:    ],
 ----------
-Should this be committed to the repository? (y)es, (n)o, (s)kip, (q)uit:
+Should this string be committed to the repository? (y)es, (n)o, (s)kip, (q)uit:
 ```
 
 There are two common cases for manual labelling:

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -29,7 +29,7 @@ Secret Type: Secret Keyword
 68:      }
 69:    ],
 ----------
-Is this a secret that should be committed to this repository? (y)es, (n)o, (s)kip, (q)uit:
+Should this be committed to the repository? (y)es, (n)o, (s)kip, (q)uit:
 ```
 
 There are two common cases for manual labelling:

--- a/tests/audit/io_test.py
+++ b/tests/audit/io_test.py
@@ -12,7 +12,7 @@ from detect_secrets.audit import io
                 'allow_backstep': True,
             },
             (
-                'Is this a secret that should be committed to this repository? '
+                'Should this be committed to the repository? '
                 '(y)es, (n)o, (s)kip, (b)ack, (q)uit: '
             ),
         ),

--- a/tests/audit/io_test.py
+++ b/tests/audit/io_test.py
@@ -12,7 +12,7 @@ from detect_secrets.audit import io
                 'allow_backstep': True,
             },
             (
-                'Should this be committed to the repository? '
+                'Should this string be committed to the repository? '
                 '(y)es, (n)o, (s)kip, (b)ack, (q)uit: '
             ),
         ),


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**

Modifies the wording of the audit prompt, so that it makes sense for false positives as well as genuine detections.

This was initially raised as issue #734 

* **What is the current behavior?**

The current audit prompt is confusing for false positives.

* **What is the new behavior (if this is a feature change)?**

The prompt now omits any reference to the detection being a secret (since we don't know whether it is or isn't at this point)

* **Does this PR introduce a breaking change?**

No

* **Other information**:
