### PR TITLE
Fix baseline path normalization in is_baseline_file filter

### DIFF
--- a/detect_secrets/filters/common.py
+++ b/detect_secrets/filters/common.py
@@ -17,13 +17,13 @@ def is_invalid_file(filename: str) -> bool:
 
 
 def is_baseline_file(filename: str) -> bool:
-    return os.path.basename(filename) == _get_baseline_filename()
+    return os.path.normpath(filename) == _get_baseline_filename()
 
 
 @lru_cache(maxsize=1)
 def _get_baseline_filename() -> str:
     path = get_caller_path(offset=1)
-    return cast(str, get_settings().filters[path]['filename'])
+    return os.path.normpath(cast(str, get_settings().filters[path]['filename']))
 
 
 def is_ignored_due_to_verification_policies(

--- a/detect_secrets/settings.py
+++ b/detect_secrets/settings.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 from copy import deepcopy
 from functools import lru_cache
@@ -54,7 +55,7 @@ def configure_settings_from_baseline(baseline: Dict[str, Any], filename: str = '
 
     if filename:
         settings.filters['detect_secrets.filters.common.is_baseline_file'] = {
-            'filename': filename,
+            'filename': os.path.normpath(filename),
         }
 
     return settings

--- a/tests/filters/common_filter_test.py
+++ b/tests/filters/common_filter_test.py
@@ -6,9 +6,36 @@ import requests
 
 from detect_secrets import main as main_module
 from detect_secrets.constants import VerifiedResult
+from detect_secrets.filters.common import is_baseline_file
 from detect_secrets.plugins.base import RegexBasedDetector
+from detect_secrets.settings import transient_settings
 from testing.mocks import mock_printer
 from testing.plugins import register_plugin
+
+
+class TestIsBaselineFile:
+    @staticmethod
+    @pytest.mark.parametrize(
+        'baseline_path, scanned_filename, expected',
+        (
+            ('secrets.baseline', 'secrets.baseline', True),
+            ('./secrets.baseline', 'secrets.baseline', True),
+            ('secrets.baseline', './secrets.baseline', True),
+            ('./secrets.baseline', './secrets.baseline', True),
+            ('path/to/secrets.baseline', 'path/to/secrets.baseline', True),
+            ('./path/to/secrets.baseline', 'path/to/secrets.baseline', True),
+            ('secrets.baseline', 'other.baseline', False),
+        ),
+    )
+    def test_normalizes_baseline_path(baseline_path, scanned_filename, expected):
+        with transient_settings({
+            'plugins_used': [],
+            'filters_used': [{
+                'path': 'detect_secrets.filters.common.is_baseline_file',
+                'filename': baseline_path,
+            }],
+        }):
+            assert is_baseline_file(scanned_filename) is expected
 
 
 class TestVerify:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**

Bug fix

* **What is the current behavior?**

When `--baseline` is passed with a relative path prefix (e.g. `./secrets.baseline`), the `is_baseline_file` filter fails to exclude the baseline file from scanning. This causes the baseline file itself to be reported as containing secrets.

For example, `detect-secrets-hook --baseline ./secrets.baseline` will scan and report findings in `secrets.baseline`, while `detect-secrets-hook --baseline secrets.baseline` correctly excludes it.

Fixes #912

* **What is the new behavior (if this is a feature change)?**

The baseline filename is normalized using `os.path.normpath()` both when stored in settings and when compared in the filter. This ensures that `./secrets.baseline`, `secrets.baseline`, and `path/../secrets.baseline` all resolve to the same canonical path.

* **Does this PR introduce a breaking change?**

No

* **Other information**:

The fix applies normalization at three points for defense in depth:
1. `settings.py` — normalizes the filename when storing it in filter config
2. `filters/common.py` (`_get_baseline_filename`) — normalizes when reading from the cached config
3. `filters/common.py` (`is_baseline_file`) — uses `os.path.normpath` instead of `os.path.basename` on the scanned filename, preserving directory components for correct matching of baselines in subdirectories

🤖 Generated with [Claude Code](https://claude.ai/code)