### PR TITLE
Switch to time.monotonic

### DIFF
--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,7 +1,7 @@
 coverage
 flake8==7.1.1
 gibberish-detector>=0.1.1
-monotonic
+monotonic; python_version < '3.3'
 mypy
 pre-commit
 pyahocorasick

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ identify==2.5.36
 idna==3.7
 iniconfig==2.0.0
 mccabe==0.7.0
-monotonic==1.6
+monotonic==1.6; python_version < '3.3'
 mypy==0.971
 mypy-extensions==1.0.0
 nodeenv==1.9.1

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -6,7 +6,10 @@ import statistics
 import subprocess
 import sys
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:
+    from monotonic import monotonic
 
 from detect_secrets.core.color import AnsiColor
 from detect_secrets.core.color import colorize


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**

`time.monotonic` was added to the standard library in Python 3.3.  When you use `monotonic.monotonic` from PyPI, it's an alias to the standard library function.  Attempting to import `time.monotonic` directly avoids an unnecessary dependency.

* **What is the current behavior?**

The PyPI monotonic is an unnecessary dependency, but because it's listed in the requirements file it is installed in developer virtual environments, during every CI run, and during builds of distribution packages.

* **What is the new behavior (if this is a feature change)?**

The PyPI monotonic package isn't installed when it isn't needed.

* **Does this PR introduce a breaking change?**

No.

* **Other information**:
