### PR TITLE
New plugin for OpenAI tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ JwtTokenDetector
 KeywordDetector
 MailchimpDetector
 NpmDetector
+OpenAIDetector
 PrivateKeyDetector
 PypiTokenDetector
 SendGridDetector

--- a/detect_secrets/plugins/openai.py
+++ b/detect_secrets/plugins/openai.py
@@ -1,0 +1,18 @@
+"""
+This plugin searches for OpenAI tokens
+"""
+import re
+
+from detect_secrets.plugins.base import RegexBasedDetector
+
+
+class OpenAIDetector(RegexBasedDetector):
+    """Scans for OpenAI tokens."""
+    secret_type = 'OpenAI Token'
+
+    denylist = [
+        # refs https://community.openai.com/t/what-are-the-valid-characters-for-the-apikey/288643
+        # User api keys (legacy): 'sk-[20 alnum]T3BlbkFJ[20 alnum]'
+        # Project-based api keys: 'sk-[project-name]-[20 alnum]T3BlbkFJ[20 alnum]'
+        re.compile(r'sk-[A-Za-z0-9-_]*[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}'),
+    ]

--- a/tests/plugins/openai_test.py
+++ b/tests/plugins/openai_test.py
@@ -16,7 +16,6 @@ class TestOpenAIDetector:
             ('sk-proj-Xi8tdMjHV6pmbBbwilTeT4BlbkFJ3UDnpdEwNNm6wVBpYM0o', False),
         ],
     )
-
     def test_analyze(self, payload, should_flag):
         logic = OpenAIDetector()
         output = logic.analyze_line(filename='mock_filename', line=payload)

--- a/tests/plugins/openai_test.py
+++ b/tests/plugins/openai_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from detect_secrets.plugins.openai import OpenAIDetector
+
+
+class TestOpenAIDetector:
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            # pragma: allowlist nextline secret
+            ('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', True),
+            # pragma: allowlist nextline secret
+            ('sk-proj-Xi8tdMjHV6pmbBbwilTeT3BlbkFJ3UDnpdEwNNm6wVBpYM0o', True),
+            # pragma: allowlist nextline secret
+            ('sk-proj-Xi8tdMjHV6pmbBbwilTeT4BlbkFJ3UDnpdEwNNm6wVBpYM0o', False),
+        ],
+    )
+
+    def test_analyze(self, payload, should_flag):
+        logic = OpenAIDetector()
+        output = logic.analyze_line(filename='mock_filename', line=payload)
+
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

## What kind of change does this PR introduce?
<!-- (Bug fix, feature, docs update, ...) -->
Feature: New plugin to detect OpenAI api keys

## Token Format
- User API keys (legacy): `sk-[20_alpha_numberic] T3BlbkFJ [20_alpha_numberic]` (`T3BlbkFJ` = base64 for "OpenAI")
    - there's no official documentation but found [this](https://community.openai.com/t/what-are-the-valid-characters-for-the-apikey/288643/2) community forum which mentions legacy token format
- Project API keys: `sk-<project_name>-[20_alpha_numberic] T3BlbkFJ [20_alpha_numberic]`
- Generated tokens for both from OpenAI portal and verified manually

### Token verification
Checking whether token is active might not be possible; so haven't implemented `verify()` method for the plugin:
- No official API to check validity of tokens (refs: [openai api-reference](https://platform.openai.com/docs/api-reference/introduction))
- Calling random apis (like: `v1/models`) may or may not work because of the restrictions placed on tokens during creation
    - another downside could be credit usage for valid tokens

## Tests
- New tests added for plugin
- Tested manually in local with sample token in file
```sh
      {
        "type": "OpenAI Token",
        "filename": "test_data/files/file_with_secrets.py",
        "hashed_secret": "007111295d396c8234d268fa24014ef5235136b0",
        "is_verified": false,
        "line_number": 5
      }
```
