### PR TITLE
Fix check bypass via square brackets Issue #857

### DIFF
--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -316,7 +316,7 @@ def _process_line_based_plugins(
     # filters return True.
     for line_number, line in lines:
         log.debug(f'Processing {filename}:{line_number}')
-        line = line.rstrip()
+        line = line.rstrip().replace("[", "\[").replace("]", "\]")
         code_snippet = get_code_snippet(
             lines=line_content,
             line_number=line_number,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**

Fixes behavior on missed secrets that have square brackets before their default value.
Example:
```
"<%= ENV['CLIENT_ACCESS_KEY_ID'].presence || 'AKIA123456789ABCDEF1' %>"
```

* **What is the current behavior?**

Issue: https://github.com/Yelp/detect-secrets/issues/857

* **What is the new behavior (if this is a feature change)?**

Escapes the square brackets and catches secrets properly.

* **Does this PR introduce a breaking change?**

No breaking changes.
