### PR TITLE
Check netloc in urlparse result if path is empty

### DIFF
--- a/detect_secrets/core/usage/filters.py
+++ b/detect_secrets/core/usage/filters.py
@@ -98,7 +98,15 @@ def _add_custom_filters(parser: argparse._ArgumentGroup) -> None:
             # May be local file.
             # We do some initial pre-processing, but perform the file validation during the
             # post-processing step.
-            components = parts.path.split('::')
+
+            # urllib can put results of urlparse into either path or netloc
+            # depending on the version, so check both
+            if parts.path:
+                components = parts.path.split('::')
+
+            elif parts.netloc:
+                components = parts.netloc.split('::')
+
             if len(components) != 2:
                 raise argparse.ArgumentTypeError(
                     'Did not specify function name for imported file.',


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
This fixes a bug where certain versions of urllib will put the results of a parsed file (e.g. file://testing/custom_filters.py::is_invalid_secret) into the netloc property of urlparse instead of the path property.

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->
https://github.com/Yelp/detect-secrets/issues/715

* **What is the new behavior (if this is a feature change)?**
The custom filter parser will now check netloc if path is not populated

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->
Users should have to make no changes, as it prefers path over netloc

* **Other information**:
