### PR TITLE
Add Length Override to Secrets Collection

### DIFF
--- a/detect_secrets/core/secrets_collection.py
+++ b/detect_secrets/core/secrets_collection.py
@@ -308,6 +308,10 @@ class SecretsCollection:
 
         return output
 
+    def __len__(self) -> int:
+        """Returns the total number of secrets in the collection."""
+        return sum(len(secrets) for secrets in self.data.values())
+
 
 def _scan_file_and_serialize(filename: str) -> List[PotentialSecret]:
     """Used for multiprocessing, since lambdas can't be serialized."""

--- a/detect_secrets/pre_commit_hook.py
+++ b/detect_secrets/pre_commit_hook.py
@@ -133,14 +133,14 @@ def pretty_print_diagnostics(secrets: SecretsCollection, width: int = 80) -> Non
         ),
     )
     print()
-    
+
     # Display found secrets
     for _, secret in secrets:
         print(secret)
 
     # Display the number of detected secrets
-    print(f"\nTotal secrets detected: {len(secrets)}")
-    
+    print(f'\nTotal secrets detected: {len(secrets)}')
+
     # Display mitigation suggestions
     print('Possible mitigations:')
     wrapper = textwrap.TextWrapper(

--- a/tests/pre_commit_hook_test.py
+++ b/tests/pre_commit_hook_test.py
@@ -98,6 +98,7 @@ def test_console_output():
     # Assert formatting
     output = capturedOutput.getvalue()
     assert output.startswith('ERROR: Potential secrets about to be committed to git repo!')
+    assert 'Total secrets detected: 1' in output
 
 
 def test_console_output_json_formatting():


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
- Bug fix for recently merged [PR](https://github.com/Yelp/detect-secrets/commit/5ed9de658148d0342045bc3984455431fd06ff91) which outputs length of secrets in pre-commit hook

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->
- Currently there is no length override for SecretsCollection therefore this causes a failure

* **What is the new behavior (if this is a feature change)?**
- Add length override to SecretsCollection to output total number of secrets found in the collection

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->
- N/A

* **Other information**:
