### PR TITLE
Improve AWS access key detection

### DIFF
--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -28,7 +28,7 @@ class AWSKeyDetector(RegexBasedDetector):
         re.compile(r'(?:A3T[A-Z0-9]|ABIA|ACCA|AKIA|ASIA)[0-9A-Z]{16}'),
 
         # This examines the variable name to identify AWS secret tokens.
-        # The order is important since we want to prefer finding `AKIA`-based
+        # The order is important since we want to prefer finding access
         # keys (since they can be verified), rather than the secret tokens.
 
         re.compile(

--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -25,7 +25,7 @@ class AWSKeyDetector(RegexBasedDetector):
     secret_keyword = r'(?:key|pwd|pw|password|pass|token)'
 
     denylist = (
-        re.compile(r'AKIA[0-9A-Z]{16}'),
+        re.compile(r'(?:A3T[A-Z0-9]|ABIA|ACCA|AKIA|ASIA)[0-9A-Z]{16}'),
 
         # This examines the variable name to identify AWS secret tokens.
         # The order is important since we want to prefer finding `AKIA`-based

--- a/tests/plugins/aws_key_test.py
+++ b/tests/plugins/aws_key_test.py
@@ -33,6 +33,22 @@ class TestAWSKeyDetector:
                 False,
             ),
             (
+                'A3T0ZZZZZZZZZZZZZZZZ',
+                True,
+            ),
+            (
+                'ABIAZZZZZZZZZZZZZZZZ',
+                True,
+            ),
+            (
+                'ACCAZZZZZZZZZZZZZZZZ',
+                True,
+            ),
+            (
+                'ASIAZZZZZZZZZZZZZZZZ',
+                True,
+            ),
+            (
                 'aws_access_key = "{}"'.format(EXAMPLE_SECRET),
                 True,
             ),


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [X] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

Updates the pattern for matching different types of AWS access keys

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->

It currently only flags access keys that are prefixed with `AKIA`. AWS access keys can come in a few different formats, and without this change they would go undetected.

Here is a [list](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids) from AWS of different prefixes and what they are.

For instance `ASIA` is for temporary service token.

This:

```js
export const KEY="ASIAZZZZZZZZZZZZZZZZ"
```

would be flagged by

<details>
  <summary>git-secrets</summary>
  
  ```shell
git-secrets.js:1:export const KEY="ASIAZZZZZZZZZZZZZZZZ"

[ERROR] Matched one or more prohibited patterns

Possible mitigations:
- Mark false positives as allowed using: git config --add secrets.allowed ...
- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory
- List your configured patterns: git config --get-all secrets.patterns
- List your configured allowed patterns: git config --get-all secrets.allowed
- List your configured allowed patterns in .gitallowed at repository's root directory
- Use --no-verify if this is a one-time false positive

  ```
</details>

and by

<details>
  <summary>gitleaks</summary>
  
  ```shell

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     export const KEY="ASIAZZZZZZZZZZZZZZZZ
Secret:      ASIAZZZZZZZZZZZZZZZZ
RuleID:      aws-access-token
Entropy:     3.621928
File:        git-secrets.js
Line:        1
Fingerprint: git-secrets.js:aws-access-token:1

  ```
</details>

but not 

<details>
  <summary>detect-secrets</summary>

```shell
{
  "version": "1.4.0",
  "plugins_used": [
    {
      "name": "ArtifactoryDetector"
    },
    {
      "name": "AWSKeyDetector"
    },
    {
      "name": "AzureStorageKeyDetector"
    },
    {
      "name": "Base64HighEntropyString",
      "limit": 4.5
    },
    {
      "name": "BasicAuthDetector"
    },
    {
      "name": "CloudantDetector"
    },
    {
      "name": "DiscordBotTokenDetector"
    },
    {
      "name": "GitHubTokenDetector"
    },
    {
      "name": "HexHighEntropyString",
      "limit": 3.0
    },
    {
      "name": "IbmCloudIamDetector"
    },
    {
      "name": "IbmCosHmacDetector"
    },
    {
      "name": "JwtTokenDetector"
    },
    {
      "name": "KeywordDetector",
      "keyword_exclude": ""
    },
    {
      "name": "MailchimpDetector"
    },
    {
      "name": "NpmDetector"
    },
    {
      "name": "PrivateKeyDetector"
    },
    {
      "name": "SendGridDetector"
    },
    {
      "name": "SlackDetector"
    },
    {
      "name": "SoftlayerDetector"
    },
    {
      "name": "SquareOAuthDetector"
    },
    {
      "name": "StripeDetector"
    },
    {
      "name": "TwilioKeyDetector"
    }
  ],
  "filters_used": [
    {
      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
    },
    {
      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
      "min_level": 2
    },
    {
      "path": "detect_secrets.filters.gibberish.should_exclude_secret",
      "limit": 3.7
    },
    {
      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_lock_file"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_sequential_string"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_swagger_file"
    },
    {
      "path": "detect_secrets.filters.heuristic.is_templated_secret"
    }
  ],
  "results": {},
  "generated_at": "2024-03-02T16:23:36Z"
}
```
</details>

* **What is the new behavior (if this is a feature change)?**

It will flag other related AWS access keys one would probably want to be notified about.

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->

No

* **Other information**:

This is the same pattern used in [gitleaks](https://github.com/gitleaks/gitleaks/blob/8d23afd45deecbcaaf142ce6226f06698db9d9e1/cmd/generate/config/rules/aws.go#L15) (although pattern changed to be in alphabetical order), but not as detailed as [git-secrets](https://github.com/awslabs/git-secrets/blob/5357e18bc27b42a827b6780564ea873a72ca1f01/git-secrets#L239).  The gitleaks pattern makes the most sense to me.  It doesn't include every variation as explained [here](https://github.com/gitleaks/gitleaks/pull/1307), just the ones that make sense.
