### PR TITLE
Adding support for filtering secrets using deep learning models

### DIFF
--- a/detect_secrets/core/usage/filters.py
+++ b/detect_secrets/core/usage/filters.py
@@ -80,12 +80,12 @@ def add_filter_options(parent: argparse.ArgumentParser) -> None:
 
     if filters.bert_classifier.is_feature_enabled():
         parser.add_argument(
-            '--bert-model',
+            '--huggingface-model',
             type=str,
             help='HuggingFace model path for classifying secrets.',
         )
         parser.add_argument(
-            '--bert-threshold',
+            '--threshold',
             type=float,
             help='Threshold to determine whether a string is a secret.',
         )
@@ -187,11 +187,11 @@ def parse_args(args: argparse.Namespace) -> None:
 
     if filters.bert_classifier.is_feature_ready(args):
         kwargs = {}
-        if args.bert_model:
-            kwargs['model_path'] = args.bert_model
+        if args.huggingface_model:
+            kwargs['huggingface_model'] = args.huggingface_model
 
-        if args.bert_threshold:
-            kwargs['limit'] = args.bert_threshold
+        if args.threshold:
+            kwargs['threshold'] = args.threshold
 
         if args.huggingface_token:
             kwargs['huggingface_token'] = args.huggingface_token

--- a/detect_secrets/filters/__init__.py
+++ b/detect_secrets/filters/__init__.py
@@ -3,3 +3,4 @@ from . import gibberish     # noqa: F401
 from . import heuristic     # noqa: F401
 from . import regex         # noqa: F401
 from . import wordlist      # noqa: F401
+from . import bert_classifier  # noqa: F401

--- a/detect_secrets/filters/bert_classifier.py
+++ b/detect_secrets/filters/bert_classifier.py
@@ -1,0 +1,96 @@
+import logging
+import string
+from typing import Dict
+from typing import Union
+from typing import Optional
+
+from functools import lru_cache
+
+from transformers import Pipeline
+
+from ..core.plugins import Plugin
+from ..plugins.private_key import PrivateKeyDetector
+from ..settings import get_settings
+
+from argparse import Namespace
+
+logger = logging.getLogger(__name__)
+
+def is_feature_enabled() -> bool:
+    try:
+        import torch
+        import transformers
+
+        return True
+    except Exception:
+        return False
+    
+def is_feature_ready(args: Namespace) -> bool:
+    return args.bert_model and args.bert_threshold and args.huggingface_token
+    
+def initialize(model_path: str = None, limit: float = 0.8, huggingface_token: Optional[str] = None) -> None:
+    """
+    :param limit: this limit was obtained through trial and error. Check out
+        the original pull request for rationale.
+
+    :raises: ValueError
+    """
+    path = model_path
+
+    model = get_model(model_path, huggingface_token)
+
+    config: Dict[str, Union[float, str]] = {
+        'limit': limit,
+    }
+    if model_path:
+        config['model'] = model_path
+        config['huggingface_token'] = huggingface_token
+
+    path = f'{__name__}.should_exclude_secret'
+    get_settings().filters[path] = config
+
+def should_exclude_secret(secret: str, plugin: Optional[Plugin] = None) -> bool:
+    """
+    :param plugin: optional, for easier testing. The dependency injection system
+        will populate its proper value on complete runs.
+    """
+    # Private keys are actual words, so they will be a false negative.
+    if isinstance(plugin, PrivateKeyDetector):
+        return False
+    
+    if not (set(secret) - set(string.hexdigits + '-')):
+        return False
+
+    if not get_model(get_settings().filters[f'{__name__}.should_exclude_secret']['model'], get_settings().filters[f'{__name__}.should_exclude_secret']['huggingface_token']):
+        raise AssertionError('Attempting to use uninitialized HuggingFace model.')
+
+    pipeline = get_model(get_settings().filters[f'{__name__}.should_exclude_secret']['model'], get_settings().filters[f'{__name__}.should_exclude_secret']['huggingface_token'])
+    result = pipeline(secret)[0]
+
+    return result['label'] == 'LABEL_1' and result['score'] >= get_settings().filters[f'{__name__}.should_exclude_secret']['limit']
+
+@lru_cache(maxsize=1)
+def get_model(model_name: str, huggingface_token: str) -> 'Pipeline':
+    import torch
+    from transformers import pipeline, BertForSequenceClassification, BertTokenizer
+
+    model = BertForSequenceClassification.from_pretrained(model_name, token=huggingface_token)
+    model = model.share_memory()
+
+    tokenizer = BertTokenizer.from_pretrained(model_name, token=huggingface_token)
+
+    if torch.cuda.is_available():
+        logger.info("CUDA is available. Using GPU for Bert model.")
+        return pipeline(
+            'text-classification',
+            model=model,
+            tokenizer=tokenizer,
+            device=torch.cuda.current_device(),
+        )
+    else:
+        logger.info("CUDA is not available. Using CPU for Bert model.")
+        return pipeline(
+            'text-classification',
+            model=model_name,
+            use_auth_token=huggingface_token,
+        )

--- a/detect_secrets/main.py
+++ b/detect_secrets/main.py
@@ -64,6 +64,9 @@ def handle_scan_action(args: argparse.Namespace) -> None:
             for secret in scan_for_allowlisted_secrets_in_file(filename):
                 secrets[secret.filename].add(secret)
 
+        # clear stdout buffer
+        sys.stdout.flush()
+
         print(json.dumps(baseline.format_for_output(secrets), indent=2))
         return
 
@@ -86,6 +89,9 @@ def handle_scan_action(args: argparse.Namespace) -> None:
 
         baseline.save_to_file(secrets, args.baseline_filename)
     else:
+        # clear stdout buffer
+        sys.stdout.flush()
+
         print(json.dumps(baseline.format_for_output(secrets, is_slim_mode=args.slim), indent=2))
 
 
@@ -135,6 +141,7 @@ def handle_audit_action(args: argparse.Namespace) -> None:
                 class_to_print = audit.report.SecretClassToPrint.REAL_SECRET
             elif args.only_false:
                 class_to_print = audit.report.SecretClassToPrint.FALSE_POSITIVE
+
             print(
                 json.dumps(
                     audit.report.generate_report(args.filename[0], class_to_print),


### PR DESCRIPTION
Adding support for filtering secrets using deep learning models from huggingface specialized in string classification for detecting secrets.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
This PR add the abality for detect-secrets to filter scans using deep learning model from huggingface.
By running the following command :
```
detect-secrets scan --huggingface-model huggingface/path --threshold 0.8 --huggingface-token TOKEN
```

* **Other information**:
When using this feature the performance of detect-secrets drops a bit because of usage of big models.  