### PR TITLE
GH-768: Plugin to detect Telegram bot tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ SlackDetector
 SoftlayerDetector
 SquareOAuthDetector
 StripeDetector
+TelegramBotTokenDetector
 TwilioKeyDetector
 ```
 

--- a/detect_secrets/plugins/telegram_token.py
+++ b/detect_secrets/plugins/telegram_token.py
@@ -1,0 +1,31 @@
+"""
+This plugin searches for Telegram bot tokens
+"""
+import re
+
+import requests
+
+from ..constants import VerifiedResult
+from detect_secrets.plugins.base import RegexBasedDetector
+
+
+class TelegramBotTokenDetector(RegexBasedDetector):
+    """Scans for Telegram bot tokens."""
+    secret_type = 'Telegram Bot Token'
+
+    denylist = [
+        # refs https://core.telegram.org/bots/api#authorizing-your-bot
+        re.compile(r'\d{8,10}:[0-9A-Za-z_-]{35}'),
+    ]
+
+    def verify(self, secret: str) -> VerifiedResult:  # pragma: no cover
+        response = requests.get(
+            'https://api.telegram.org/bot{}/getMe'.format(
+                secret,
+            ),
+        )
+        return (
+            VerifiedResult.VERIFIED_TRUE
+            if response.status_code == 200
+            else VerifiedResult.VERIFIED_FALSE
+        )

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -1,0 +1,22 @@
+import pytest
+
+from detect_secrets.plugins.telegram_token import TelegramBotTokenDetector
+
+
+class TestTelegramTokenDetector:
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            ('bot110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
+            ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
+            ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
+            ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),
+            ('foo', False),
+        ],
+    )
+    def test_analyze(self, payload, should_flag):
+        logic = TelegramBotTokenDetector()
+        output = logic.analyze_line(filename='mock_filename', line=payload)
+
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

## What kind of change does this PR introduce?
<!-- (Bug fix, feature, docs update, ...) -->
- Feature: new plugin for Telegram bot tokens
- GH-768

## Tests
- New test added for plugin
- Tested manually in local with newly created token
```sh
{
        "type": "Telegram Bot Token",
        "filename": "test_data/test-bot.yaml",
        "hashed_secret": "c429079ee6a839ece2e7b0a6770198d8fe5ed438",
        "is_verified": true,
        "line_number": 11
},
```
