### PR TITLE
Fix: ValueError handling for empty files scanning with only-allowlist…

### DIFF
--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -201,13 +201,11 @@ def scan_for_allowlisted_secrets_in_file(filename: str) -> Generator[PotentialSe
     # know which lines we want to scan.
     try:
         for lines in _get_lines_from_file(filename):
-            yield from _scan_for_allowlisted_secrets_in_lines(enumerate(lines, start=1), filename)
-            break
+            if lines:
+                yield from _scan_for_allowlisted_secrets_in_lines(enumerate(lines, start=1), filename)
+                break
     except IOError:
         log.warning(f'Unable to open file: {filename}')
-        return
-    except ValueError:
-        log.warning(f'Unable to scan file: {filename}. Please ignore if file is empty.')
         return
 
 

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -206,6 +206,9 @@ def scan_for_allowlisted_secrets_in_file(filename: str) -> Generator[PotentialSe
     except IOError:
         log.warning(f'Unable to open file: {filename}')
         return
+    except ValueError:
+        log.warning(f'Unable to scan file: {filename}. Please ignore if file is empty.')
+        return
 
 
 def scan_for_allowlisted_secrets_in_diff(diff: str) -> Generator[PotentialSecret, None, None]:


### PR DESCRIPTION
Fixes #936 

- [X] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Bug fix: Handling the ValueError when running `detect-secrets scan --only-allowlisted` in a directory containing empty files

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->
A ValueError is raised as described in [issue #936 ](https://github.com/Yelp/detect-secrets/issues/936)

* **What is the new behavior (if this is a feature change)?**
A warning is raised, and the scan continues.
