### PR TITLE
Add ENCRYPTED PRIVATE KEY and OpenVPN patterns to PrivateKeyDetector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ If you love `detect-secrets`, please star our project on GitHub to show your sup
 [@xxxx]: https://github.com/xxxx
 -->
 
+### Unreleased
+
+#### :telescope: Accuracy
+- Added `BEGIN ENCRYPTED PRIVATE KEY` and `BEGIN OpenVPN Static key V1` patterns to `PrivateKeyDetector` for parity with `pre-commit-hooks` `detect-private-key`
+
 ### v1.5.0
 ##### May 6th, 2024
 

--- a/detect_secrets/plugins/private_key.py
+++ b/detect_secrets/plugins/private_key.py
@@ -44,7 +44,9 @@ class PrivateKeyDetector(RegexBasedDetector):
         for regexp in (
             r'BEGIN DSA PRIVATE KEY',
             r'BEGIN EC PRIVATE KEY',
+            r'BEGIN ENCRYPTED PRIVATE KEY',
             r'BEGIN OPENSSH PRIVATE KEY',
+            r'BEGIN OpenVPN Static key V1',
             r'BEGIN PGP PRIVATE KEY BLOCK',
             r'BEGIN PRIVATE KEY',
             r'BEGIN RSA PRIVATE KEY',

--- a/tests/plugins/private_key_test.py
+++ b/tests/plugins/private_key_test.py
@@ -18,6 +18,16 @@ from testing.mocks import mock_named_temporary_file
             '-----BEGIN PRIVATE KEY-----\n'
             'yabba dabba doo'
         ),
+        (
+            '-----BEGIN ENCRYPTED PRIVATE KEY-----\n'
+            'MIIFHDBOBgkqhkiG9w0BBQ0wQTApBgkqhkiG9w0BBQwwHAQI\n'
+            '-----END ENCRYPTED PRIVATE KEY-----'
+        ),
+        (
+            '-----BEGIN OpenVPN Static key V1-----\n'
+            'abcdef1234567890abcdef1234567890\n'
+            '-----END OpenVPN Static key V1-----'
+        ),
     ],
 )
 def test_basic(file_content):


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [X] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [X] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
 

> This adds two missing private key patterns to PrivateKeyDetector

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->
 

> PrivateKeyDetector does not flag `BEGIN ENCRYPTED PRIVATE KEY` (PKCS#8 encrypted format) or `BEGIN OpenVPN Static key V1` files. These are detected by pre-commit/pre-commit-hooks' detect-private-key but not by detect-secrets. (Related: #70)

* **What is the new behavior (if this is a feature change)?**

> Both patterns are now included in the PrivateKeyDetector denylist and will be flagged as secrets.

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->
 

> No. Existing behavior is preserved; this only adds detection for two additional patterns.

* **Other information**:

> These patterns were identified by comparing detect-secrets' denylist against pre-commit-hooks' detect-private-key (which this plugin was originally derived from, per the source file header). As per #70's discussion, it was agreed that encrypted keys should still be flagged since passphrase strength cannot be assumed.
