### PR TITLE
fix(ip_public): Exclude IPv4 Link Local

### DIFF
--- a/detect_secrets/plugins/ip_public.py
+++ b/detect_secrets/plugins/ip_public.py
@@ -11,6 +11,7 @@ class IPPublicDetector(RegexBasedDetector):
         - 10.
         - 172.(16-31)
         - 192.168.
+        - 169.254. - Link Local Address IPv4
 
     Reference:
     https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml
@@ -25,6 +26,7 @@ class IPPublicDetector(RegexBasedDetector):
                 192\.168\. # Exclude "192.168."
                 |127\.     # Exclude "127."
                 |10\.      # Exclude "10."
+                |169\.254\. # Exclude IPv4 Link Local Address (169.254.0.0/16)
                 |172\.(?:1[6-9]|2[0-9]|3[01])   # Exclude "172." with specific ranges
             )
             (?:            # Non-capturing group for octets

--- a/tests/plugins/ip_public_test.py
+++ b/tests/plugins/ip_public_test.py
@@ -37,6 +37,7 @@ class TestIPPublicDetector:
                 ('10.0.0.1', False),
                 ('172.16.0.1', False),
                 ('192.168.0.1', False),
+                ('169.254.169.254', False),
                 # Invalid IPv4 addresses
                 ('256.256.256.256', False),
                 ('1.2.3', False),


### PR DESCRIPTION
* **Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green
```
(venv) ➜  time python -m pytest tests/plugins/ip_public_test.py       
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.11.10, pytest-7.4.3, pluggy-1.5.0
rootdir: /Users/pepin/Desktop/Code/Prowler/detect-secrets
collected 17 items                                                                                                                                                                  

tests/plugins/ip_public_test.py .................                                                                                                                             [100%]

================================================================================ 17 passed in 0.09s =================================================================================
python -m pytest tests/plugins/ip_public_test.py  0.24s user 0.06s system 98% cpu 0.302 total
```

* **What kind of change does this PR introduce?**
This PR fixes a bug with the `IPPublicDetector` since an IPv4 Link Local address was being flagged as public.

* **What is the current behaviour?**
IPv4 Link Local addresses 169.254/16 are being flagged as public.

* **What is the new behaviour (if this is a feature change)?**
Exclude 169.254/16 from the `IPPublicDetector`.

* **Does this PR introduce a breaking change?**
No.
* **Other information**:
