### PR TITLE
feat: fix #313 + other new slack tokens

### DIFF
--- a/detect_secrets/plugins/slack.py
+++ b/detect_secrets/plugins/slack.py
@@ -18,7 +18,7 @@ class SlackDetector(RegexBasedDetector):
 
     denylist = (
         # Slack Token
-        re.compile(r'xox(?:a|b|p|o|s|r)-(?:\d+-)+[a-z0-9]+', flags=re.IGNORECASE),
+        re.compile(r'(xwfp|xapp|xox(?:a|b|c|p|o|s|r))-(?:\d+-)+[a-z0-9]+', flags=re.IGNORECASE),
         # Slack Webhooks
         re.compile(
             r'https://hooks\.slack\.com/services/T[a-zA-Z0-9_]+/B[a-zA-Z0-9_]+/[a-zA-Z0-9_]+',

--- a/tests/plugins/slack_test.py
+++ b/tests/plugins/slack_test.py
@@ -30,6 +30,15 @@ class TestSlackDetector:
                 'xoxb-34532454-e039d02840a0b9379c'
             ),
             (
+                'xoxc-1111111111-111111111111-1111111111111-11111111111111111'
+            ),
+            (
+                'xwfp-523423-234243-234233-e039d02840a0b9379c'
+            ),
+            (
+                'xapp-523423-234243-234233-e039d02840a0b9379c'
+            ),
+            (
                 'https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx'
             ),
         ],


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [X] All CI checks are green

* **What kind of change does this PR introduce?**
 - Implements #313 (`xoxc-` slack token detection)
 - Adds other slack token types as per [slack api docs](https://api.slack.com/concepts/token-types): 
   - `xapp-`, 
   - `xwfp-` 

* **What is the current behavior?**
#313 - `xoxc-`, `xapp-`, `xwfp-` undetected

* **What is the new behavior (if this is a feature change)?**
Detects `xoxc-`, `xapp-`, `xwfp-`

* **Does this PR introduce a breaking change?**
No

* **Other information**:
