### PR TITLE
fix(telegram_bot_token): Regex must match just bot tokens

### DIFF
--- a/detect_secrets/plugins/telegram_token.py
+++ b/detect_secrets/plugins/telegram_token.py
@@ -15,7 +15,7 @@ class TelegramBotTokenDetector(RegexBasedDetector):
 
     denylist = [
         # refs https://core.telegram.org/bots/api#authorizing-your-bot
-        re.compile(r'\d{8,10}:[0-9A-Za-z_-]{35}'),
+        re.compile(r'^\d{8,10}:[0-9A-Za-z_-]{35}$'),
     ]
 
     def verify(self, secret: str) -> VerifiedResult:  # pragma: no cover

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -13,6 +13,7 @@ class TestTelegramTokenDetector:
             ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
             ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),
             ('foo', False),
+            ('arn:aws:sns:aaa:111122223333:aaaaaaaaaaaaaaaaaaassssssddddddddddddd', False)
         ],
     )
     def test_analyze(self, payload, should_flag):

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -8,7 +8,7 @@ class TestTelegramTokenDetector:
     @pytest.mark.parametrize(
         'payload, should_flag',
         [
-            ('bot110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
+            ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
             ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
             ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
             ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -13,7 +13,7 @@ class TestTelegramTokenDetector:
             ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
             ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),
             ('foo', False),
-            ('arn:aws:sns:aaa:111122223333:aaaaaaaaaaaaaaaaaaassssssddddddddddddd', False)
+            ('arn:aws:sns:aaa:111122223333:aaaaaaaaaaaaaaaaaaassssssddddddddddddd', False),
         ],
     )
     def test_analyze(self, payload, should_flag):

--- a/tests/plugins/telegram_token_test.py
+++ b/tests/plugins/telegram_token_test.py
@@ -8,7 +8,7 @@ class TestTelegramTokenDetector:
     @pytest.mark.parametrize(
         'payload, should_flag',
         [
-            ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
+            ('bot110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', False),
             ('110201543:AAHdqTcvCH1vGWJxfSe1ofSAs0K5PALDsaw', True),
             ('7213808860:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', True),
             ('foo:AAH1bjqpKKW3maRSPAxzIU-0v6xNuq2-NjM', False),


### PR DESCRIPTION
* **Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green
```
(venv) ➜  time python -m pytest tests/plugins/telegram_token_test.py
================================================================================ test session starts =================================================================================
platform darwin -- Python 3.11.9, pytest-7.4.3, pluggy-1.5.0
rootdir: /private/tmp/detect-secrets
plugins: xdist-3.6.1
collected 6 items

tests/plugins/telegram_token_test.py ......                                                                                                                                    [100%]

================================================================================= 6 passed in 0.05s ==================================================================================
python -m pytest tests/plugins/telegram_token_test.py  0,21s user 0,04s system 96% cpu 0,262 total
```

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

This PR fixes a bug with the TelegramBotToken since some AWS ARNs were matched against it due to the regex configured in the `deny_list`.

* **What is the current behaviour?**
<!-- (You can also link to an open issue here) -->
The following AWS ARN `arn:aws:sns:aaa:111122223333:aaaaaaaaaaaaaaaaaaassssssdddddddddddd` matches against the TelegramBotToken when the `verify` option is not enabled, but it should not be needed to be verified since it is not.

This match because the regex is not enough restrictive from the beginning and the end.

* **What is the new behaviour (if this is a feature change)?**
Add the start-of-line `^` and end-of-line `$` character to reduce false positives.

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->
No.
* **Other information**:
