### PR TITLE
feat: Amazon Bedrock plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
 
 ```bash
 $ detect-secrets scan --list-all-plugins
+AmazonBedrockApiKeyDetector
 ArtifactoryDetector
 AWSKeyDetector
 AzureStorageKeyDetector

--- a/detect_secrets/plugins/amazon_bedrock.py
+++ b/detect_secrets/plugins/amazon_bedrock.py
@@ -1,0 +1,18 @@
+"""
+This plugin searches for Amazon Bedrock API keys
+"""
+import re
+
+from detect_secrets.plugins.base import RegexBasedDetector
+
+class AmazonBedrockApiKeyDetector(RegexBasedDetector):
+    """Scans for Amazon Bedrock API keys."""
+    secret_type = 'Amazon Bedrock API key'
+
+    denylist = [
+        # refs https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html
+        # Long-lived keys begin with ABSK
+        re.compile(r'(?<![A-Za-z0-9+/=])ABSK[A-Za-z0-9+/]{109,269}={0,2}(?![A-Za-z0-9+/=])'),
+        # Short-lived keys begin with bedrock-api-key-
+        re.compile(r'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t')
+    ]

--- a/tests/plugins/amazon_bedrock_test.py
+++ b/tests/plugins/amazon_bedrock_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from detect_secrets.plugins.amazon_bedrock import AmazonBedrockApiKeyDetector
+
+
+class TestAmazonBedrockDetector:
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            ('ABSKQmVkcm9ja0FQSUtleS1EXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXM=', True),
+            ('ABSKQmVkcm9ja0FQSUtleS1', False),
+            ('bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29tEXAMPLE', True),
+            ('bedrock-api-key', False),
+        ],
+    )
+    def test_analyze(self, payload, should_flag):
+        logic = AmazonBedrockApiKeyDetector()
+        output = logic.analyze_line(filename='mock_filename', line=payload)
+
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] All CI checks are green

* **What kind of change does this PR introduce?**
Plugin to detect [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-how.html) secret patterns

* **What is the current behavior?**
No support for Amazon Bedrock API keys

* **What is the new behavior (if this is a feature change)?**
Detection plugin for Amazon Bedrock API key patters

* **Does this PR introduce a breaking change?**
No

* **Other information**:
